### PR TITLE
feat(i18n): translate admin route pages and shared dialogs (PR 3/5)

### DIFF
--- a/routes/admin/cache.astro
+++ b/routes/admin/cache.astro
@@ -7,39 +7,52 @@ Licensed under the Business Source License 1.1
 export const prerender = false;
 import AdminLayout from './layout.astro';
 import { loadSite } from '../../api/data.js';
+import { resolveUiLocale } from './i18n/resolve.js';
+import { createT } from './i18n/t.js';
 const site = await loadSite();
+const uiLocale = resolveUiLocale({
+  cookie: Astro.request.headers.get('cookie'),
+  acceptLanguage: Astro.request.headers.get('accept-language'),
+});
+const t = createT(uiLocale);
+const cacheI18n = {
+  invalidateTitle: t('cache.invalidateTitle'),
+  invalidatedSuccess: t('cache.invalidatedSuccess'),
+  invalidateError: t('cache.invalidateError'),
+  operationFailed: t('cache.operationFailed'),
+};
 ---
 
-<AdminLayout site={site} title="Caché">
+<AdminLayout site={site} title={t('cache.title')}>
   <div class="cms-stack">
     <div class="cms-page-intro">
       <div class="cms-page-intro-copy">
-        <span class="cms-page-eyebrow">Operaciones</span>
+        <span class="cms-page-eyebrow">{t('cache.eyebrow')}</span>
         <div class="cms-page-header">
-          <h1 class="cms-title">Gestión de caché pública</h1>
+          <h1 class="cms-title">{t('cache.title')}</h1>
         </div>
         <p class="cms-page-lead">
-          Invalida la caché SSR del sitio cuando necesites forzar contenido fresco sin esperar a la expiración natural del runtime.
+          {t('cache.lead')}
         </p>
       </div>
     </div>
     <div class="cms-cache-grid">
       <div class="cms-card cms-cache-card">
         <div class="cms-cache-card-copy">
-          <span class="cms-cache-card-kicker">SSR cache</span>
-          <h2 class="cms-cache-card-title">Invalidación manual de caché</h2>
+          <span class="cms-cache-card-kicker">{t('cache.cardKicker')}</span>
+          <h2 class="cms-cache-card-title">{t('cache.cardTitle')}</h2>
           <p class="cms-cache-card-text">
-            Purga la caché SSR del sitio público para forzar una nueva renderización con contenido fresco.
+            {t('cache.cardText')}
           </p>
-          <p class="cms-cache-card-note">Úsalo solo cuando hayas publicado cambios importantes y necesites verlos reflejados al momento.</p>
+          <p class="cms-cache-card-note">{t('cache.cardNote')}</p>
         </div>
         <div class="cms-cache-card-action">
-          <button type="button" id="cache-invalidate-btn" class="cms-btn cms-btn-primary">Invalidar toda la caché</button>
+          <button type="button" id="cache-invalidate-btn" class="cms-btn cms-btn-primary">{t('cache.invalidateBtn')}</button>
         </div>
       </div>
     </div>
   </div>
-  <script>
+  <script define:vars={{ cacheI18n }}>
     (function() {
       const invalidateBtn = document.getElementById('cache-invalidate-btn');
 
@@ -63,7 +76,7 @@ const site = await loadSite();
           if (res.ok) {
             window.cmsToast?.({ title: successTitle, message: payload.message || successMessage, tone: 'success' });
           } else {
-            const detail = payload.detail || payload.error || 'La operación ha fallado.';
+            const detail = payload.detail || payload.error || cacheI18n.operationFailed;
             const exitCode = payload.exitCode !== undefined && payload.exitCode !== null ? ` (exit code ${payload.exitCode})` : '';
             await window.cmsAlert({ message: `${detail}${exitCode}`, title: errorTitle });
           }
@@ -76,9 +89,9 @@ const site = await loadSite();
         await runAction(
           invalidateBtn,
           '/cms/api/cache/invalidate',
-          'Invalidar caché',
-          'Caché invalidada correctamente.',
-          'Error al invalidar caché'
+          cacheI18n.invalidateTitle,
+          cacheI18n.invalidatedSuccess,
+          cacheI18n.invalidateError
         );
       });
     })();

--- a/routes/admin/components/AlertDialog.astro
+++ b/routes/admin/components/AlertDialog.astro
@@ -5,25 +5,36 @@ Licensed under the Business Source License 1.1
 */
 
 /**
- * Diálogo de aviso del CMS (no usa alert() nativo).
- * Expone window.cmsAlert(options) que devuelve Promise<void>.
+ * Reusable CMS alert dialog (no native alert()).
+ * Exposes window.cmsAlert(options) returning Promise<void>.
  * options: { message: string, title?: string, okLabel?: string }
+ *
+ * Default labels are injected server-side via props to avoid Spanish literals
+ * in the is:inline script.
  */
+interface Props {
+  defaultTitle?: string;
+  defaultOkLabel?: string;
+}
+const {
+  defaultTitle = 'Notice',
+  defaultOkLabel = 'OK',
+} = Astro.props;
 ---
 
 <dialog id="cms-alert-dialog" class="cms-alert-dialog" aria-labelledby="cms-alert-title" aria-describedby="cms-alert-message">
   <div class="cms-alert-panel">
-    <h2 id="cms-alert-title" class="cms-alert-title">Aviso</h2>
+    <h2 id="cms-alert-title" class="cms-alert-title">{defaultTitle}</h2>
     <p id="cms-alert-message" class="cms-alert-message"></p>
     <div class="cms-alert-actions cms-form-actions">
       <div class="cms-form-actions-right">
-        <button type="button" id="cms-alert-ok" class="cms-btn cms-btn-primary">Aceptar</button>
+        <button type="button" id="cms-alert-ok" class="cms-btn cms-btn-primary">{defaultOkLabel}</button>
       </div>
     </div>
   </div>
 </dialog>
 
-<script is:inline>
+<script define:vars={{ defaultTitle, defaultOkLabel }}>
   (function() {
     var dialog = document.getElementById('cms-alert-dialog');
     var titleEl = document.getElementById('cms-alert-title');
@@ -32,8 +43,8 @@ Licensed under the Business Source License 1.1
 
     function open(opts) {
       var message = (opts && opts.message) || '';
-      var title = (opts && opts.title) != null ? opts.title : 'Aviso';
-      var okLabel = (opts && opts.okLabel) != null ? opts.okLabel : 'Aceptar';
+      var title = (opts && opts.title) != null ? opts.title : defaultTitle;
+      var okLabel = (opts && opts.okLabel) != null ? opts.okLabel : defaultOkLabel;
       if (messageEl) messageEl.textContent = message;
       if (titleEl) titleEl.textContent = title;
       if (okBtn) okBtn.textContent = okLabel;

--- a/routes/admin/components/ConfirmDialog.astro
+++ b/routes/admin/components/ConfirmDialog.astro
@@ -5,28 +5,41 @@ Licensed under the Business Source License 1.1
 */
 
 /**
- * Diálogo de confirmación del CMS (no usa confirm() nativo).
- * Expone window.cmsConfirm(options) que devuelve Promise<boolean>.
+ * Reusable CMS confirm dialog (no native confirm()).
+ * Exposes window.cmsConfirm(options) returning Promise<boolean>.
  * options: { message: string, title?: string, confirmLabel?: string, cancelLabel?: string }
+ *
+ * Default labels are injected server-side via props to avoid Spanish literals
+ * in the is:inline script.
  */
+interface Props {
+  defaultTitle?: string;
+  defaultConfirmLabel?: string;
+  defaultCancelLabel?: string;
+}
+const {
+  defaultTitle = 'Confirm',
+  defaultConfirmLabel = 'Delete',
+  defaultCancelLabel = 'Cancel',
+} = Astro.props;
 ---
 
 <dialog id="cms-confirm-dialog" class="cms-confirm-dialog" aria-labelledby="cms-confirm-title" aria-describedby="cms-confirm-message">
   <div class="cms-confirm-panel">
-    <h2 id="cms-confirm-title" class="cms-confirm-title">Confirmar</h2>
+    <h2 id="cms-confirm-title" class="cms-confirm-title">{defaultTitle}</h2>
     <p id="cms-confirm-message" class="cms-confirm-message"></p>
     <div class="cms-confirm-actions cms-form-actions">
       <div class="cms-form-actions-left">
-        <button type="button" id="cms-confirm-cancel" class="cms-btn cms-btn-secondary">Cancelar</button>
+        <button type="button" id="cms-confirm-cancel" class="cms-btn cms-btn-secondary">{defaultCancelLabel}</button>
       </div>
       <div class="cms-form-actions-right">
-        <button type="button" id="cms-confirm-ok" class="cms-btn cms-btn-danger">Eliminar</button>
+        <button type="button" id="cms-confirm-ok" class="cms-btn cms-btn-danger">{defaultConfirmLabel}</button>
       </div>
     </div>
   </div>
 </dialog>
 
-<script is:inline>
+<script define:vars={{ defaultTitle, defaultConfirmLabel, defaultCancelLabel }}>
   (function() {
     var dialog = document.getElementById('cms-confirm-dialog');
     var titleEl = document.getElementById('cms-confirm-title');
@@ -35,10 +48,10 @@ Licensed under the Business Source License 1.1
     var okBtn = document.getElementById('cms-confirm-ok');
 
     function open(opts) {
-      var message = (opts && opts.message) || '¿Continuar?';
-      var title = (opts && opts.title) != null ? opts.title : 'Confirmar';
-      var confirmLabel = (opts && opts.confirmLabel) != null ? opts.confirmLabel : 'Eliminar';
-      var cancelLabel = (opts && opts.cancelLabel) != null ? opts.cancelLabel : 'Cancelar';
+      var message = (opts && opts.message) || '';
+      var title = (opts && opts.title) != null ? opts.title : defaultTitle;
+      var confirmLabel = (opts && opts.confirmLabel) != null ? opts.confirmLabel : defaultConfirmLabel;
+      var cancelLabel = (opts && opts.cancelLabel) != null ? opts.cancelLabel : defaultCancelLabel;
       if (messageEl) messageEl.textContent = message;
       if (titleEl) titleEl.textContent = title;
       if (okBtn) okBtn.textContent = confirmLabel;

--- a/routes/admin/configs.astro
+++ b/routes/admin/configs.astro
@@ -10,6 +10,8 @@ import AdminLayout from './layout.astro';
 import DetailModal from './components/DetailModal.astro';
 import { Pencil, Trash2, Lightbulb } from '@lucide/astro';
 import { loadConfigs, loadSite } from '../../api/data.js';
+import { resolveUiLocale } from './i18n/resolve.js';
+import { createT } from './i18n/t.js';
 
 const site = await loadSite();
 const configsData = await loadConfigs();
@@ -17,22 +19,27 @@ const configs = configsData.configs || [];
 function maskConfigValue(value: string | undefined): string {
   return value ? '••••••••' : '—';
 }
+const uiLocale = resolveUiLocale({
+  cookie: Astro.request.headers.get('cookie'),
+  acceptLanguage: Astro.request.headers.get('accept-language'),
+});
+const t = createT(uiLocale);
 ---
 
-<AdminLayout site={site} title="Parámetros">
+<AdminLayout site={site} title={t('configs.title')}>
   <div class="cms-stack">
     <div class="cms-page-intro">
       <div class="cms-page-intro-copy">
-        <span class="cms-page-eyebrow">Configuración</span>
+        <span class="cms-page-eyebrow">{t('configs.eyebrow')}</span>
         <div class="cms-page-header">
-          <h1 class="cms-title">Parámetros</h1>
+          <h1 class="cms-title">{t('configs.title')}</h1>
         </div>
         <p class="cms-page-lead">
-          Define claves globales para consumirlas en componentes y layouts. Son valores string editables desde el CMS sin tocar código.
+          {t('configs.lead')}
         </p>
       </div>
       <div class="cms-page-actions">
-        <button type="button" id="cms-config-new-btn" class="cms-btn cms-btn-primary">Nuevo parámetro</button>
+        <button type="button" id="cms-config-new-btn" class="cms-btn cms-btn-primary">{t('configs.newParam')}</button>
       </div>
     </div>
 
@@ -40,7 +47,7 @@ function maskConfigValue(value: string | undefined): string {
       <p class="cms-menus-info-text">
         <Lightbulb size={14} class="cms-menus-info-icon" aria-hidden="true" />
         <span class="cms-menus-info-body">
-          Úsalo para casos como <code>GOOGLE_MAPS_API_KEY</code> o <code>FORM_RECIPIENT</code>. <strong>Cómo se utiliza:</strong> importa <code>getConfig</code> desde <code>@astroblocks/astro-blocks/getConfig</code> y llama, por ejemplo, <code>await getConfig('GOOGLE_MAPS_API_KEY')</code>. En SSR los cambios aplican tras guardar e invalidar caché; en modo estático se reflejan tras rebuild.
+          {t('configs.info')}
         </span>
       </p>
     </div>
@@ -48,11 +55,11 @@ function maskConfigValue(value: string | undefined): string {
     <div class="cms-toolbar">
       <div class="cms-toolbar-group">
         <div class="cms-field cms-toolbar-search">
-          <input type="search" id="cms-configs-search" placeholder="Buscar por clave, valor o descripción" />
+          <input type="search" id="cms-configs-search" placeholder={t('configs.searchPlaceholder')} />
         </div>
       </div>
       <div class="cms-toolbar-meta">
-        <span class="cms-results-count" id="cms-configs-count">{configs.length} parámetros</span>
+        <span class="cms-results-count" id="cms-configs-count">{t('configs.count', { count: String(configs.length) })}</span>
       </div>
     </div>
 
@@ -62,9 +69,9 @@ function maskConfigValue(value: string | undefined): string {
           <thead>
             <tr>
               <th class="cms-table-actions"></th>
-              <th>Clave</th>
-              <th>Valor</th>
-              <th>Descripción</th>
+              <th>{t('configs.colKey')}</th>
+              <th>{t('configs.colValue')}</th>
+              <th>{t('configs.colDescription')}</th>
               <th class="cms-table-actions-delete"></th>
             </tr>
           </thead>
@@ -72,7 +79,7 @@ function maskConfigValue(value: string | undefined): string {
             {configs.map((entry) => (
               <tr>
                 <td class="cms-table-actions">
-                  <button type="button" class="cms-table-btn-edit cms-config-edit" data-id={entry.id} aria-label="Editar">
+                  <button type="button" class="cms-table-btn-edit cms-config-edit" data-id={entry.id} aria-label={t('common.edit')}>
                     <Pencil size={14} />
                   </button>
                 </td>
@@ -80,7 +87,7 @@ function maskConfigValue(value: string | undefined): string {
                 <td class="cms-table-cell-monospace cms-configs-value-cell">{maskConfigValue(entry.value)}</td>
                 <td class="cms-configs-description-cell" title={entry.description || ''}>{entry.description || '—'}</td>
                 <td class="cms-table-actions-delete">
-                  <button type="button" class="cms-table-btn-delete cms-config-delete" data-id={entry.id} aria-label="Eliminar">
+                  <button type="button" class="cms-table-btn-delete cms-config-delete" data-id={entry.id} aria-label={t('common.delete')}>
                     <Trash2 size={14} />
                   </button>
                 </td>
@@ -90,20 +97,20 @@ function maskConfigValue(value: string | undefined): string {
         </table>
       </div>
       <div id="cms-configs-empty" class:list={['cms-empty-state', 'cms-empty-state--inset', configs.length > 0 && 'cms-hidden']}>
-        <p class="cms-empty-state-title">No hay parámetros configurados</p>
-        <p class="cms-empty-state-text">Crea el primero para centralizar claves y valores consumibles desde tus componentes.</p>
+        <p class="cms-empty-state-title">{t('configs.empty.title')}</p>
+        <p class="cms-empty-state-text">{t('configs.empty.text')}</p>
         <div class="cms-empty-state-actions">
-          <button type="button" class="cms-btn cms-btn-primary" data-open-config-new>Crear parámetro</button>
+          <button type="button" class="cms-btn cms-btn-primary" data-open-config-new>{t('configs.createParam')}</button>
         </div>
       </div>
     </div>
   </div>
 
-  <DetailModal id="config-detail-modal" title="Parámetro">
+  <DetailModal id="config-detail-modal" title={t('configs.modalTitle')}>
     <form id="config-detail-form" class="cms-form">
       <input type="hidden" id="config-detail-id" name="id" value="" />
       <div class="cms-field">
-        <label for="config-detail-key">Clave</label>
+        <label for="config-detail-key">{t('configs.labelKey')}</label>
         <input
           type="text"
           id="config-detail-key"
@@ -114,18 +121,18 @@ function maskConfigValue(value: string | undefined): string {
         />
       </div>
       <div class="cms-field">
-        <label for="config-detail-value">Valor (string)</label>
+        <label for="config-detail-value">{t('configs.labelValue')}</label>
         <textarea id="config-detail-value" name="value" rows="4" placeholder="AIza..."></textarea>
       </div>
       <div class="cms-field">
-        <label for="config-detail-description">Descripción (opcional)</label>
-        <textarea id="config-detail-description" name="description" rows="2" placeholder="Uso interno del parámetro"></textarea>
+        <label for="config-detail-description">{t('configs.labelDescription')}</label>
+        <textarea id="config-detail-description" name="description" rows="2" placeholder={t('configs.descriptionPlaceholder')}></textarea>
       </div>
-      <p class="cms-muted cms-hint">Clave obligatoria. Solo se permiten letras, números, punto (<code>.</code>), guion (<code>-</code>) y guion bajo (<code>_</code>).</p>
+      <p class="cms-muted cms-hint">{t('configs.hint')}</p>
       <p id="config-detail-error" class="cms-muted cms-hidden cms-hint cms-hint-error" role="alert"></p>
     </form>
-    <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" data-close-modal="config-detail-modal">Cancelar</button>
-    <button type="button" class="cms-btn cms-btn-primary" slot="actions-right" id="config-detail-submit">Guardar</button>
+    <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" data-close-modal="config-detail-modal">{t('common.cancel')}</button>
+    <button type="button" class="cms-btn cms-btn-primary" slot="actions-right" id="config-detail-submit">{t('common.save')}</button>
   </DetailModal>
 
   <script>

--- a/routes/admin/global-blocks.astro
+++ b/routes/admin/global-blocks.astro
@@ -11,24 +11,32 @@ import DetailModal from './components/DetailModal.astro';
 import { Pencil, Lightbulb } from '@lucide/astro';
 import { loadSite } from '../../api/data.js';
 import { globalBlocksRegistry as runtimeGlobalBlocksRegistry } from 'astro-blocks-runtime';
+import { resolveUiLocale } from './i18n/resolve.js';
+import { createT } from './i18n/t.js';
 
 const site = await loadSite();
 
 // v2: registry carries { slug, schemaName, componentPath, label? }
 const globalBlocksRegistry: { slug: string; schemaName: string; componentPath: string; label?: string }[] =
   runtimeGlobalBlocksRegistry ?? [];
+
+const uiLocale = resolveUiLocale({
+  cookie: Astro.request.headers.get('cookie'),
+  acceptLanguage: Astro.request.headers.get('accept-language'),
+});
+const t = createT(uiLocale);
 ---
 
-<AdminLayout site={site} title="Bloques globales">
+<AdminLayout site={site} title={t('globalBlocks.title')}>
   <div class="cms-stack">
     <div class="cms-page-intro">
       <div class="cms-page-intro-copy">
-        <span class="cms-page-eyebrow">Contenido</span>
+        <span class="cms-page-eyebrow">{t('globalBlocks.eyebrow')}</span>
         <div class="cms-page-header">
-          <h1 class="cms-title">Bloques globales</h1>
+          <h1 class="cms-title">{t('globalBlocks.title')}</h1>
         </div>
         <p class="cms-page-lead">
-          Edita elementos reutilizables como cabeceras, pies de página y secciones compartidas. Los cambios se aplican en todos los sitios que los referencien.
+          {t('globalBlocks.lead')}
         </p>
       </div>
     </div>
@@ -37,7 +45,7 @@ const globalBlocksRegistry: { slug: string; schemaName: string; componentPath: s
       <p class="cms-menus-info-text">
         <Lightbulb size={14} class="cms-menus-info-icon" aria-hidden="true" />
         <span class="cms-menus-info-body">
-          Los slugs se declaran en <code>astro.config.mjs</code> mediante la opción <code>globalBlocks</code>. Para añadir o eliminar slugs, modificá la configuración del proyecto y volvé a hacer build.
+          {t('globalBlocks.info')}
         </span>
       </p>
     </div>
@@ -48,8 +56,8 @@ const globalBlocksRegistry: { slug: string; schemaName: string; componentPath: s
           <thead>
             <tr>
               <th class="cms-table-actions"></th>
-              <th>Slug</th>
-              <th>Etiqueta</th>
+              <th>{t('globalBlocks.colSlug')}</th>
+              <th>{t('globalBlocks.colLabel')}</th>
             </tr>
           </thead>
           <tbody id="cms-global-blocks-tbody">
@@ -62,7 +70,7 @@ const globalBlocksRegistry: { slug: string; schemaName: string; componentPath: s
                     data-slug={entry.slug}
                     data-label={entry.label || entry.slug}
                     data-schema-name={entry.schemaName}
-                    aria-label="Editar"
+                    aria-label={t('common.edit')}
                   >
                     <Pencil size={14} />
                   </button>
@@ -78,21 +86,21 @@ const globalBlocksRegistry: { slug: string; schemaName: string; componentPath: s
         id="cms-global-blocks-empty"
         class:list={['cms-empty-state', 'cms-empty-state--inset', globalBlocksRegistry.length > 0 && 'cms-hidden']}
       >
-        <p class="cms-empty-state-title">No hay bloques globales declarados</p>
+        <p class="cms-empty-state-title">{t('globalBlocks.empty.title')}</p>
         <p class="cms-empty-state-text">
-          Declará slugs en <code>globalBlocks</code> dentro de tu <code>astro.config.mjs</code> y volvé a hacer build para empezar.
+          {t('globalBlocks.empty.text')}
         </p>
       </div>
     </div>
   </div>
 
-  <DetailModal id="global-block-detail-modal" title="Editar bloque global" large>
+  <DetailModal id="global-block-detail-modal" title={t('globalBlocks.title')} large>
     <form id="global-block-detail-form" class="cms-form cms-global-block-detail-form">
       <div id="global-block-form-container"></div>
       <p id="global-block-error" class="cms-muted cms-hidden cms-hint cms-hint-error" role="alert"></p>
     </form>
-    <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" id="global-block-cancel-btn">Cancelar</button>
-    <button type="submit" form="global-block-detail-form" class="cms-btn cms-btn-primary" slot="actions-right" id="global-block-submit-btn">Guardar</button>
+    <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" id="global-block-cancel-btn">{t('common.cancel')}</button>
+    <button type="submit" form="global-block-detail-form" class="cms-btn cms-btn-primary" slot="actions-right" id="global-block-submit-btn">{t('common.save')}</button>
   </DetailModal>
 
   <script>

--- a/routes/admin/i18n/en.ts
+++ b/routes/admin/i18n/en.ts
@@ -210,6 +210,8 @@ export const en = {
   'redirects.deleted': 'Redirect deleted.',
   'redirects.updated': 'Redirect updated.',
   'redirects.created': 'Redirect created.',
+  'redirects.code301': 'Permanent',
+  'redirects.code302': 'Temporary',
   'redirects.deleteConfirm': 'Delete redirect {from} → {to}?',
 
   // ─── Configs / Parameters ─────────────────────────────────────────────────
@@ -413,6 +415,8 @@ export const en = {
   // ─── Dialogs ──────────────────────────────────────────────────────────────
   'dialog.defaultAlertTitle': 'Notice',
   'dialog.defaultConfirmLabel': 'Confirm',
+  'dialog.defaultConfirmTitle': 'Confirm',
+  'dialog.defaultOkLabel': 'OK',
   'dialog.defaultErrorTitle': 'Error',
 
   // ─── API Errors ───────────────────────────────────────────────────────────

--- a/routes/admin/i18n/es.ts
+++ b/routes/admin/i18n/es.ts
@@ -210,6 +210,8 @@ export const es = {
   'redirects.deleted': 'Redirección eliminada.',
   'redirects.updated': 'Redirección actualizada.',
   'redirects.created': 'Redirección creada.',
+  'redirects.code301': 'Permanente',
+  'redirects.code302': 'Temporal',
   'redirects.deleteConfirm': '¿Eliminar la redirección {from} → {to}?',
 
   // ─── Configs / Parameters ─────────────────────────────────────────────────
@@ -413,6 +415,8 @@ export const es = {
   // ─── Dialogs ──────────────────────────────────────────────────────────────
   'dialog.defaultAlertTitle': 'Aviso',
   'dialog.defaultConfirmLabel': 'Confirmar',
+  'dialog.defaultConfirmTitle': 'Confirmar',
+  'dialog.defaultOkLabel': 'OK',
   'dialog.defaultErrorTitle': 'Error',
 
   // ─── API Errors ───────────────────────────────────────────────────────────

--- a/routes/admin/index.astro
+++ b/routes/admin/index.astro
@@ -10,6 +10,8 @@ import { Globe, FileText, Menu, Languages, Upload, Plus, Settings, RefreshCw, Ex
 import { loadSite, loadPages, getDefaultLocale, getPageIndexable, getPageLocaleView, getPageStatus, getPublishedPages, loadLanguages, loadMenus } from '../../api/data.js';
 import { getUploadsDir } from '../../utils/paths.js';
 import { slugToPath } from '../../utils/slug.js';
+import { resolveUiLocale } from './i18n/resolve.js';
+import { createT } from './i18n/t.js';
 
 const site = await loadSite();
 const pagesData = await loadPages();
@@ -43,30 +45,36 @@ const recentPages = [...allPages]
   .map((page) => getPageLocaleView(page, defaultLocale, defaultLocale));
 
 const lastUpdatedPage = recentPages[0];
+
+const uiLocale = resolveUiLocale({
+  cookie: Astro.request.headers.get('cookie'),
+  acceptLanguage: Astro.request.headers.get('accept-language'),
+});
+const t = createT(uiLocale);
 ---
 
-<AdminLayout site={site} title="Dashboard">
+<AdminLayout site={site} title={t('dashboard.title')}>
   <div class="cms-stack cms-dashboard">
     <div class="cms-page-intro">
       <div class="cms-page-intro-copy">
-        <span class="cms-page-eyebrow">Control center</span>
+        <span class="cms-page-eyebrow">{t('dashboard.eyebrow')}</span>
         <div class="cms-page-header">
-          <h1 class="cms-title">Dashboard</h1>
+          <h1 class="cms-title">{t('dashboard.title')}</h1>
         </div>
         <p class="cms-page-lead">
-          Vista general del contenido, la navegación y el estado del proyecto para trabajar con rapidez y sin ruido visual.
+          {t('dashboard.lead')}
         </p>
       </div>
       <div class="cms-page-actions">
         {site.baseUrl && (
           <a href={site.baseUrl} target="_blank" rel="noopener noreferrer" class="cms-btn cms-btn-secondary">
             <ExternalLink size={13} />
-            <span>Ver sitio</span>
+            <span>{t('nav.viewSite')}</span>
           </a>
         )}
         <a href="/cms/pages" class="cms-btn cms-btn-primary">
           <Plus size={13} />
-          <span>Nueva página</span>
+          <span>{t('dashboard.actionNewPage')}</span>
         </a>
       </div>
     </div>
@@ -76,9 +84,9 @@ const lastUpdatedPage = recentPages[0];
         <div class="cms-card cms-dashboard-lead-card">
           <div class="cms-dashboard-lead-top">
             <span class="cms-dashboard-kicker">{site.siteName || 'AstroBlocks'}</span>
-            <h2 class="cms-dashboard-lead-title">Resumen operativo del CMS</h2>
+            <h2 class="cms-dashboard-lead-title">{t('dashboard.operativeSummary')}</h2>
             <p class="cms-dashboard-lead-text">
-              Todo el contenido, la navegación y el branding del proyecto desde un panel compacto y fácil de escanear.
+              {t('dashboard.summaryText')}
             </p>
           </div>
           <div class="cms-dashboard-lead-bottom">
@@ -89,7 +97,7 @@ const lastUpdatedPage = recentPages[0];
               </span>
               <span class="cms-dashboard-meta-pill">
                 <Clock3 size={12} />
-                <span>{lastUpdatedPage ? `Última edición: ${lastUpdatedPage.title}` : 'Sin actividad reciente'}</span>
+                <span>{lastUpdatedPage ? t('dashboard.lastEdit', { title: lastUpdatedPage.title }) : t('dashboard.noRecentActivity')}</span>
               </span>
             </div>
           </div>
@@ -101,49 +109,49 @@ const lastUpdatedPage = recentPages[0];
               <Globe size={14} />
             </div>
             <p class="cms-stat-value cms-stat-value--primary">{published.length}</p>
-            <p class="cms-stat-label">Publicadas</p>
+            <p class="cms-stat-label">{t('dashboard.published')}</p>
           </div>
           <div class="cms-card cms-dashboard-stat">
             <div class="cms-stat-icon-wrap cms-stat-icon-wrap--neutral">
               <FileText size={14} />
             </div>
             <p class="cms-stat-value">{drafts.length}</p>
-            <p class="cms-stat-label">Borradores</p>
+            <p class="cms-stat-label">{t('dashboard.drafts')}</p>
           </div>
           <div class="cms-card cms-dashboard-stat">
             <div class="cms-stat-icon-wrap cms-stat-icon-wrap--neutral">
               <Menu size={14} />
             </div>
             <p class="cms-stat-value">{menus.length}</p>
-            <p class="cms-stat-label">Menús</p>
+            <p class="cms-stat-label">{t('dashboard.menus')}</p>
           </div>
           <div class="cms-card cms-dashboard-stat">
             <div class="cms-stat-icon-wrap cms-stat-icon-wrap--neutral">
               <Languages size={14} />
             </div>
             <p class="cms-stat-value">{enabledLanguagesCount}</p>
-            <p class="cms-stat-label">Idiomas</p>
+            <p class="cms-stat-label">{t('dashboard.languages')}</p>
           </div>
           <div class="cms-card cms-dashboard-stat">
             <div class="cms-stat-icon-wrap cms-stat-icon-wrap--neutral">
               <Upload size={14} />
             </div>
             <p class="cms-stat-value">{uploadCount}</p>
-            <p class="cms-stat-label">Archivos</p>
+            <p class="cms-stat-label">{t('dashboard.files')}</p>
           </div>
         </div>
 
         <div class="cms-card cms-card--no-padding cms-dashboard-recent">
           <div class="cms-dashboard-block-header">
-            <span class="cms-dashboard-block-title">Actividad reciente</span>
-            <a href="/cms/pages" class="cms-dashboard-block-link">Ir a páginas</a>
+            <span class="cms-dashboard-block-title">{t('dashboard.recentActivity')}</span>
+            <a href="/cms/pages" class="cms-dashboard-block-link">{t('dashboard.goToPages')}</a>
           </div>
           {recentPages.length === 0 ? (
             <div class="cms-empty-state cms-empty-state--inset">
-              <p class="cms-empty-state-title">Todavía no hay páginas creadas</p>
-              <p class="cms-empty-state-text">Crea la primera página para empezar a poblar el sitio y activar el flujo editorial del CMS.</p>
+              <p class="cms-empty-state-title">{t('dashboard.noPages.title')}</p>
+              <p class="cms-empty-state-text">{t('dashboard.noPages.text')}</p>
               <div class="cms-empty-state-actions">
-                <a href="/cms/pages" class="cms-btn cms-btn-primary">Crear primera página</a>
+                <a href="/cms/pages" class="cms-btn cms-btn-primary">{t('dashboard.createFirstPage')}</a>
               </div>
             </div>
           ) : (
@@ -151,11 +159,11 @@ const lastUpdatedPage = recentPages[0];
               <tbody>
                 {recentPages.map((page) => (
                   <tr>
-                    <td class="cms-dashboard-recent-title">{page.title || '(sin título)'}</td>
+                    <td class="cms-dashboard-recent-title">{page.title || t('dashboard.noTitle')}</td>
                     <td class="cms-table-cell-monospace cms-dashboard-recent-slug">{slugToPath(page.slug)}</td>
                     <td class="cms-dashboard-recent-status">
                       <span class={`cms-badge ${page.status === 'published' ? 'cms-badge-success' : 'cms-badge-neutral'}`}>
-                        {page.status === 'published' ? 'Publicada' : 'Borrador'}
+                        {page.status === 'published' ? t('status.published') : t('status.draft')}
                       </span>
                     </td>
                   </tr>
@@ -168,38 +176,38 @@ const lastUpdatedPage = recentPages[0];
 
       <div class="cms-dashboard-secondary">
         <div class="cms-card cms-dashboard-actions-card">
-          <h2 class="cms-dashboard-section-title">Acciones rápidas</h2>
-          <p class="cms-dashboard-section-copy">Accesos directos a las tareas más frecuentes del panel.</p>
+          <h2 class="cms-dashboard-section-title">{t('dashboard.quickActions')}</h2>
+          <p class="cms-dashboard-section-copy">{t('dashboard.quickActionsLead')}</p>
           <div class="cms-dashboard-action-grid">
             <a href="/cms/pages" class="cms-dashboard-action-card">
               <span class="cms-dashboard-action-icon"><Plus size={14} /></span>
-              <span class="cms-dashboard-action-title">Nueva página</span>
-              <p class="cms-dashboard-action-text">Crear y editar contenido.</p>
+              <span class="cms-dashboard-action-title">{t('dashboard.actionNewPage')}</span>
+              <p class="cms-dashboard-action-text">{t('dashboard.actionNewPageText')}</p>
             </a>
             <a href="/cms/menus" class="cms-dashboard-action-card">
               <span class="cms-dashboard-action-icon"><Menu size={14} /></span>
-              <span class="cms-dashboard-action-title">Menús</span>
-              <p class="cms-dashboard-action-text">Gestionar navegación.</p>
+              <span class="cms-dashboard-action-title">{t('dashboard.actionMenus')}</span>
+              <p class="cms-dashboard-action-text">{t('dashboard.actionMenusText')}</p>
             </a>
             <a href="/cms/settings" class="cms-dashboard-action-card" data-cms-owner-only>
               <span class="cms-dashboard-action-icon"><Settings size={14} /></span>
-              <span class="cms-dashboard-action-title">Ajustes</span>
-              <p class="cms-dashboard-action-text">White-label y branding.</p>
+              <span class="cms-dashboard-action-title">{t('dashboard.actionSettings')}</span>
+              <p class="cms-dashboard-action-text">{t('dashboard.actionSettingsText')}</p>
             </a>
             <a href="/cms/cache" class="cms-dashboard-action-card">
               <span class="cms-dashboard-action-icon"><RefreshCw size={14} /></span>
-              <span class="cms-dashboard-action-title">Caché</span>
-              <p class="cms-dashboard-action-text">Invalidar SSR.</p>
+              <span class="cms-dashboard-action-title">{t('dashboard.actionCache')}</span>
+              <p class="cms-dashboard-action-text">{t('dashboard.actionCacheText')}</p>
             </a>
           </div>
         </div>
 
         <div class="cms-card cms-dashboard-site-card">
-          <h2 class="cms-dashboard-section-title">Sitio y branding</h2>
-          <p class="cms-dashboard-section-copy">Referencia rápida del proyecto y acceso al sitio público.</p>
+          <h2 class="cms-dashboard-section-title">{t('dashboard.siteAndBranding')}</h2>
+          <p class="cms-dashboard-section-copy">{t('dashboard.siteAndBrandingLead')}</p>
           <div class="cms-dashboard-meta">
             <span class="cms-dashboard-meta-pill">
-              <span>{site.siteName || 'Proyecto sin nombre'}</span>
+              <span>{site.siteName || t('dashboard.noName')}</span>
             </span>
             <span class="cms-dashboard-meta-pill">
               <ShieldCheck size={12} />
@@ -213,8 +221,8 @@ const lastUpdatedPage = recentPages[0];
             </a>
           ) : (
             <div class="cms-empty-state">
-              <p class="cms-empty-state-title">Falta la URL base</p>
-              <p class="cms-empty-state-text">Define la URL base en ajustes para mejorar el contexto del panel y del SEO.</p>
+              <p class="cms-empty-state-title">{t('dashboard.noBaseUrl.title')}</p>
+              <p class="cms-empty-state-text">{t('dashboard.noBaseUrl.text')}</p>
             </div>
           )}
         </div>

--- a/routes/admin/languages.astro
+++ b/routes/admin/languages.astro
@@ -9,31 +9,60 @@ import AdminLayout from './layout.astro';
 import DetailModal from './components/DetailModal.astro';
 import { Pencil, Trash2, Lightbulb } from '@lucide/astro';
 import { loadLanguages, loadSite } from '../../api/data.js';
+import { resolveUiLocale } from './i18n/resolve.js';
+import { createT } from './i18n/t.js';
 const site = await loadSite();
 const languagesData = await loadLanguages();
 const languages = languagesData.languages || [];
+const uiLocale = resolveUiLocale({
+  cookie: Astro.request.headers.get('cookie'),
+  acceptLanguage: Astro.request.headers.get('accept-language'),
+});
+const t = createT(uiLocale);
+// Strings injected into the is:inline script via a define:vars bridge script
+const languagesI18n = {
+  statusActive: t('languages.statusActive'),
+  statusDisabled: t('languages.statusDisabled'),
+  isDefaultYes: t('languages.isDefaultYes'),
+  editLabel: t('common.edit'),
+  deleteLabel: t('languages.deleteLabel'),
+  newForm: t('languages.newForm'),
+  editForm: t('languages.editForm'),
+  createBtn: t('languages.createBtn'),
+  saveBtn: t('common.save'),
+  loadError: t('languages.loadError'),
+  deleteError: t('languages.deleteError'),
+  saveError: t('languages.saveError'),
+  validationTitle: t('languages.validationTitle'),
+  codeObligatory: t('languages.codeObligatory'),
+  deleted: t('languages.deleted'),
+  created: t('languages.created'),
+  updated: t('languages.updated'),
+  dialogTitle: t('languages.modalTitle'),
+  deleteConfirmTemplate: t('languages.deleteConfirm'),
+};
 ---
 
-<AdminLayout site={site} title="Idiomas">
+<AdminLayout site={site} title={t('languages.title')}>
   <div class="cms-stack">
     <div class="cms-page-intro">
       <div class="cms-page-intro-copy">
-        <span class="cms-page-eyebrow">Localización</span>
+        <span class="cms-page-eyebrow">{t('languages.eyebrow')}</span>
         <div class="cms-page-header">
-          <h1 class="cms-title">Idiomas de contenido</h1>
+          <h1 class="cms-title">{t('languages.title')}</h1>
         </div>
         <p class="cms-page-lead">
-          Define los idiomas disponibles para el contenido público del sitio. El idioma de interfaz del panel se configura por separado y no es editable aquí.
+          {t('languages.lead')}
         </p>
       </div>
       <div class="cms-page-actions">
-        <button type="button" id="cms-language-new-btn" class="cms-btn cms-btn-primary">Nuevo idioma</button>
+        <button type="button" id="cms-language-new-btn" class="cms-btn cms-btn-primary">{t('languages.newLanguage')}</button>
       </div>
     </div>
     <div class="cms-card cms-menus-info-card">
       <p class="cms-menus-info-text">
         <Lightbulb size={14} class="cms-menus-info-icon" aria-hidden="true" />
-        <span class="cms-menus-info-body">Usa <code>getLanguages()</code> desde <code>astro-blocks/getLanguages</code> para leer los idiomas de contenido en tu proyecto Astro y construir un selector o menú de idioma en frontend. El helper devuelve <code>languages</code> y <code>defaultLocale</code>; por defecto incluye solo idiomas habilitados.</span>
+        <span class="cms-menus-info-body">{t('languages.info')}</span>
       </p>
     </div>
 
@@ -43,10 +72,10 @@ const languages = languagesData.languages || [];
           <thead>
             <tr>
               <th class="cms-table-actions"></th>
-              <th>Código</th>
-              <th>Etiqueta</th>
-              <th>Estado</th>
-              <th>Predeterminado</th>
+              <th>{t('languages.colCode')}</th>
+              <th>{t('languages.colLabel')}</th>
+              <th>{t('languages.colStatus')}</th>
+              <th>{t('languages.colDefault')}</th>
               <th class="cms-table-actions-delete"></th>
             </tr>
           </thead>
@@ -54,7 +83,7 @@ const languages = languagesData.languages || [];
             {languages.map((language) => (
               <tr>
                 <td class="cms-table-actions">
-                  <button type="button" class="cms-table-btn-edit cms-language-edit" data-code={language.code} aria-label="Editar">
+                  <button type="button" class="cms-table-btn-edit cms-language-edit" data-code={language.code} aria-label={t('common.edit')}>
                     <Pencil size={14} />
                   </button>
                 </td>
@@ -62,12 +91,12 @@ const languages = languagesData.languages || [];
                 <td>{language.label}</td>
                 <td>
                   <span class={language.enabled !== false ? 'cms-badge cms-badge-success' : 'cms-badge cms-badge-neutral'}>
-                    {language.enabled !== false ? 'Activo' : 'Desactivado'}
+                    {language.enabled !== false ? t('languages.statusActive') : t('languages.statusDisabled')}
                   </span>
                 </td>
-                <td>{language.isDefault ? 'Sí' : '—'}</td>
+                <td>{language.isDefault ? t('languages.isDefaultYes') : '—'}</td>
                 <td class="cms-table-actions-delete">
-                  <button type="button" class="cms-table-btn-delete cms-language-delete" data-code={language.code} aria-label="Eliminar">
+                  <button type="button" class="cms-table-btn-delete cms-language-delete" data-code={language.code} aria-label={t('languages.deleteLabel')}>
                     <Trash2 size={14} />
                   </button>
                 </td>
@@ -77,39 +106,42 @@ const languages = languagesData.languages || [];
         </table>
       </div>
       <div id="cms-languages-empty" class:list={['cms-empty-state', 'cms-empty-state--inset', languages.length > 0 && 'cms-hidden']}>
-        <p class="cms-empty-state-title">No hay idiomas configurados</p>
-        <p class="cms-empty-state-text">Crea al menos un idioma para empezar a editar contenido multi idioma.</p>
+        <p class="cms-empty-state-title">{t('languages.empty.title')}</p>
+        <p class="cms-empty-state-text">{t('languages.empty.text')}</p>
       </div>
     </div>
   </div>
 
-  <DetailModal id="language-detail-modal" title="Idioma">
+  <DetailModal id="language-detail-modal" title={t('languages.modalTitle')}>
     <form id="language-detail-form" class="cms-form">
       <input type="hidden" id="language-detail-mode" value="create" />
       <input type="hidden" id="language-detail-current-code" value="" />
       <div class="cms-field">
-        <label for="language-detail-code">Código</label>
-        <input type="text" id="language-detail-code" name="code" placeholder="es, ca, en" required />
+        <label for="language-detail-code">{t('languages.labelCode')}</label>
+        <input type="text" id="language-detail-code" name="code" placeholder={t('languages.codePlaceholder')} required />
       </div>
       <div class="cms-field">
-        <label for="language-detail-label">Etiqueta</label>
-        <input type="text" id="language-detail-label" name="label" placeholder="Español" required />
+        <label for="language-detail-label">{t('languages.labelLabel')}</label>
+        <input type="text" id="language-detail-label" name="label" placeholder={t('languages.labelPlaceholder')} required />
       </div>
       <div class="cms-field cms-field-checkbox">
         <input type="checkbox" id="language-detail-enabled" name="enabled" checked />
-        <label for="language-detail-enabled" class="cms-label-tight">Habilitado</label>
+        <label for="language-detail-enabled" class="cms-label-tight">{t('languages.labelEnabled')}</label>
       </div>
       <div class="cms-field cms-field-checkbox">
         <input type="checkbox" id="language-detail-default" name="isDefault" />
-        <label for="language-detail-default" class="cms-label-tight">Predeterminado</label>
+        <label for="language-detail-default" class="cms-label-tight">{t('languages.labelDefault')}</label>
       </div>
       <p class="cms-muted cms-hint">
-        El idioma predeterminado se sirve sin prefijo en URL. Los demás usan prefijo (ej. <code>/en/...</code>).
+        {t('languages.hint')}
       </p>
     </form>
-    <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" data-close-modal="language-detail-modal">Cancelar</button>
-    <button type="submit" form="language-detail-form" class="cms-btn cms-btn-primary" id="language-detail-submit" slot="actions-right">Guardar</button>
+    <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" data-close-modal="language-detail-modal">{t('common.cancel')}</button>
+    <button type="submit" form="language-detail-form" class="cms-btn cms-btn-primary" id="language-detail-submit" slot="actions-right">{t('common.save')}</button>
   </DetailModal>
+
+  {/* Bridge: inject server-translated strings into the is:inline script below */}
+  <script define:vars={{ languagesI18n }}></script>
 
   <script is:inline>
     (function() {
@@ -199,7 +231,7 @@ const languages = languagesData.languages || [];
           labelInput.value = '';
           enabledInput.checked = true;
           defaultInput.checked = false;
-          setModalTitle('Nuevo idioma', 'Crear');
+          setModalTitle(languagesI18n.newForm, languagesI18n.createBtn);
         }
 
         function openNew() {
@@ -217,7 +249,7 @@ const languages = languagesData.languages || [];
           labelInput.value = language.label || language.code;
           enabledInput.checked = language.enabled !== false;
           defaultInput.checked = language.isDefault === true;
-          setModalTitle('Editar idioma', 'Guardar');
+          setModalTitle(languagesI18n.editForm, languagesI18n.saveBtn);
           openModal();
         }
 
@@ -226,12 +258,12 @@ const languages = languagesData.languages || [];
             var active = language.enabled !== false;
             return (
               '<tr>' +
-                '<td class="cms-table-actions"><button type="button" class="cms-table-btn-edit cms-language-edit" data-code="' + language.code + '" aria-label="Editar">' + pencilSvg + '</button></td>' +
+                '<td class="cms-table-actions"><button type="button" class="cms-table-btn-edit cms-language-edit" data-code="' + language.code + '" aria-label="' + languagesI18n.editLabel + '">' + pencilSvg + '</button></td>' +
                 '<td class="cms-table-cell-monospace">' + language.code + '</td>' +
                 '<td>' + (language.label || language.code) + '</td>' +
-                '<td><span class="cms-badge ' + (active ? 'cms-badge-success' : 'cms-badge-neutral') + '">' + (active ? 'Activo' : 'Desactivado') + '</span></td>' +
-                '<td>' + (language.isDefault ? 'Sí' : '—') + '</td>' +
-                '<td class="cms-table-actions-delete"><button type="button" class="cms-table-btn-delete cms-language-delete" data-code="' + language.code + '" aria-label="Eliminar">' + trashSvg + '</button></td>' +
+                '<td><span class="cms-badge ' + (active ? 'cms-badge-success' : 'cms-badge-neutral') + '">' + (active ? languagesI18n.statusActive : languagesI18n.statusDisabled) + '</span></td>' +
+                '<td>' + (language.isDefault ? languagesI18n.isDefaultYes : '—') + '</td>' +
+                '<td class="cms-table-actions-delete"><button type="button" class="cms-table-btn-delete cms-language-delete" data-code="' + language.code + '" aria-label="' + languagesI18n.deleteLabel + '">' + trashSvg + '</button></td>' +
               '</tr>'
             );
           }).join('');
@@ -255,13 +287,13 @@ const languages = languagesData.languages || [];
 
         function refreshLanguages() {
           return fetch('/cms/api/languages', { headers: { Authorization: 'Bearer ' + token } })
-            .then(function(r) { if (!r.ok) throw new Error('Error al cargar idiomas'); return r.json(); })
+            .then(function(r) { if (!r.ok) throw new Error(languagesI18n.loadError); return r.json(); })
             .then(function(payload) {
               languagesState = payload.languages || [];
               renderRows();
             })
             .catch(function(err) {
-              window.cmsAlert && window.cmsAlert({ title: 'Error', message: err.message || 'Error al cargar idiomas' });
+              window.cmsAlert && window.cmsAlert({ title: languagesI18n.dialogTitle, message: err.message || languagesI18n.loadError });
             });
         }
 
@@ -279,11 +311,11 @@ const languages = languagesData.languages || [];
         async function deleteLanguage(code) {
           try {
             var counts = await getCascadeCounts(code);
-            var message = 'Eliminar el idioma "' + code + '" borrará en cascada su contenido asociado.\n\n' +
-              '- Páginas afectadas: ' + counts.pages + '\n' +
-              '- Menús afectados: ' + counts.menus + '\n\n' +
-              'Esta acción no se puede deshacer. ¿Continuar?';
-            var ok = await window.cmsConfirm({ message: message, confirmLabel: 'Eliminar idioma' });
+            var message = languagesI18n.deleteConfirmTemplate
+              .replace('{code}', code)
+              .replace('{pages}', String(counts.pages))
+              .replace('{menus}', String(counts.menus));
+            var ok = await window.cmsConfirm({ message: message, confirmLabel: languagesI18n.deleteLabel });
             if (!ok) return;
 
             var response = await fetch('/cms/api/languages/' + encodeURIComponent(code), {
@@ -292,14 +324,14 @@ const languages = languagesData.languages || [];
             });
             if (!response.ok) {
               var errorBody = await response.json().catch(function() { return {}; });
-              throw new Error(errorBody.error || 'Error al eliminar idioma');
+              throw new Error(errorBody.error || languagesI18n.deleteError);
             }
 
-            window.cmsToast && window.cmsToast({ title: 'Idiomas', message: 'Idioma eliminado correctamente.', tone: 'success' });
+            window.cmsToast && window.cmsToast({ title: languagesI18n.dialogTitle, message: languagesI18n.deleted, tone: 'success' });
             await refreshLanguages();
             notifyLanguagesUpdated();
           } catch (err) {
-            window.cmsAlert && window.cmsAlert({ title: 'Error', message: (err && err.message) || 'Error al eliminar idioma' });
+            window.cmsAlert && window.cmsAlert({ title: languagesI18n.dialogTitle, message: (err && err.message) || languagesI18n.deleteError });
           }
         }
 
@@ -311,7 +343,7 @@ const languages = languagesData.languages || [];
           var isDefault = defaultInput.checked;
 
           if (!code) {
-            await window.cmsAlert({ title: 'Validación', message: 'El código de idioma es obligatorio.' });
+            await window.cmsAlert({ title: languagesI18n.validationTitle, message: languagesI18n.codeObligatory });
             return;
           }
 
@@ -336,20 +368,20 @@ const languages = languagesData.languages || [];
 
           if (!response.ok) {
             var errorBody = await response.json().catch(function() { return {}; });
-            throw new Error(errorBody.error || 'Error al guardar idioma');
+            throw new Error(errorBody.error || languagesI18n.saveError);
           }
 
           closeModal();
           await refreshLanguages();
           notifyLanguagesUpdated();
-          window.cmsToast && window.cmsToast({ title: 'Idiomas', message: mode === 'create' ? 'Idioma creado.' : 'Idioma actualizado.', tone: 'success' });
+          window.cmsToast && window.cmsToast({ title: languagesI18n.dialogTitle, message: mode === 'create' ? languagesI18n.created : languagesI18n.updated, tone: 'success' });
         }
 
         document.getElementById('cms-language-new-btn')?.addEventListener('click', openNew);
         form.addEventListener('submit', function(event) {
           event.preventDefault();
           submitForm().catch(function(err) {
-            window.cmsAlert && window.cmsAlert({ title: 'Error', message: err.message || 'Error al guardar idioma' });
+            window.cmsAlert && window.cmsAlert({ title: languagesI18n.dialogTitle, message: err.message || languagesI18n.saveError });
           });
         });
 

--- a/routes/admin/layout.astro
+++ b/routes/admin/layout.astro
@@ -106,7 +106,7 @@ const t = createT(uiLocale);
               <div class="cms-topbar-locale">
                 <label for="cms-content-locale-select" class="cms-hidden">{t('topbar.contentLanguage')}</label>
                 <select id="cms-content-locale-select" aria-label={t('topbar.contentLanguage')}>
-                  <option value="">Cargando…</option>
+                  <option value="">{t('topbar.contentLanguageLoading')}</option>
                 </select>
               </div>
               {site.baseUrl && (
@@ -196,8 +196,15 @@ const t = createT(uiLocale);
         </footer>
       </div>
     </div>
-    <ConfirmDialog />
-    <AlertDialog />
+    <ConfirmDialog
+      defaultTitle={t('dialog.defaultConfirmTitle')}
+      defaultConfirmLabel={t('common.delete')}
+      defaultCancelLabel={t('common.cancel')}
+    />
+    <AlertDialog
+      defaultTitle={t('dialog.defaultAlertTitle')}
+      defaultOkLabel={t('dialog.defaultOkLabel')}
+    />
     <div class="cms-topbar-dropdown" id="cms-profile-dropdown" role="menu">
       <div class="cms-topbar-dropdown-label">
         <span class="cms-topbar-dropdown-label-title">{site.siteName || 'AstroBlocks'}</span>
@@ -377,6 +384,13 @@ const t = createT(uiLocale);
         window.getCmsUiLocale = function() { return next; };
       };
     </script>
+    <!-- Bridge: SSR-translated layout UI strings for bundled scripts (Fix 2 & 3) -->
+    <script define:vars={{ _layoutSelectFallback: t('common.select'), _layoutToastNotice: t('dialog.defaultAlertTitle') }}>
+      window.__cmsLayoutI18n = {
+        selectFallback: _layoutSelectFallback,
+        toastNotice: _layoutToastNotice,
+      };
+    </script>
     <script>
       (window as unknown as {
         getCmsToken: () => string;
@@ -529,7 +543,8 @@ const t = createT(uiLocale);
 
         function setTriggerLabel(entry: ManagedSelect): void {
           const selected = entry.select.options[entry.select.selectedIndex] || entry.select.options[0];
-          entry.label.textContent = selected?.textContent?.trim() || 'Seleccionar';
+          const selectFallback = (window as unknown as { __cmsLayoutI18n?: { selectFallback?: string } }).__cmsLayoutI18n?.selectFallback || 'Select';
+          entry.label.textContent = selected?.textContent?.trim() || selectFallback;
         }
 
         function syncActiveOption(entry: ManagedSelect): void {
@@ -777,8 +792,9 @@ const t = createT(uiLocale);
           toastRegion.innerHTML = '';
           const toast = document.createElement('div');
           toast.className = `cms-toast cms-toast--${options.tone || 'info'}`;
+          const toastNotice = (window as unknown as { __cmsLayoutI18n?: { toastNotice?: string } }).__cmsLayoutI18n?.toastNotice || 'Notice';
           toast.innerHTML =
-            `<strong class="cms-toast-title">${options.title || 'Aviso'}</strong>` +
+            `<strong class="cms-toast-title">${options.title || toastNotice}</strong>` +
             `<p class="cms-toast-message"></p>`;
           const messageEl = toast.querySelector('.cms-toast-message');
           if (messageEl) messageEl.textContent = options.message;

--- a/routes/admin/menus.astro
+++ b/routes/admin/menus.astro
@@ -9,43 +9,50 @@ import AdminLayout from './layout.astro';
 import DetailModal from './components/DetailModal.astro';
 import { Pencil, Trash2, Lightbulb } from '@lucide/astro';
 import { getDefaultLocale, getMenuLocaleView, loadLanguages, loadMenus, loadSite } from '../../api/data.js';
+import { resolveUiLocale } from './i18n/resolve.js';
+import { createT } from './i18n/t.js';
 const site = await loadSite();
 const menusData = await loadMenus();
 const languagesData = await loadLanguages();
 const defaultLocale = getDefaultLocale(languagesData);
 const menus = (menusData.menus ?? []).map((menu) => getMenuLocaleView(menu, defaultLocale, defaultLocale));
+const uiLocale = resolveUiLocale({
+  cookie: Astro.request.headers.get('cookie'),
+  acceptLanguage: Astro.request.headers.get('accept-language'),
+});
+const t = createT(uiLocale);
 ---
 
-<AdminLayout site={site} title="Menús">
+<AdminLayout site={site} title={t('menus.title')}>
   <div class="cms-stack">
     <div class="cms-page-intro">
       <div class="cms-page-intro-copy">
-        <span class="cms-page-eyebrow">Navegación</span>
+        <span class="cms-page-eyebrow">{t('menus.eyebrow')}</span>
         <div class="cms-page-header">
-          <h1 class="cms-title">Arquitectura de menús</h1>
+          <h1 class="cms-title">{t('menus.title')}</h1>
         </div>
         <p class="cms-page-lead">
-          Organiza la navegación del sitio como una estructura clara y reutilizable. Cada menú tiene un selector único y puede contener subniveles sin perder legibilidad.
+          {t('menus.lead')}
         </p>
       </div>
       <div class="cms-page-actions">
-        <button type="button" id="cms-menu-new-btn" class="cms-btn cms-btn-primary">Nuevo menú</button>
+        <button type="button" id="cms-menu-new-btn" class="cms-btn cms-btn-primary">{t('menus.newMenu')}</button>
       </div>
     </div>
     <div class="cms-card cms-menus-info-card">
       <p class="cms-menus-info-text">
         <Lightbulb size={14} class="cms-menus-info-icon" aria-hidden="true" />
-        <span class="cms-menus-info-body">Cada menú se identifica por su <strong>selector</strong> (ej. <code>main</code>, <code>footer</code>). En el código del sitio se obtienen sus ítems con <code>getMenu('selector')</code> desde <code>astro-blocks/getMenu</code>; el resultado es un array de enlaces (<code>name</code>, <code>path</code>) que puedes usar en el layout o en componentes para renderizar la navegación. Los ítems pueden tener submenús anidados (<code>children</code>) para desplegables o listas anidadas.</span>
+        <span class="cms-menus-info-body">{t('menus.info')}</span>
       </p>
     </div>
     <div class="cms-toolbar">
       <div class="cms-toolbar-group">
         <div class="cms-field cms-toolbar-search">
-          <input type="search" id="cms-menus-search" placeholder="Buscar por nombre o selector" />
+          <input type="search" id="cms-menus-search" placeholder={t('menus.searchPlaceholder')} />
         </div>
       </div>
       <div class="cms-toolbar-meta">
-        <span class="cms-results-count" id="cms-menus-count">{menus.length} menús</span>
+        <span class="cms-results-count" id="cms-menus-count">{t('menus.count', { count: String(menus.length) })}</span>
       </div>
     </div>
     <div class="cms-card cms-card--no-padding">
@@ -54,8 +61,8 @@ const menus = (menusData.menus ?? []).map((menu) => getMenuLocaleView(menu, defa
           <thead>
             <tr>
               <th class="cms-table-actions"></th>
-              <th>Nombre</th>
-              <th class="cms-table-cell-monospace">Selector</th>
+              <th>{t('menus.colName')}</th>
+              <th class="cms-table-cell-monospace">{t('menus.colSelector')}</th>
               <th class="cms-table-actions-delete"></th>
             </tr>
           </thead>
@@ -63,14 +70,14 @@ const menus = (menusData.menus ?? []).map((menu) => getMenuLocaleView(menu, defa
             {menus.map((m) => (
               <tr>
                 <td class="cms-table-actions">
-                  <button type="button" class="cms-table-btn-edit cms-menu-edit" data-id={m.id} aria-label="Editar">
+                  <button type="button" class="cms-table-btn-edit cms-menu-edit" data-id={m.id} aria-label={t('common.edit')}>
                     <Pencil size={14} />
                   </button>
                 </td>
                 <td>{m.name}</td>
                 <td class="cms-table-cell-monospace">{m.selector}</td>
                 <td class="cms-table-actions-delete">
-                  <button type="button" class="cms-table-btn-delete cms-menu-delete" data-id={m.id} aria-label="Eliminar">
+                  <button type="button" class="cms-table-btn-delete cms-menu-delete" data-id={m.id} aria-label={t('common.delete')}>
                     <Trash2 size={14} />
                   </button>
                 </td>
@@ -80,43 +87,43 @@ const menus = (menusData.menus ?? []).map((menu) => getMenuLocaleView(menu, defa
         </table>
       </div>
       <div id="cms-menus-empty" class:list={['cms-empty-state', 'cms-empty-state--inset', menus.length > 0 && 'cms-hidden']}>
-        <p class="cms-empty-state-title">No hay menús disponibles</p>
-        <p class="cms-empty-state-text">Crea un menú para empezar a controlar la navegación del sitio desde el panel.</p>
+        <p class="cms-empty-state-title">{t('menus.empty.title')}</p>
+        <p class="cms-empty-state-text">{t('menus.empty.text')}</p>
         <div class="cms-empty-state-actions">
-          <button type="button" class="cms-btn cms-btn-primary" data-open-menu-new>Crear menú</button>
+          <button type="button" class="cms-btn cms-btn-primary" data-open-menu-new>{t('menus.createMenu')}</button>
         </div>
       </div>
     </div>
   </div>
 
-  <DetailModal id="menu-detail-modal" title="Menú">
+  <DetailModal id="menu-detail-modal" title={t('menus.modalTitle')}>
     <form id="menu-detail-form" class="cms-form cms-menu-detail-form">
       <input type="hidden" id="menu-detail-id" name="id" value="" />
       <div class="cms-menu-detail-head">
         <div class="cms-field">
-          <label for="menu-detail-name">Nombre</label>
-          <input type="text" id="menu-detail-name" name="name" placeholder="Ej. Menú principal" />
+          <label for="menu-detail-name">{t('menus.labelName')}</label>
+          <input type="text" id="menu-detail-name" name="name" placeholder={t('menus.namePlaceholder')} />
         </div>
         <div class="cms-field">
-          <label for="menu-detail-selector">Selector</label>
-          <input type="text" id="menu-detail-selector" name="selector" placeholder="main, footer..." />
+          <label for="menu-detail-selector">{t('menus.labelSelector')}</label>
+          <input type="text" id="menu-detail-selector" name="selector" placeholder={t('menus.selectorPlaceholder')} />
           <p id="menu-detail-selector-hint" class="cms-muted cms-hidden cms-hint"></p>
         </div>
       </div>
       <div class="cms-field">
-        <label>Elementos del menú</label>
+        <label>{t('menus.labelItems')}</label>
         <div class="cms-menu-builder cms-menu-builder-offset">
           <div class="cms-page-actions">
-            <button type="button" id="menu-detail-add-item" class="cms-btn cms-btn-secondary">Añadir elemento</button>
+            <button type="button" id="menu-detail-add-item" class="cms-btn cms-btn-secondary">{t('menus.addItem')}</button>
           </div>
           <div id="menu-detail-items-list" class="cms-menu-builder-list"></div>
-          <p id="menu-detail-empty" class="cms-menu-builder-empty">Aún no hay elementos. Añade enlaces principales y, si hace falta, submenús anidados.</p>
+          <p id="menu-detail-empty" class="cms-menu-builder-empty">{t('menus.noItems')}</p>
         </div>
       </div>
       <p id="menu-detail-error" class="cms-muted cms-hidden cms-hint cms-hint-error" role="alert"></p>
     </form>
-    <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" data-close-modal="menu-detail-modal">Cancelar</button>
-    <button type="button" id="menu-detail-submit" class="cms-btn cms-btn-primary" slot="actions-right">Guardar</button>
+    <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" data-close-modal="menu-detail-modal">{t('common.cancel')}</button>
+    <button type="button" id="menu-detail-submit" class="cms-btn cms-btn-primary" slot="actions-right">{t('common.save')}</button>
   </DetailModal>
 
   <script>

--- a/routes/admin/pages.astro
+++ b/routes/admin/pages.astro
@@ -8,6 +8,8 @@ import AdminLayout from './layout.astro';
 import DetailModal from './components/DetailModal.astro';
 import { Pencil, Trash2 } from '@lucide/astro';
 import { getDefaultLocale, getPageLocaleView, loadLanguages, loadPages, loadSite } from '../../api/data.js';
+import { resolveUiLocale } from './i18n/resolve.js';
+import { createT } from './i18n/t.js';
 const site = await loadSite();
 const pagesData = await loadPages();
 const languagesData = await loadLanguages();
@@ -18,39 +20,44 @@ function slugStr(p: { slug?: string | string[] }) {
   if (p.slug === '/' || (Array.isArray(p.slug) && !p.slug.length)) return '/';
   return Array.isArray(p.slug) ? '/' + p.slug.join('/') : p.slug;
 }
+const uiLocale = resolveUiLocale({
+  cookie: Astro.request.headers.get('cookie'),
+  acceptLanguage: Astro.request.headers.get('accept-language'),
+});
+const t = createT(uiLocale);
 ---
 
-<AdminLayout site={site} title="Páginas">
+<AdminLayout site={site} title={t('nav.pages')}>
   <div class="cms-stack">
     <div class="cms-page-intro">
       <div class="cms-page-intro-copy">
-        <span class="cms-page-eyebrow">Contenido</span>
+        <span class="cms-page-eyebrow">{t('pages.eyebrow')}</span>
         <div class="cms-page-header">
-          <h1 class="cms-title">Biblioteca editorial</h1>
+          <h1 class="cms-title">{t('pages.title')}</h1>
         </div>
         <p class="cms-page-lead">
-          Gestiona borradores, páginas publicadas e indexabilidad desde una única vista. El editor mantiene el foco en contenido, SEO y bloques.
+          {t('pages.lead')}
         </p>
       </div>
       <div class="cms-page-actions">
-        <button type="button" id="cms-page-new-btn" class="cms-btn cms-btn-primary">Nueva página</button>
+        <button type="button" id="cms-page-new-btn" class="cms-btn cms-btn-primary">{t('pages.newPage')}</button>
       </div>
     </div>
     <div class="cms-toolbar">
       <div class="cms-toolbar-group">
         <div class="cms-field cms-toolbar-search">
-          <input type="search" id="cms-pages-search" placeholder="Buscar por título o slug" />
+          <input type="search" id="cms-pages-search" placeholder={t('pages.searchPlaceholder')} />
         </div>
         <div class="cms-field">
-          <select id="cms-pages-status-filter" aria-label="Filtrar por estado">
-            <option value="all">Todos los estados</option>
-            <option value="published">Publicadas</option>
-            <option value="draft">Borradores</option>
+          <select id="cms-pages-status-filter" aria-label={t('pages.filterByStatus')}>
+            <option value="all">{t('pages.allStatuses')}</option>
+            <option value="published">{t('pages.publishedFilter')}</option>
+            <option value="draft">{t('pages.draftsFilter')}</option>
           </select>
         </div>
       </div>
       <div class="cms-toolbar-meta">
-        <span class="cms-results-count" id="cms-pages-count">{pages.length} páginas · {publishedCount} publicadas</span>
+        <span class="cms-results-count" id="cms-pages-count">{t('pages.count', { count: String(pages.length), published: String(publishedCount) })}</span>
       </div>
     </div>
     <div class="cms-card cms-card--no-padding">
@@ -59,10 +66,10 @@ function slugStr(p: { slug?: string | string[] }) {
           <thead>
             <tr>
               <th class="cms-table-actions"></th>
-              <th>Título</th>
-              <th>Slug</th>
-              <th>Estado</th>
-              <th>Indexable</th>
+              <th>{t('pages.colTitle')}</th>
+              <th>{t('pages.colSlug')}</th>
+              <th>{t('pages.colStatus')}</th>
+              <th>{t('pages.colIndexable')}</th>
               <th class="cms-table-actions-delete"></th>
             </tr>
           </thead>
@@ -70,7 +77,7 @@ function slugStr(p: { slug?: string | string[] }) {
             {pages.map((p: { id: string; title: string; slug?: string | string[]; status: string; indexable?: boolean }) => (
               <tr>
                 <td class="cms-table-actions">
-                  <button type="button" class="cms-table-btn-edit cms-page-edit" data-id={p.id} aria-label="Editar">
+                  <button type="button" class="cms-table-btn-edit cms-page-edit" data-id={p.id} aria-label={t('common.edit')}>
                     <Pencil size={14} />
                   </button>
                 </td>
@@ -78,18 +85,18 @@ function slugStr(p: { slug?: string | string[] }) {
                 <td class="cms-table-cell-monospace">{slugStr(p)}</td>
                 <td>
                   <span class={p.status === 'published' ? 'cms-badge cms-badge-success' : 'cms-badge cms-badge-neutral'}>
-                    {p.status}
+                    {p.status === 'published' ? t('status.published') : t('status.draft')}
                   </span>
                 </td>
                 <td>
                   <span
                     class={'cms-indexable-dot cms-indexable-dot--' + (p.indexable !== false ? 'yes' : 'no')}
-                    aria-label={p.indexable !== false ? 'Indexable' : 'No indexable'}
+                    aria-label={p.indexable !== false ? t('status.indexable') : t('status.notIndexable')}
                     role="img"
                   />
                 </td>
                 <td class="cms-table-actions-delete">
-                  <button type="button" class="cms-table-btn-delete cms-page-delete" data-id={p.id} aria-label="Eliminar">
+                  <button type="button" class="cms-table-btn-delete cms-page-delete" data-id={p.id} aria-label={t('common.delete')}>
                     <Trash2 size={14} />
                   </button>
                 </td>
@@ -99,106 +106,106 @@ function slugStr(p: { slug?: string | string[] }) {
         </table>
       </div>
       <div id="cms-pages-empty" class:list={['cms-empty-state', 'cms-empty-state--inset', pages.length > 0 && 'cms-hidden']}>
-        <p class="cms-empty-state-title">No hay páginas que mostrar</p>
-        <p class="cms-empty-state-text">Crea una nueva página o ajusta la búsqueda para volver a ver resultados.</p>
+        <p class="cms-empty-state-title">{t('pages.empty.title')}</p>
+        <p class="cms-empty-state-text">{t('pages.empty.text')}</p>
         <div class="cms-empty-state-actions">
-          <button type="button" class="cms-btn cms-btn-primary" data-open-page-new>Crear página</button>
+          <button type="button" class="cms-btn cms-btn-primary" data-open-page-new>{t('pages.createPage')}</button>
         </div>
       </div>
     </div>
   </div>
 
-  <DetailModal id="page-detail-modal" title="Página" large>
+  <DetailModal id="page-detail-modal" title={t('pageEditor.newPage')} large>
     <form id="page-detail-form" class="cms-form cms-page-detail-form">
       <input type="hidden" id="page-detail-id" name="id" value="" />
       <div class="cms-page-detail-layout">
         <div class="cms-page-detail-col cms-page-detail-col--info">
-          <div class="cms-page-detail-tabs" role="tablist" aria-label="Secciones del formulario">
-            <button type="button" role="tab" aria-selected="true" id="page-detail-tab-info" aria-controls="page-detail-panel-info" class="cms-page-detail-tab cms-page-detail-tab--active">Información</button>
-            <button type="button" role="tab" aria-selected="false" id="page-detail-tab-seo" aria-controls="page-detail-panel-seo" class="cms-page-detail-tab">SEO</button>
+          <div class="cms-page-detail-tabs" role="tablist" aria-label={t('pageEditor.tabInfo')}>
+            <button type="button" role="tab" aria-selected="true" id="page-detail-tab-info" aria-controls="page-detail-panel-info" class="cms-page-detail-tab cms-page-detail-tab--active">{t('pageEditor.tabInfo')}</button>
+            <button type="button" role="tab" aria-selected="false" id="page-detail-tab-seo" aria-controls="page-detail-panel-seo" class="cms-page-detail-tab">{t('pageEditor.tabSeo')}</button>
           </div>
           <div id="page-detail-panel-info" role="tabpanel" aria-labelledby="page-detail-tab-info" class="cms-page-detail-tabpanel cms-page-detail-tabpanel--active">
             <div class="cms-field">
-              <label for="page-detail-title">Título</label>
+              <label for="page-detail-title">{t('pageEditor.labelTitle')}</label>
               <input type="text" id="page-detail-title" name="title" required />
             </div>
             <div class="cms-field">
-              <label for="page-detail-slug">Slug</label>
-              <input type="text" id="page-detail-slug" name="slug" placeholder="/ o /about" />
+              <label for="page-detail-slug">{t('pageEditor.labelSlug')}</label>
+              <input type="text" id="page-detail-slug" name="slug" placeholder={t('pageEditor.slugPlaceholder')} />
             </div>
             <input type="hidden" name="status" id="page-detail-status" value="draft" />
             <div class="cms-field cms-field-indexable cms-field-checkbox">
               <input type="checkbox" name="indexable" id="page-detail-indexable" checked />
-              <label for="page-detail-indexable" class="cms-label-tight">Indexable</label>
+              <label for="page-detail-indexable" class="cms-label-tight">{t('pageEditor.labelIndexable')}</label>
             </div>
             <p id="page-detail-seo-hidden-hint" class="cms-muted cms-hidden cms-hint">
-              Las páginas no indexables no aparecen en el sitemap y llevan meta noindex. Los campos SEO no se utilizan.
+              {t('pageEditor.seoHiddenHint')}
             </p>
           </div>
           <div id="page-detail-panel-seo" role="tabpanel" aria-labelledby="page-detail-tab-seo" class="cms-page-detail-tabpanel">
           <div id="page-detail-seo-fields" class="cms-stack">
             <div class="cms-field">
-              <label for="page-detail-seo-title">Título SEO</label>
-              <input type="text" id="page-detail-seo-title" name="seo-title" placeholder="50–60 caracteres" />
+              <label for="page-detail-seo-title">{t('pageEditor.labelSeoTitle')}</label>
+              <input type="text" id="page-detail-seo-title" name="seo-title" placeholder={t('pageEditor.seoTitlePlaceholder')} />
             </div>
             <div class="cms-field">
-              <label for="page-detail-seo-description">Descripción</label>
-              <textarea id="page-detail-seo-description" name="seo-description" rows="2" placeholder="150–160 caracteres"></textarea>
+              <label for="page-detail-seo-description">{t('pageEditor.labelDescription')}</label>
+              <textarea id="page-detail-seo-description" name="seo-description" rows="2" placeholder={t('pageEditor.seoDescriptionPlaceholder')}></textarea>
             </div>
             <div class="cms-field">
-              <label for="page-detail-seo-canonical">URL canónica</label>
-              <input type="text" id="page-detail-seo-canonical" name="seo-canonical" placeholder="Dejar vacío para usar la URL de la página" />
+              <label for="page-detail-seo-canonical">{t('pageEditor.labelCanonical')}</label>
+              <input type="text" id="page-detail-seo-canonical" name="seo-canonical" placeholder={t('pageEditor.seoCanonicalPlaceholder')} />
             </div>
             <div class="cms-field">
-              <label>Imagen (og:image / twitter:image)</label>
+              <label>{t('pageEditor.labelOgImage')}</label>
               <div class="cms-seo-image-field">
                 <input type="hidden" id="page-detail-seo-image" name="seo-image" value="" />
                 <div id="page-detail-seo-image-preview" class="cms-seo-image-preview">
-                  <img id="page-detail-seo-image-thumb" class="cms-seo-image-thumb cms-hidden" alt="" />
-                  <span id="page-detail-seo-image-empty" class="cms-seo-image-empty">Sin imagen</span>
+                  <img id="page-detail-seo-image-thumb" class="cms-seo-image-thumb cms-hidden" alt={t('pageEditor.seoImageAlt')} />
+                  <span id="page-detail-seo-image-empty" class="cms-seo-image-empty">{t('pageEditor.noImage')}</span>
                 </div>
                 <div class="cms-seo-image-actions">
-                  <button type="button" id="page-detail-seo-image-upload" class="cms-btn cms-btn-secondary">Subir imagen</button>
-                  <button type="button" id="page-detail-seo-image-remove" class="cms-btn cms-btn-secondary cms-hidden" aria-label="Eliminar imagen">Eliminar</button>
+                  <button type="button" id="page-detail-seo-image-upload" class="cms-btn cms-btn-secondary">{t('pageEditor.uploadImage')}</button>
+                  <button type="button" id="page-detail-seo-image-remove" class="cms-btn cms-btn-secondary cms-hidden" aria-label={t('pageEditor.removeImage')}>{t('pageEditor.changeImage')}</button>
                 </div>
               </div>
               <input type="file" id="page-detail-seo-image-file" accept="image/*" class="cms-hidden" />
             </div>
             <div class="cms-field cms-field-checkbox">
               <input type="checkbox" name="seo-nofollow" id="page-detail-seo-nofollow" />
-              <label for="page-detail-seo-nofollow" class="cms-label-tight">Añadir nofollow</label>
+              <label for="page-detail-seo-nofollow" class="cms-label-tight">{t('pageEditor.seoNofollow')}</label>
             </div>
           </div>
           </div>
         </div>
         <div class="cms-page-detail-col cms-page-detail-col--blocks">
           <div class="cms-field">
-            <label>Bloques</label>
+            <label>{t('pageEditor.blocks')}</label>
             <div id="page-detail-blocks-section" class="cms-blocks-section">
-              <p id="page-detail-blocks-empty" class="cms-muted cms-blocks-empty">Ningún bloque. Añade bloques para construir el contenido de la página.</p>
-              <ul id="page-detail-blocks-list" class="cms-blocks-list" aria-label="Lista de bloques"></ul>
-              <button type="button" id="page-detail-blocks-add" class="cms-btn cms-btn-secondary">Añadir bloque</button>
+              <p id="page-detail-blocks-empty" class="cms-muted cms-blocks-empty">{t('pageEditor.noBlocks')}</p>
+              <ul id="page-detail-blocks-list" class="cms-blocks-list" aria-label={t('pageEditor.blocks')}></ul>
+              <button type="button" id="page-detail-blocks-add" class="cms-btn cms-btn-secondary">{t('pageEditor.addBlock')}</button>
             </div>
           </div>
         </div>
       </div>
     </form>
-    <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" data-close-modal="page-detail-modal">Cancelar</button>
+    <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" data-close-modal="page-detail-modal">{t('common.cancel')}</button>
     <div class="cms-cluster cms-cluster-gap-md" slot="actions-right">
-      <button type="button" class="cms-btn cms-btn-publish" id="page-detail-publish-btn" aria-label="Guardar y publicar">Publicar</button>
-      <button type="button" class="cms-btn cms-btn-unpublish cms-hidden" id="page-detail-unpublish-btn" aria-label="Guardar y pasar a borrador">A borrador</button>
-      <button type="submit" form="page-detail-form" class="cms-btn cms-btn-primary" id="page-detail-submit">Guardar</button>
+      <button type="button" class="cms-btn cms-btn-publish" id="page-detail-publish-btn" aria-label={t('common.publish')}>{t('common.publish')}</button>
+      <button type="button" class="cms-btn cms-btn-unpublish cms-hidden" id="page-detail-unpublish-btn" aria-label={t('common.unpublish')}>{t('common.unpublish')}</button>
+      <button type="submit" form="page-detail-form" class="cms-btn cms-btn-primary" id="page-detail-submit">{t('common.save')}</button>
     </div>
   </DetailModal>
 
   <dialog id="page-detail-block-select-modal" class="cms-detail-modal" aria-labelledby="page-detail-block-select-title">
     <div class="cms-detail-modal-panel" role="document">
-      <h2 id="page-detail-block-select-title" class="cms-detail-modal-title">Seleccionar tipo de bloque</h2>
+      <h2 id="page-detail-block-select-title" class="cms-detail-modal-title">{t('pageEditor.blockSelectTitle')}</h2>
       <div class="cms-detail-modal-body">
         <ul id="page-detail-block-select-list" class="cms-blocks-select-list cms-blocks-select-grid"></ul>
       </div>
       <div class="cms-detail-modal-actions cms-form-actions">
-        <button type="button" class="cms-btn cms-btn-secondary" data-close-modal="page-detail-block-select-modal">Cancelar</button>
+        <button type="button" class="cms-btn cms-btn-secondary" data-close-modal="page-detail-block-select-modal">{t('common.cancel')}</button>
       </div>
     </div>
   </dialog>

--- a/routes/admin/redirects.astro
+++ b/routes/admin/redirects.astro
@@ -10,44 +10,51 @@ import AdminLayout from './layout.astro';
 import DetailModal from './components/DetailModal.astro';
 import { Pencil, Trash2, Lightbulb } from '@lucide/astro';
 import { loadRedirects, loadSite } from '../../api/data.js';
+import { resolveUiLocale } from './i18n/resolve.js';
+import { createT } from './i18n/t.js';
 
 const site = await loadSite();
 const redirectsData = await loadRedirects();
 const redirects = redirectsData.redirects || [];
+const uiLocale = resolveUiLocale({
+  cookie: Astro.request.headers.get('cookie'),
+  acceptLanguage: Astro.request.headers.get('accept-language'),
+});
+const t = createT(uiLocale);
 ---
 
-<AdminLayout site={site} title="Redirecciones">
+<AdminLayout site={site} title={t('redirects.title')}>
   <div class="cms-stack">
     <div class="cms-page-intro">
       <div class="cms-page-intro-copy">
-        <span class="cms-page-eyebrow">Contenido</span>
+        <span class="cms-page-eyebrow">{t('redirects.eyebrow')}</span>
         <div class="cms-page-header">
-          <h1 class="cms-title">Redirecciones</h1>
+          <h1 class="cms-title">{t('redirects.title')}</h1>
         </div>
         <p class="cms-page-lead">
-          Gestiona rutas antiguas y cambios de URL sin romper enlaces existentes. En este MVP las redirecciones son exactas, internas y se aplican en SSR.
+          {t('redirects.lead')}
         </p>
       </div>
       <div class="cms-page-actions">
-        <button type="button" id="cms-redirect-new-btn" class="cms-btn cms-btn-primary">Nueva redirección</button>
+        <button type="button" id="cms-redirect-new-btn" class="cms-btn cms-btn-primary">{t('redirects.newRedirect')}</button>
       </div>
     </div>
     <div class="cms-card cms-menus-info-card">
       <p class="cms-menus-info-text">
         <Lightbulb size={14} class="cms-menus-info-icon" aria-hidden="true" />
         <span class="cms-menus-info-body">
-          Usa rutas públicas reales. Para el idioma por defecto sin prefijo (ej. <code>/antigua</code>) y para locales no default con prefijo (ej. <code>/en/old</code>).
+          {t('redirects.info')}
         </span>
       </p>
     </div>
     <div class="cms-toolbar">
       <div class="cms-toolbar-group">
         <div class="cms-field cms-toolbar-search">
-          <input type="search" id="cms-redirects-search" placeholder="Buscar por origen o destino" />
+          <input type="search" id="cms-redirects-search" placeholder={t('redirects.searchPlaceholder')} />
         </div>
       </div>
       <div class="cms-toolbar-meta">
-        <span class="cms-results-count" id="cms-redirects-count">{redirects.length} redirecciones</span>
+        <span class="cms-results-count" id="cms-redirects-count">{t('redirects.count', { count: String(redirects.length) })}</span>
       </div>
     </div>
     <div class="cms-card cms-card--no-padding">
@@ -56,10 +63,10 @@ const redirects = redirectsData.redirects || [];
           <thead>
             <tr>
               <th class="cms-table-actions"></th>
-              <th>Origen</th>
-              <th>Destino</th>
-              <th>Código</th>
-              <th>Estado</th>
+              <th>{t('redirects.colSource')}</th>
+              <th>{t('redirects.colDest')}</th>
+              <th>{t('redirects.colCode')}</th>
+              <th>{t('redirects.colStatus')}</th>
               <th class="cms-table-actions-delete"></th>
             </tr>
           </thead>
@@ -67,7 +74,7 @@ const redirects = redirectsData.redirects || [];
             {redirects.map((entry) => (
               <tr>
                 <td class="cms-table-actions">
-                  <button type="button" class="cms-table-btn-edit cms-redirect-edit" data-id={entry.id} aria-label="Editar">
+                  <button type="button" class="cms-table-btn-edit cms-redirect-edit" data-id={entry.id} aria-label={t('common.edit')}>
                     <Pencil size={14} />
                   </button>
                 </td>
@@ -78,11 +85,11 @@ const redirects = redirectsData.redirects || [];
                 </td>
                 <td>
                   <span class={entry.enabled !== false ? 'cms-badge cms-badge-success' : 'cms-badge cms-badge-neutral'}>
-                    {entry.enabled !== false ? 'Activa' : 'Inactiva'}
+                    {entry.enabled !== false ? t('redirects.statusActive') : t('redirects.statusInactive')}
                   </span>
                 </td>
                 <td class="cms-table-actions-delete">
-                  <button type="button" class="cms-table-btn-delete cms-redirect-delete" data-id={entry.id} aria-label="Eliminar">
+                  <button type="button" class="cms-table-btn-delete cms-redirect-delete" data-id={entry.id} aria-label={t('common.delete')}>
                     <Trash2 size={14} />
                   </button>
                 </td>
@@ -92,42 +99,42 @@ const redirects = redirectsData.redirects || [];
         </table>
       </div>
       <div id="cms-redirects-empty" class:list={['cms-empty-state', 'cms-empty-state--inset', redirects.length > 0 && 'cms-hidden']}>
-        <p class="cms-empty-state-title">No hay redirecciones configuradas</p>
-        <p class="cms-empty-state-text">Añade la primera redirección para conservar tráfico cuando cambies una URL publicada.</p>
+        <p class="cms-empty-state-title">{t('redirects.empty.title')}</p>
+        <p class="cms-empty-state-text">{t('redirects.empty.text')}</p>
         <div class="cms-empty-state-actions">
-          <button type="button" class="cms-btn cms-btn-primary" data-open-redirect-new>Crear redirección</button>
+          <button type="button" class="cms-btn cms-btn-primary" data-open-redirect-new>{t('redirects.createRedirect')}</button>
         </div>
       </div>
     </div>
   </div>
 
-  <DetailModal id="redirect-detail-modal" title="Redirección">
+  <DetailModal id="redirect-detail-modal" title={t('redirects.modalTitle')}>
     <form id="redirect-detail-form" class="cms-form">
       <input type="hidden" id="redirect-detail-id" name="id" value="" />
       <div class="cms-field">
-        <label for="redirect-detail-from">Ruta origen</label>
-        <input type="text" id="redirect-detail-from" name="from" placeholder="/ruta-antigua" required />
+        <label for="redirect-detail-from">{t('redirects.labelFrom')}</label>
+        <input type="text" id="redirect-detail-from" name="from" placeholder={t('redirects.fromPlaceholder')} required />
       </div>
       <div class="cms-field">
-        <label for="redirect-detail-to">Ruta destino</label>
-        <input type="text" id="redirect-detail-to" name="to" placeholder="/ruta-nueva" required />
+        <label for="redirect-detail-to">{t('redirects.labelTo')}</label>
+        <input type="text" id="redirect-detail-to" name="to" placeholder={t('redirects.toPlaceholder')} required />
       </div>
       <div class="cms-field">
-        <label for="redirect-detail-status-code">Código HTTP</label>
+        <label for="redirect-detail-status-code">{t('redirects.labelStatusCode')}</label>
         <select id="redirect-detail-status-code" name="statusCode">
-          <option value="301">301 (Permanente)</option>
-          <option value="302">302 (Temporal)</option>
+          <option value="301">301 ({t('redirects.code301')})</option>
+          <option value="302">302 ({t('redirects.code302')})</option>
         </select>
       </div>
       <div class="cms-field cms-field-checkbox">
         <input type="checkbox" id="redirect-detail-enabled" name="enabled" checked />
-        <label for="redirect-detail-enabled" class="cms-label-tight">Activa</label>
+        <label for="redirect-detail-enabled" class="cms-label-tight">{t('redirects.labelEnabled')}</label>
       </div>
-      <p class="cms-muted cms-hint">Solo se admiten rutas internas exactas sin query (<code>?</code>) ni fragmento (<code>#</code>).</p>
+      <p class="cms-muted cms-hint">{t('redirects.hint')}</p>
       <p id="redirect-detail-error" class="cms-muted cms-hidden cms-hint cms-hint-error" role="alert"></p>
     </form>
-    <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" data-close-modal="redirect-detail-modal">Cancelar</button>
-    <button type="button" class="cms-btn cms-btn-primary" slot="actions-right" id="redirect-detail-submit">Guardar</button>
+    <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" data-close-modal="redirect-detail-modal">{t('common.cancel')}</button>
+    <button type="button" class="cms-btn cms-btn-primary" slot="actions-right" id="redirect-detail-submit">{t('common.save')}</button>
   </DetailModal>
 
   <script>

--- a/routes/admin/settings.astro
+++ b/routes/admin/settings.astro
@@ -6,6 +6,8 @@ Licensed under the Business Source License 1.1
 
 import AdminLayout from './layout.astro';
 import { loadSite } from '../../api/data.js';
+import { resolveUiLocale } from './i18n/resolve.js';
+import { createT } from './i18n/t.js';
 const site = await loadSite();
 function toFullHex(val: string | undefined, fallback: string) {
   if (!val || !val.startsWith('#')) return fallback;
@@ -16,18 +18,28 @@ function toFullHex(val: string | undefined, fallback: string) {
 }
 const primaryHex = toFullHex(site.primaryColor, '#2C53B8');
 const secondaryHex = toFullHex(site.secondaryColor, '#0DB8DB');
+const uiLocale = resolveUiLocale({
+  cookie: Astro.request.headers.get('cookie'),
+  acceptLanguage: Astro.request.headers.get('accept-language'),
+});
+const t = createT(uiLocale);
+const settingsI18n = {
+  saveTitle: t('settings.saveTitle'),
+  saved: t('settings.saved'),
+  saveError: t('settings.saveError'),
+};
 ---
 
-<AdminLayout site={site} title="Ajustes">
+<AdminLayout site={site} title={t('settings.title')}>
   <div class="cms-stack">
     <div class="cms-page-intro">
       <div class="cms-page-intro-copy">
-        <span class="cms-page-eyebrow">White-label</span>
+        <span class="cms-page-eyebrow">{t('settings.eyebrow')}</span>
         <div class="cms-page-header">
-          <h1 class="cms-title">Sistema visual y datos del sitio</h1>
+          <h1 class="cms-title">{t('settings.title')}</h1>
         </div>
         <p class="cms-page-lead">
-          Ajusta branding, URL base y colorimetría del panel sin salir del CMS. La previsualización te ayuda a validar el tema antes de guardar.
+          {t('settings.lead')}
         </p>
       </div>
     </div>
@@ -35,37 +47,37 @@ const secondaryHex = toFullHex(site.secondaryColor, '#0DB8DB');
       <div class="cms-settings-grid">
         <div class="cms-settings-column">
           <div class="cms-settings-section">
-            <p class="cms-settings-section-title">Información del sitio</p>
+            <p class="cms-settings-section-title">{t('settings.siteInfoTitle')}</p>
             <div class="cms-field">
-              <label for="siteName">Nombre del sitio</label>
+              <label for="siteName">{t('settings.labelSiteName')}</label>
               <input type="text" id="siteName" name="siteName" value={site.siteName} />
             </div>
             <div class="cms-field">
-              <label for="baseUrl">URL base</label>
+              <label for="baseUrl">{t('settings.labelBaseUrl')}</label>
               <input type="text" id="baseUrl" name="baseUrl" value={site.baseUrl} placeholder="https://example.com" />
             </div>
             <div class="cms-field">
-              <label for="favicon">Favicon (ruta)</label>
+              <label for="favicon">{t('settings.labelFavicon')}</label>
               <input type="text" id="favicon" name="favicon" value={site.favicon} placeholder="/favicon.ico" />
             </div>
             <div class="cms-field">
-              <label for="logo">Logo (URL)</label>
+              <label for="logo">{t('settings.labelLogo')}</label>
               <input type="text" id="logo" name="logo" value={site.logo} />
             </div>
           </div>
           <div class="cms-settings-section">
-            <p class="cms-settings-section-title">Apariencia (white-label)</p>
+            <p class="cms-settings-section-title">{t('settings.appearanceTitle')}</p>
             <div class="cms-field">
-              <label for="primaryColor">Color primario</label>
+              <label for="primaryColor">{t('settings.labelPrimaryColor')}</label>
               <div class="cms-color-field">
-                <input type="color" id="primaryColor-picker" value={primaryHex} title="Elegir color" />
+                <input type="color" id="primaryColor-picker" value={primaryHex} title={t('settings.chooseColor')} />
                 <input type="text" id="primaryColor" name="primaryColor" value={site.primaryColor} placeholder="#2C53B8" maxlength="7" />
               </div>
             </div>
             <div class="cms-field">
-              <label for="secondaryColor">Color secundario</label>
+              <label for="secondaryColor">{t('settings.labelSecondaryColor')}</label>
               <div class="cms-color-field">
-                <input type="color" id="secondaryColor-picker" value={secondaryHex} title="Elegir color" />
+                <input type="color" id="secondaryColor-picker" value={secondaryHex} title={t('settings.chooseColor')} />
                 <input type="text" id="secondaryColor" name="secondaryColor" value={site.secondaryColor} placeholder="#0DB8DB" maxlength="7" />
               </div>
             </div>
@@ -73,7 +85,7 @@ const secondaryHex = toFullHex(site.secondaryColor, '#0DB8DB');
         </div>
         <div class="cms-settings-column">
           <div class="cms-settings-section cms-settings-preview-card">
-            <p class="cms-settings-section-title">Preview del panel</p>
+            <p class="cms-settings-section-title">{t('settings.previewTitle')}</p>
             <div id="cms-theme-preview" class="cms-settings-preview-shell" style={`--cms-primary: ${primaryHex}; --cms-secondary: ${secondaryHex};`}>
               <div class="cms-settings-preview-sidebar">
                 <div class="cms-settings-preview-accent" id="cms-theme-preview-primary"></div>
@@ -87,32 +99,32 @@ const secondaryHex = toFullHex(site.secondaryColor, '#0DB8DB');
             <div class="cms-settings-preview-palette">
               <div class="cms-settings-preview-swatch">
                 <div id="cms-preview-primary-swatch" class="cms-settings-preview-swatch-chip" style={`background: ${primaryHex};`}></div>
-                <label for="primaryColor">Primario</label>
+                <label for="primaryColor">{t('settings.primary')}</label>
                 <span id="cms-preview-primary-text">{site.primaryColor || primaryHex}</span>
               </div>
               <div class="cms-settings-preview-swatch">
                 <div id="cms-preview-secondary-swatch" class="cms-settings-preview-swatch-chip" style={`background: ${secondaryHex};`}></div>
-                <label for="secondaryColor">Secundario</label>
+                <label for="secondaryColor">{t('settings.secondary')}</label>
                 <span id="cms-preview-secondary-text">{site.secondaryColor || secondaryHex}</span>
               </div>
             </div>
           </div>
           <div class="cms-card">
-            <p class="cms-dashboard-section-title">Notas de diseño</p>
+            <p class="cms-dashboard-section-title">{t('settings.designNotes')}</p>
             <p class="cms-dashboard-section-copy">
-              El color primario funciona como acento de interacción. El panel mantiene superficies neutras para seguir siendo usable con cualquier identidad visual.
+              {t('settings.designNotesCopy')}
             </p>
           </div>
         </div>
       </div>
       <div class="cms-form-actions cms-form-actions--flush">
         <div class="cms-form-actions-right">
-          <button type="submit" class="cms-btn cms-btn-primary">Guardar ajustes</button>
+          <button type="submit" class="cms-btn cms-btn-primary">{t('settings.save')}</button>
         </div>
       </div>
     </form>
   </div>
-  <script>
+  <script define:vars={{ settingsI18n }}>
     (function() {
       function toFullHex(s: string) {
         if (!s || !s.startsWith('#')) return null;
@@ -187,11 +199,11 @@ const secondaryHex = toFullHex(site.secondaryColor, '#0DB8DB');
         headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
         body: JSON.stringify(body),
       });
-      if (!res.ok) await window.cmsAlert({ message: 'Error: ' + (await res.text()), title: 'Error' });
+      if (!res.ok) await window.cmsAlert({ message: settingsI18n.saveError.replace('{detail}', await res.text()), title: settingsI18n.saveTitle });
       else {
         document.body.style.setProperty('--cms-primary', body.primaryColor || '#2C53B8');
         document.body.style.setProperty('--cms-secondary', body.secondaryColor || body.primaryColor || '#0DB8DB');
-        window.cmsToast?.({ title: 'Ajustes', message: 'Cambios guardados correctamente.', tone: 'success' });
+        window.cmsToast?.({ title: settingsI18n.saveTitle, message: settingsI18n.saved, tone: 'success' });
       }
     });
   </script>

--- a/routes/admin/users.astro
+++ b/routes/admin/users.astro
@@ -8,53 +8,85 @@ export const prerender = false;
 import AdminLayout from './layout.astro';
 import DetailModal from './components/DetailModal.astro';
 import { loadSite } from '../../api/data.js';
+import { resolveUiLocale } from './i18n/resolve.js';
+import { createT } from './i18n/t.js';
 const site = await loadSite();
+const uiLocale = resolveUiLocale({
+  cookie: Astro.request.headers.get('cookie'),
+  acceptLanguage: Astro.request.headers.get('accept-language'),
+});
+const t = createT(uiLocale);
+// Strings injected into the is:inline script via a define:vars bridge script
+const usersI18n = {
+  dialogTitle: t('users.modalTitle'),
+  roleOwner: t('users.roleOwner'),
+  roleUser: t('users.roleUser'),
+  editLabel: t('common.edit'),
+  deleteLabel: t('users.deleteLabel'),
+  newForm: t('users.newForm'),
+  editForm: t('users.editForm'),
+  createBtn: t('users.createBtn'),
+  saveBtn: t('common.save'),
+  deleteConfirm: t('users.deleteConfirm'),
+  cannotDeleteLastOwner: t('users.cannotDeleteLastOwner'),
+  emailRequired: t('users.emailRequired'),
+  passwordRequiredNew: t('users.passwordRequiredNew'),
+  loadError: t('users.loadError'),
+  saveError: t('users.saveError'),
+  deleteError: t('users.deleteError'),
+  deleted: t('users.deleted'),
+  updated: t('users.updated'),
+  created: t('users.created'),
+  noDate: t('common.noDate'),
+  countLabel: t('users.count'),
+  loading: t('users.loadingUsers'),
+};
 ---
 
-<AdminLayout site={site} title="Usuarios">
+<AdminLayout site={site} title={t('users.title')}>
   <div class="cms-stack">
     <div class="cms-page-intro">
       <div class="cms-page-intro-copy">
-        <span class="cms-page-eyebrow">Equipo</span>
+        <span class="cms-page-eyebrow">{t('users.eyebrow')}</span>
         <div class="cms-page-header">
-          <h1 class="cms-title">Accesos y roles del panel</h1>
+          <h1 class="cms-title">{t('users.title')}</h1>
         </div>
         <p class="cms-page-lead">
-          Administra los usuarios del CMS, controla quién puede editar el contenido y mantén el acceso del proyecto bajo una jerarquía clara.
+          {t('users.lead')}
         </p>
       </div>
       <div class="cms-page-actions">
-        <button type="button" id="cms-users-add-btn" class="cms-btn cms-btn-primary">Añadir usuario</button>
+        <button type="button" id="cms-users-add-btn" class="cms-btn cms-btn-primary">{t('users.addUser')}</button>
       </div>
     </div>
     <div class="cms-toolbar">
       <div class="cms-toolbar-group">
         <div class="cms-field cms-toolbar-search">
-          <input type="search" id="cms-users-search" placeholder="Buscar por email" />
+          <input type="search" id="cms-users-search" placeholder={t('users.searchPlaceholder')} />
         </div>
         <div class="cms-field">
-          <select id="cms-users-role-filter" aria-label="Filtrar por rol">
-            <option value="all">Todos los roles</option>
-            <option value="owner">Propietarios</option>
-            <option value="user">Usuarios</option>
+          <select id="cms-users-role-filter" aria-label={t('users.filterByRole')}>
+            <option value="all">{t('users.allRoles')}</option>
+            <option value="owner">{t('users.owners')}</option>
+            <option value="user">{t('users.users')}</option>
           </select>
         </div>
       </div>
       <div class="cms-toolbar-meta">
-        <span class="cms-results-count" id="cms-users-count">0 usuarios</span>
+        <span class="cms-results-count" id="cms-users-count">{t('users.count', { count: '0' })}</span>
       </div>
     </div>
     <p id="cms-users-error" class="cms-muted cms-hidden" role="alert"></p>
-    <p id="cms-users-loading" class="cms-muted">Cargando…</p>
+    <p id="cms-users-loading" class="cms-muted">{t('users.loadingUsers')}</p>
     <div id="cms-users-list-wrap" class="cms-hidden cms-card cms-card--no-padding">
       <div class="cms-table-wrap">
         <table class="cms-table">
           <thead>
             <tr>
               <th class="cms-table-actions"></th>
-              <th>Email</th>
-              <th>Rol</th>
-              <th>Fecha</th>
+              <th>{t('users.colEmail')}</th>
+              <th>{t('users.colRole')}</th>
+              <th>{t('users.colDate')}</th>
               <th class="cms-table-actions-delete"></th>
             </tr>
           </thead>
@@ -62,37 +94,40 @@ const site = await loadSite();
         </table>
       </div>
       <div id="cms-users-empty" class="cms-empty-state cms-empty-state--inset cms-hidden">
-        <p class="cms-empty-state-title">No hay usuarios que coincidan</p>
-        <p class="cms-empty-state-text">Prueba otra búsqueda o crea un nuevo usuario para ampliar el acceso al panel.</p>
+        <p class="cms-empty-state-title">{t('users.empty.title')}</p>
+        <p class="cms-empty-state-text">{t('users.empty.text')}</p>
         <div class="cms-empty-state-actions">
-          <button type="button" class="cms-btn cms-btn-primary" data-open-users-new>Añadir usuario</button>
+          <button type="button" class="cms-btn cms-btn-primary" data-open-users-new>{t('users.addUser')}</button>
         </div>
       </div>
     </div>
   </div>
 
-  <DetailModal id="user-detail-modal" title="Usuario">
+  <DetailModal id="user-detail-modal" title={t('users.modalTitle')}>
     <form id="user-detail-form" class="cms-form">
       <input type="hidden" id="user-detail-id" name="id" value="" />
       <div class="cms-field">
-        <label for="user-detail-email">Email</label>
-        <input type="email" id="user-detail-email" name="email" placeholder="usuario@ejemplo.com" />
+        <label for="user-detail-email">{t('users.labelEmail')}</label>
+        <input type="email" id="user-detail-email" name="email" placeholder={t('users.emailPlaceholder')} />
       </div>
       <div class="cms-field" id="user-detail-password-wrap">
-        <label for="user-detail-password">Contraseña</label>
-        <input type="password" id="user-detail-password" name="password" placeholder="Dejar en blanco para no cambiar" autocomplete="new-password" />
+        <label for="user-detail-password">{t('users.labelPassword')}</label>
+        <input type="password" id="user-detail-password" name="password" placeholder={t('users.passwordPlaceholder')} autocomplete="new-password" />
       </div>
       <div class="cms-field">
-        <label for="user-detail-role">Rol</label>
+        <label for="user-detail-role">{t('users.labelRole')}</label>
         <select name="role" id="user-detail-role">
-          <option value="user">Usuario</option>
-          <option value="owner">Propietario</option>
+          <option value="user">{t('users.roleUser')}</option>
+          <option value="owner">{t('users.roleOwner')}</option>
         </select>
       </div>
     </form>
-    <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" data-close-modal="user-detail-modal">Cancelar</button>
-    <button type="submit" form="user-detail-form" class="cms-btn cms-btn-primary" id="user-detail-submit" slot="actions-right">Guardar</button>
+    <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" data-close-modal="user-detail-modal">{t('common.cancel')}</button>
+    <button type="submit" form="user-detail-form" class="cms-btn cms-btn-primary" id="user-detail-submit" slot="actions-right">{t('common.save')}</button>
   </DetailModal>
+
+  {/* Bridge: inject server-translated strings into the is:inline script below */}
+  <script define:vars={{ usersI18n }}></script>
 
   <script is:inline>
     (function() {
@@ -136,7 +171,7 @@ const site = await loadSite();
           if (errorEl) { errorEl.textContent = msg || ''; errorEl.classList.toggle('cms-hidden', !msg); }
         }
         function formatDate(iso) {
-          if (!iso) return 'Sin fecha';
+          if (!iso) return usersI18n.noDate;
           try { return new Date(iso).toLocaleDateString(undefined, { day: '2-digit', month: 'short', year: 'numeric' }); } catch (e) { return iso; }
         }
         function closeModal() { if (dialog) dialog.close(); }
@@ -155,7 +190,7 @@ const site = await loadSite();
           });
         }
         function updateMeta(list) {
-          if (countEl) countEl.textContent = list.length + ' usuarios';
+          if (countEl) countEl.textContent = usersI18n.countLabel.replace('{count}', String(list.length));
           if (emptyEl) emptyEl.classList.toggle('cms-hidden', list.length > 0);
         }
         function openNew() {
@@ -164,7 +199,7 @@ const site = await loadSite();
           if (passwordInput) { passwordInput.value = ''; passwordInput.required = true; }
           if (passwordWrap) passwordWrap.style.display = '';
           if (roleSelect) roleSelect.value = 'user';
-          setFormTitle('Nuevo usuario', 'Crear');
+          setFormTitle(usersI18n.newForm, usersI18n.createBtn);
           openModal();
         }
         function openEdit(u) {
@@ -174,7 +209,7 @@ const site = await loadSite();
           if (passwordInput) { passwordInput.value = ''; passwordInput.required = false; }
           if (passwordWrap) passwordWrap.style.display = '';
           if (roleSelect) roleSelect.value = u.role || 'user';
-          setFormTitle('Editar usuario', 'Guardar');
+          setFormTitle(usersI18n.editForm, usersI18n.saveBtn);
           openModal();
         }
 
@@ -191,14 +226,14 @@ const site = await loadSite();
             var tr = document.createElement('tr');
             var canDelete = u.role !== 'owner' || ownerCount > 1;
             tr.innerHTML =
-              '<td class="cms-table-actions"><button type="button" class="cms-table-btn-edit cms-user-edit" data-id="' + u.id + '" aria-label="Editar">' + pencilSvg + '</button></td>' +
+              '<td class="cms-table-actions"><button type="button" class="cms-table-btn-edit cms-user-edit" data-id="' + u.id + '" aria-label="' + usersI18n.editLabel + '">' + pencilSvg + '</button></td>' +
               '<td>' + (u.email || '') + '</td>' +
-              '<td><span class="cms-badge ' + (u.role === 'owner' ? 'cms-badge-success' : 'cms-badge-neutral') + '">' + (u.role === 'owner' ? 'Propietario' : 'Usuario') + '</span></td>' +
+              '<td><span class="cms-badge ' + (u.role === 'owner' ? 'cms-badge-success' : 'cms-badge-neutral') + '">' + (u.role === 'owner' ? usersI18n.roleOwner : usersI18n.roleUser) + '</span></td>' +
               '<td>' + formatDate(u.createdAt) + '</td>' +
               '<td class="cms-table-actions-delete">' +
                 (canDelete
-                  ? '<button type="button" class="cms-table-btn-delete cms-user-delete" data-id="' + u.id + '" aria-label="Eliminar">' + trashSvg + '</button>'
-                  : '<button type="button" class="cms-table-btn-delete cms-user-delete" data-id="' + u.id + '" disabled aria-label="Eliminar" title="No se puede eliminar al único propietario">' + trashSvg + '</button>') +
+                  ? '<button type="button" class="cms-table-btn-delete cms-user-delete" data-id="' + u.id + '" aria-label="' + usersI18n.deleteLabel + '">' + trashSvg + '</button>'
+                  : '<button type="button" class="cms-table-btn-delete cms-user-delete" data-id="' + u.id + '" disabled aria-label="' + usersI18n.deleteLabel + '" title="' + usersI18n.cannotDeleteLastOwner + '">' + trashSvg + '</button>') +
               '</td>';
             tbody.appendChild(tr);
             tr.querySelector('.cms-user-edit').addEventListener('click', function() { openEdit(u); });
@@ -213,7 +248,7 @@ const site = await loadSite();
           fetch('/cms/api/users', { headers: headers() })
             .then(function(r) {
               if (r.status === 403) { window.location.href = '/cms'; return null; }
-              if (!r.ok) throw new Error('Error al cargar usuarios');
+              if (!r.ok) throw new Error(usersI18n.loadError);
               return r.json();
             })
             .then(function(data) {
@@ -224,24 +259,24 @@ const site = await loadSite();
             })
             .catch(function(err) {
               if (loadingEl) loadingEl.classList.add('cms-hidden');
-              setError(err.message || 'Error al cargar');
+              setError(err.message || usersI18n.loadError);
             });
         }
         function deleteUser(id) {
           if (!id) return;
-          window.cmsConfirm({ message: '¿Eliminar este usuario?', confirmLabel: 'Eliminar' }).then(function(ok) {
+          window.cmsConfirm({ message: usersI18n.deleteConfirm, confirmLabel: usersI18n.deleteLabel }).then(function(ok) {
             if (!ok) return;
             setError('');
             fetch('/cms/api/users/' + id, { method: 'DELETE', headers: headers() })
               .then(function(r) {
                 if (r.status === 204) {
-                  window.cmsToast && window.cmsToast({ title: 'Usuarios', message: 'Usuario eliminado.', tone: 'success' });
+                  window.cmsToast && window.cmsToast({ title: usersI18n.dialogTitle, message: usersI18n.deleted, tone: 'success' });
                   loadUsers();
                   return;
                 }
-                return r.json().then(function(data) { throw new Error(data.error || 'Error al eliminar'); });
+                return r.json().then(function(data) { throw new Error(data.error || usersI18n.deleteError); });
               })
-              .catch(function(err) { setError(err.message || 'Error al eliminar'); });
+              .catch(function(err) { setError(err.message || usersI18n.deleteError); });
           });
         }
 
@@ -264,8 +299,8 @@ const site = await loadSite();
           var email = emailInput && emailInput.value ? emailInput.value.trim() : '';
           var password = passwordInput && passwordInput.value ? passwordInput.value : '';
           var role = roleSelect && roleSelect.value ? roleSelect.value : 'user';
-          if (!email) { setError('Email obligatorio'); return; }
-          if (!id && !password) { setError('La contraseña es obligatoria para nuevos usuarios'); return; }
+          if (!email) { setError(usersI18n.emailRequired); return; }
+          if (!id && !password) { setError(usersI18n.passwordRequiredNew); return; }
           setError('');
           if (id) {
             var body = { role: role };
@@ -273,22 +308,22 @@ const site = await loadSite();
             fetch('/cms/api/users/' + id, { method: 'PUT', headers: headers(), body: JSON.stringify(body) })
               .then(function(r) { return r.json().then(function(d) { return { ok: r.ok, data: d }; }); })
               .then(function(res) {
-                if (!res.ok) throw new Error(res.data.error || 'Error al guardar');
+                if (!res.ok) throw new Error(res.data.error || usersI18n.saveError);
                 closeModal();
-                window.cmsToast && window.cmsToast({ title: 'Usuarios', message: 'Usuario actualizado.', tone: 'success' });
+                window.cmsToast && window.cmsToast({ title: usersI18n.dialogTitle, message: usersI18n.updated, tone: 'success' });
                 loadUsers();
               })
-              .catch(function(err) { setError(err.message || 'Error al guardar'); });
+              .catch(function(err) { setError(err.message || usersI18n.saveError); });
           } else {
             fetch('/cms/api/users', { method: 'POST', headers: headers(), body: JSON.stringify({ email: email, password: password, role: role }) })
               .then(function(r) { return r.json().then(function(d) { return { ok: r.ok, data: d }; }); })
               .then(function(res) {
-                if (!res.ok) throw new Error(res.data.error || 'Error al crear');
+                if (!res.ok) throw new Error(res.data.error || usersI18n.saveError);
                 closeModal();
-                window.cmsToast && window.cmsToast({ title: 'Usuarios', message: 'Usuario creado.', tone: 'success' });
+                window.cmsToast && window.cmsToast({ title: usersI18n.dialogTitle, message: usersI18n.created, tone: 'success' });
                 loadUsers();
               })
-              .catch(function(err) { setError(err.message || 'Error al crear'); });
+              .catch(function(err) { setError(err.message || usersI18n.saveError); });
           }
         });
 


### PR DESCRIPTION
Part of the **admin UI internationalization** effort. Refs #1.

**PR 3 of 5** (feature-branch-chain — base is the tracker `1-english-ui`, which already contains merged PR-1 #2 and PR-2 #3). This is the bulk string extraction: every admin route page and shared dialog now renders through `t()`.

## Summary

- 10 route pages + 2 shared dialogs wired to the i18n catalog (`media` was already English).
- Each route resolves the active UI locale **server-side** via the shared `resolveUiLocale` — identical to `layout.astro`, so chrome and body never disagree.
- `is:inline` scripts (`users`, `languages`) and `define:vars` pages (`settings`, `cache`) get their strings through SSR bridges — no Spanish literals inside inline scripts.

## Fixes found by independent review (the first pass missed these)

- Spanish leaks: redirects status-code option labels (`Permanente`/`Temporal`), the `cmsToast` `'Aviso'` default and `enhanceSelect` `'Seleccionar'` fallback (now via a `window.__cmsLayoutI18n` SSR bridge), and the content-locale select `'Cargando…'` placeholder.
- `pages.astro` status badge now uses `t('status.*')` (was rendering the raw value, always English regardless of locale).
- `AlertDialog` dismiss button is `'OK'` (was `'Yes'` — wrong UX on error alerts).
- `ConfirmDialog` uses a dedicated title key; removed a dead bridge key in `users.astro`.

## New catalog keys

`redirects.code301`/`code302`, `dialog.defaultConfirmTitle`, `dialog.defaultOkLabel` (key-parity preserved).

## Scope boundary

The **content-locale** axis logic is untouched (only the visible `Cargando…` placeholder text was translated). Client-side `.ts` editors and API error strings are **PR-4**.

## Test plan

- [x] `node --test` — 500 tests green
- [x] Independent fresh-context review applied (4 critical Spanish leaks + 4 correctness/quality findings fixed)
- [x] Spanish grep clean across all route pages + components + layout (only the `Gómez` copyright header and the `Español` endonym remain, both correct)
- [x] No resolution drift; HARD WALL intact

## Follow-up slices

- PR 4/5: client `.ts` editors (menus, block-form, redirects, page, configs, global-blocks) via window bridge + localized API errors (`api/handlers.ts`, `api/data.ts`)
- PR 5/5: leak guard + `withTempProject` packaging tests + playground demo + release bumps + English-only README screenshots