### PR TITLE
feat(i18n): localize client editors and API error messages (PR 4/5)

### DIFF
--- a/api/handlers.ts
+++ b/api/handlers.ts
@@ -53,6 +53,31 @@ import type {
   User,
 } from '../types/index.js';
 import * as data from './data.js';
+import { resolveUiLocale } from '../routes/admin/i18n/resolve.js';
+import { catalogs } from '../routes/admin/i18n/catalogs.js';
+import { t as translateFn } from '../routes/admin/i18n/t.js';
+
+/** Resolve the UI locale from the incoming API request (cookie > Accept-Language > 'en'). */
+function resolveRequestUiLocale(request: Request): import('../routes/admin/i18n/types.js').UiLocale {
+  return resolveUiLocale({
+    cookie: request.headers.get('cookie'),
+    acceptLanguage: request.headers.get('accept-language'),
+  });
+}
+
+/** Return a localized JSON error response. The wire shape { error: string } is preserved. */
+function localizedJsonError(
+  request: Request,
+  key: string,
+  status = 400,
+  params?: Record<string, string | number>,
+  extra?: Record<string, unknown>
+): Response {
+  const locale = resolveRequestUiLocale(request);
+  const catalog = catalogs[locale];
+  const message = translateFn(catalog, key, params);
+  return jsonError(message, status, extra);
+}
 
 const JWT_SECRET = new TextEncoder().encode(process.env.CMS_JWT_SECRET || 'cms-jwt-secret-change-me');
 const JWT_EXPIRY = '7d';
@@ -230,7 +255,7 @@ async function parseJsonBody<T>(request: Request): Promise<{ data: T | null; err
   try {
     return { data: (await request.json()) as T, error: null };
   } catch {
-    return { data: null, error: jsonError('Invalid body') };
+    return { data: null, error: localizedJsonError(request, 'errors.invalidBody') };
   }
 }
 
@@ -243,13 +268,14 @@ function scryptAsync(password: string, salt: crypto.BinaryLike, keylen: number):
   });
 }
 
+/** Returns a catalog error key (not a user-facing string) or null. */
 function validateMenuItemsPaths(items: unknown): string | null {
-  if (!Array.isArray(items)) return 'Los elementos del menú deben ser un array.';
+  if (!Array.isArray(items)) return 'errors.menuItemsArray';
 
   for (const item of items as MenuItem[]) {
-    if (!item || typeof item !== 'object') return 'Elemento del menú no válido.';
+    if (!item || typeof item !== 'object') return 'errors.invalidMenuItem';
     if (typeof item.path !== 'string' || item.path.trim() === '') {
-      return 'La ruta es obligatoria en todos los elementos del menú.';
+      return 'errors.menuPathRequired';
     }
     if (Array.isArray(item.children)) {
       const childError = validateMenuItemsPaths(item.children);
@@ -260,14 +286,15 @@ function validateMenuItemsPaths(items: unknown): string | null {
   return null;
 }
 
+/** Returns a catalog error key (not a user-facing string) or null. */
 function validateMenuSelector(menusData: { menus: Menu[] }, selector: string, excludeMenuId: string | null): string | null {
-  if (!selector) return 'El selector es obligatorio.';
+  if (!selector) return 'errors.menuSelectorRequired';
   if (!data.MENU_SELECTOR_REGEX.test(selector)) {
-    return 'El selector solo puede contener letras, números, guiones y guiones bajos (sin espacios).';
+    return 'errors.invalidMenuSelector';
   }
 
   const taken = menusData.menus.some((menu) => menu.selector === selector && menu.id !== excludeMenuId);
-  if (taken) return 'Ya existe un menú con ese selector.';
+  if (taken) return 'errors.menuSelectorExists';
 
   return null;
 }
@@ -297,11 +324,11 @@ function hasDuplicateConfigKey(configs: ConfigEntry[], key: string, excludeId?: 
   });
 }
 
-function normalizeConfigPayload(body: Record<string, unknown>, current?: ConfigEntry): ConfigEntry | { error: string } {
+function normalizeConfigPayload(body: Record<string, unknown>, current?: ConfigEntry): ConfigEntry | { errorKey: string } {
   const key = normalizeConfigKey(body.key !== undefined ? body.key : current?.key);
-  if (!key) return { error: 'La clave es obligatoria.' };
+  if (!key) return { errorKey: 'errors.configKeyRequired' };
   if (!CONFIG_KEY_REGEX.test(key)) {
-    return { error: 'La clave debe empezar por una letra y solo puede contener letras, números, punto, guion y guion bajo.' };
+    return { errorKey: 'errors.invalidConfigKey' };
   }
 
   const valueInput = body.value !== undefined ? body.value : current?.value;
@@ -319,20 +346,23 @@ function normalizeConfigPayload(body: Record<string, unknown>, current?: ConfigE
   };
 }
 
-function normalizeRedirectPayload(body: Record<string, unknown>, current?: RedirectRule): RedirectRule | { error: string } {
+function normalizeRedirectPayload(
+  body: Record<string, unknown>,
+  current?: RedirectRule
+): RedirectRule | { errorKey: string; fieldKey?: string } {
   const fromInput = body.from !== undefined ? body.from : current?.from;
   const toInput = body.to !== undefined ? body.to : current?.to;
 
   const fromError = validateRedirectPathInput(fromInput, 'from');
-  if (fromError) return { error: fromError };
+  if (fromError) return fromError;
 
   const toError = validateRedirectPathInput(toInput, 'to');
-  if (toError) return { error: toError };
+  if (toError) return toError;
 
   const from = normalizeRedirectPath(String(fromInput || '/'));
   const to = normalizeRedirectPath(String(toInput || '/'));
 
-  if (from === to) return { error: 'La ruta de origen y la de destino no pueden ser iguales.' };
+  if (from === to) return { errorKey: 'errors.redirectSameFromTo' };
 
   return {
     id: current?.id || '',
@@ -350,7 +380,7 @@ function validateLocalePrefixConflict(
   locale: string,
   defaultLocale: string,
   languagesData: LanguagesData
-): string | null {
+): { errorKey: string; params: Record<string, string> } | null {
   if (locale !== defaultLocale) return null;
 
   const segments = splitSlugSegments(slug);
@@ -365,7 +395,7 @@ function validateLocalePrefixConflict(
     .filter(Boolean);
 
   if (enabledLocales.includes(first) && first !== defaultLocale) {
-    return `El slug no puede comenzar con "${first}" porque está reservado para prefijos de idioma.`;
+    return { errorKey: 'errors.slugLocaleConflict', params: { locale: first } };
   }
 
   return null;
@@ -626,8 +656,10 @@ export async function getAuth(request: Request): Promise<AuthResult | null> {
   }
 }
 
-export function requireOwner(user?: AuthUser | null): Response | null {
-  if (!user || user.role !== 'owner') return jsonError('Forbidden', 403);
+export function requireOwner(user?: AuthUser | null, request?: Request): Response | null {
+  if (!user || user.role !== 'owner') {
+    return request ? localizedJsonError(request, 'errors.forbidden', 403) : jsonError('Forbidden', 403);
+  }
   return null;
 }
 
@@ -637,7 +669,7 @@ export async function handleLogin(request: Request): Promise<Response> {
 
   const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
   const password = typeof body.password === 'string' ? body.password : '';
-  if (!email || !password) return jsonError('Email and password required');
+  if (!email || !password) return localizedJsonError(request, 'errors.emailPasswordRequired');
 
   const usersData = await data.loadUsers();
   const users = usersData.users || [];
@@ -655,15 +687,17 @@ export async function handleLogin(request: Request): Promise<Response> {
 
   const user = users.find((entry) => entry.email === email);
   if (!user || !(await verifyPassword(password, user.passwordHash))) {
-    return jsonError('Invalid credentials', 401);
+    return localizedJsonError(request, 'errors.invalidCredentials', 401);
   }
 
   const token = await createToken(user);
   return Response.json({ token, user: { id: user.id, email: user.email, role: user.role } });
 }
 
-export async function handleAuthMe(user?: AuthUser | null): Promise<Response> {
-  if (!user) return jsonError('Unauthorized', 401);
+export async function handleAuthMe(user?: AuthUser | null, request?: Request): Promise<Response> {
+  if (!user) {
+    return request ? localizedJsonError(request, 'errors.unauthorized', 401) : jsonError('Unauthorized', 401);
+  }
   return Response.json({ user });
 }
 
@@ -686,7 +720,7 @@ export async function handleGetUsers(user?: AuthUser | null): Promise<Response> 
 }
 
 export async function handlePostUsers(request: Request, authUser?: AuthUser | null): Promise<Response> {
-  const forbidden = requireOwner(authUser);
+  const forbidden = requireOwner(authUser, request);
   if (forbidden) return forbidden;
 
   const { data: body, error } = await parseJsonBody<Record<string, unknown>>(request);
@@ -695,10 +729,10 @@ export async function handlePostUsers(request: Request, authUser?: AuthUser | nu
   const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
   const password = typeof body.password === 'string' ? body.password : '';
   const role = body.role === 'owner' ? 'owner' : 'user';
-  if (!email || !password) return jsonError('Email and password required');
+  if (!email || !password) return localizedJsonError(request, 'errors.emailPasswordRequired');
 
   const usersData = await data.loadUsers();
-  if (usersData.users.some((user) => user.email === email)) return jsonError('Email already exists');
+  if (usersData.users.some((user) => user.email === email)) return localizedJsonError(request, 'errors.emailExists');
 
   const createdAt = new Date().toISOString();
   const newUser: User = {
@@ -715,7 +749,7 @@ export async function handlePostUsers(request: Request, authUser?: AuthUser | nu
 }
 
 export async function handlePutUser(id: string, request: Request, authUser?: AuthUser | null): Promise<Response> {
-  const forbidden = requireOwner(authUser);
+  const forbidden = requireOwner(authUser, request);
   if (forbidden) return forbidden;
 
   const usersData = await data.loadUsers();
@@ -731,7 +765,7 @@ export async function handlePutUser(id: string, request: Request, authUser?: Aut
   if (body.role !== undefined) {
     const newRole = body.role === 'owner' ? 'owner' : 'user';
     if (target.role === 'owner' && newRole === 'user' && ownerCount <= 1) {
-      return jsonError('No se puede quitar el único propietario');
+      return localizedJsonError(request, 'errors.cannotRemoveLastOwner', 400);
     }
     usersData.users[index] = { ...target, role: newRole };
   }
@@ -745,8 +779,8 @@ export async function handlePutUser(id: string, request: Request, authUser?: Aut
   return Response.json({ id: updated.id, email: updated.email, role: updated.role, createdAt: updated.createdAt });
 }
 
-export async function handleDeleteUser(id: string, authUser?: AuthUser | null): Promise<Response> {
-  const forbidden = requireOwner(authUser);
+export async function handleDeleteUser(id: string, authUser?: AuthUser | null, request?: Request): Promise<Response> {
+  const forbidden = requireOwner(authUser, request);
   if (forbidden) return forbidden;
 
   const usersData = await data.loadUsers();
@@ -755,7 +789,11 @@ export async function handleDeleteUser(id: string, authUser?: AuthUser | null): 
 
   const target = usersData.users[index];
   const ownerCount = usersData.users.filter((user) => user.role === 'owner').length;
-  if (target.role === 'owner' && ownerCount <= 1) return jsonError('No se puede eliminar al único propietario');
+  if (target.role === 'owner' && ownerCount <= 1) {
+    return request
+      ? localizedJsonError(request, 'errors.cannotDeleteLastOwner', 400)
+      : jsonError('Cannot delete the only owner.', 400);
+  }
 
   usersData.users.splice(index, 1);
   await data.saveUsers(usersData);
@@ -776,13 +814,13 @@ export async function handlePostLanguages(request: Request, context: HandlerCont
   const enabled = body.enabled !== false;
   const isDefault = body.isDefault === true;
 
-  if (!code) return jsonError('El código de idioma es obligatorio.');
+  if (!code) return localizedJsonError(request, 'errors.languageCodeRequired');
   if (!/^[a-z]{2,3}(?:-[a-z0-9]{2,8})*$/.test(code)) {
-    return jsonError('Código de idioma no válido. Usa formato como "es" o "pt-br".');
+    return localizedJsonError(request, 'errors.invalidLanguageCode');
   }
 
   if (languagesData.languages.some((language) => normalizeLanguageCode(language.code) === code)) {
-    return jsonError('Ya existe un idioma con ese código.');
+    return localizedJsonError(request, 'errors.languageCodeExists');
   }
 
   const newLanguage: ContentLanguage = { code, label, enabled, isDefault };
@@ -825,7 +863,7 @@ export async function handlePutLanguage(code: string, request: Request, context:
   }
 
   if (!languagesData.languages.some((language) => language.enabled !== false)) {
-    return jsonError('Debe existir al menos un idioma habilitado.');
+    return localizedJsonError(request, 'errors.mustHaveEnabledLanguage');
   }
 
   if (!languagesData.languages.some((language) => language.isDefault && language.enabled !== false)) {
@@ -837,7 +875,7 @@ export async function handlePutLanguage(code: string, request: Request, context:
   return Response.json(languagesData.languages[index]);
 }
 
-export async function handleDeleteLanguage(code: string, context: HandlerContext = {}): Promise<Response> {
+export async function handleDeleteLanguage(code: string, context: HandlerContext = {}, request?: Request): Promise<Response> {
   const normalizedCode = normalizeLanguageCode(code);
 
   const [languagesData, pagesData, menusData, schemaResult] = await Promise.all([
@@ -849,7 +887,11 @@ export async function handleDeleteLanguage(code: string, context: HandlerContext
 
   const languageIndex = languagesData.languages.findIndex((language) => normalizeLanguageCode(language.code) === normalizedCode);
   if (languageIndex === -1) return jsonError('Not found', 404);
-  if (languagesData.languages.length <= 1) return jsonError('No se puede eliminar el último idioma.');
+  if (languagesData.languages.length <= 1) {
+    return request
+      ? localizedJsonError(request, 'errors.cannotDeleteLastLanguage')
+      : jsonError('Cannot delete the last language.');
+  }
 
   const localeKeys = getLanguageLocaleKeys(languagesData);
 
@@ -942,11 +984,11 @@ export async function handlePostPages(request: Request, context: HandlerContext 
   const blocks = Array.isArray(body.blocks) ? (body.blocks as BlockInstance[]) : [];
 
   if (hasDuplicateSlug(pagesData.pages, null, locale, defaultLocale, slug)) {
-    return jsonError('Ya existe una página con ese slug para este idioma.');
+    return localizedJsonError(request, 'errors.duplicateSlug');
   }
 
   const conflictError = validateLocalePrefixConflict(slug, locale, defaultLocale, languagesData);
-  if (conflictError) return jsonError(conflictError);
+  if (conflictError) return localizedJsonError(request, conflictError.errorKey, 400, conflictError.params);
 
   const localeKeys = getLanguageLocaleKeys(languagesData);
   const now = new Date().toISOString();
@@ -1000,11 +1042,11 @@ export async function handlePutPage(id: string, request: Request, context: Handl
   const seo = body.seo !== undefined ? normalizePageSeo(body.seo) : existingView.seo || {};
 
   if (hasDuplicateSlug(pagesData.pages, id, locale, defaultLocale, slug)) {
-    return jsonError('Ya existe una página con ese slug para este idioma.');
+    return localizedJsonError(request, 'errors.duplicateSlug');
   }
 
   const conflictError = validateLocalePrefixConflict(slug, locale, defaultLocale, languagesData);
-  if (conflictError) return jsonError(conflictError);
+  if (conflictError) return localizedJsonError(request, conflictError.errorKey, 400, conflictError.params);
 
   const localeKeys = getLanguageLocaleKeys(languagesData);
   const now = new Date().toISOString();
@@ -1087,14 +1129,14 @@ export async function handlePostMenus(request: Request, context: HandlerContext 
   const locale = resolveLocaleFromBody(body, request, languagesData);
 
   const selectorError = validateMenuSelector(menusData, payload.selector, null);
-  if (selectorError) return jsonError(selectorError);
+  if (selectorError) return localizedJsonError(request, selectorError);
 
   const pathError = validateMenuItemsPaths(payload.items);
-  if (pathError) return jsonError(pathError);
+  if (pathError) return localizedJsonError(request, pathError);
 
   const newMenu: Menu = {
     id: data.generateId(),
-    name: payload.name || 'Menú',
+    name: payload.name || 'Menu',
     selector: payload.selector || 'menu',
     items: {
       [locale]: payload.items,
@@ -1121,15 +1163,15 @@ export async function handlePutMenu(id: string, request: Request, context: Handl
   const locale = resolveLocaleFromBody(body, request, languagesData);
 
   const selectorError = validateMenuSelector(menusData, payload.selector, id);
-  if (selectorError) return jsonError(selectorError);
+  if (selectorError) return localizedJsonError(request, selectorError);
 
   const pathError = validateMenuItemsPaths(payload.items);
-  if (pathError) return jsonError(pathError);
+  if (pathError) return localizedJsonError(request, pathError);
 
   const current = menusData.menus[index];
   const updated: Menu = {
     ...current,
-    name: payload.name || current.name || 'Menú',
+    name: payload.name || current.name || 'Menu',
     selector: payload.selector || current.selector || 'menu',
     items: {
       ...(current.items || {}),
@@ -1167,10 +1209,15 @@ export async function handlePostRedirects(request: Request, context: HandlerCont
 
   const redirectsData = await data.loadRedirects();
   const parsed = normalizeRedirectPayload(body);
-  if ('error' in parsed) return jsonError(parsed.error);
+  if ('errorKey' in parsed) {
+    const locale = resolveRequestUiLocale(request);
+    const catalog = catalogs[locale];
+    const fieldLabel = parsed.fieldKey ? translateFn(catalog, parsed.fieldKey) : '';
+    return localizedJsonError(request, parsed.errorKey, 400, fieldLabel ? { field: fieldLabel } : undefined);
+  }
 
   if (hasDuplicateRedirectFrom(redirectsData.redirects, parsed.from)) {
-    return jsonError('Ya existe una redirección con esa ruta de origen.');
+    return localizedJsonError(request, 'errors.redirectFromExists');
   }
 
   const now = new Date().toISOString();
@@ -1197,10 +1244,15 @@ export async function handlePutRedirect(id: string, request: Request, context: H
 
   const current = redirectsData.redirects[index];
   const parsed = normalizeRedirectPayload(body, current);
-  if ('error' in parsed) return jsonError(parsed.error);
+  if ('errorKey' in parsed) {
+    const locale = resolveRequestUiLocale(request);
+    const catalog = catalogs[locale];
+    const fieldLabel = parsed.fieldKey ? translateFn(catalog, parsed.fieldKey) : '';
+    return localizedJsonError(request, parsed.errorKey, 400, fieldLabel ? { field: fieldLabel } : undefined);
+  }
 
   if (hasDuplicateRedirectFrom(redirectsData.redirects, parsed.from, id)) {
-    return jsonError('Ya existe una redirección con esa ruta de origen.');
+    return localizedJsonError(request, 'errors.redirectFromExists');
   }
 
   const updated: RedirectRule = {
@@ -1239,10 +1291,10 @@ export async function handlePostConfigs(request: Request, context: HandlerContex
 
   const configsData = await data.loadConfigs();
   const parsed = normalizeConfigPayload(body);
-  if ('error' in parsed) return jsonError(parsed.error);
+  if ('errorKey' in parsed) return localizedJsonError(request, parsed.errorKey);
 
   if (hasDuplicateConfigKey(configsData.configs, parsed.key)) {
-    return jsonError('Ya existe un parámetro con esa clave.');
+    return localizedJsonError(request, 'errors.configKeyExists');
   }
 
   const now = new Date().toISOString();
@@ -1269,10 +1321,10 @@ export async function handlePutConfig(id: string, request: Request, context: Han
 
   const current = configsData.configs[index];
   const parsed = normalizeConfigPayload(body, current);
-  if ('error' in parsed) return jsonError(parsed.error);
+  if ('errorKey' in parsed) return localizedJsonError(request, parsed.errorKey);
 
   if (hasDuplicateConfigKey(configsData.configs, parsed.key, id)) {
-    return jsonError('Ya existe un parámetro con esa clave.');
+    return localizedJsonError(request, 'errors.configKeyExists');
   }
 
   const updated: ConfigEntry = {

--- a/routes/admin/client/block-form.ts
+++ b/routes/admin/client/block-form.ts
@@ -39,6 +39,7 @@ import {
 } from '../../../utils/block-validation.js';
 import { isSchemaPropLocalizable } from '../../../utils/localization.js';
 import { escapeHtml, getActiveContentLocale, getCmsToken } from './common.js';
+import { ct } from '../i18n/client.js';
 import { toImageValue, parseImageValue, mediaEntryToImageValue, serializeImageValueAttr } from '../../../utils/image-value.js';
 import { fetchMedia, formatBytes, formatDimensions, formatMediaDate } from './media-fetch.js';
 import type { MediaEntry as MediaFetchEntry } from './media-fetch.js';
@@ -863,9 +864,9 @@ function renderArrayPrimitiveItem(
   return (
     `<li class="cms-array-item cms-array-item--primitive" data-array-item-row="${itemIndex}" data-error-key="${escapePickerHtml(errorKey(propName, itemIndex))}">` +
     '<div class="cms-array-item-inline">' +
-    `<span class="cms-drag-handle cms-array-item-drag" aria-label="Arrastrar">${dragHandleSvg}</span>` +
+    `<span class="cms-drag-handle cms-array-item-drag" aria-label="${ct('common.drag')}">${dragHandleSvg}</span>` +
     `<div class="cms-array-item-input">${inputControl}</div>` +
-    `<button type="button" class="cms-array-item-delete" data-array-delete="true" data-array-prop="${escapePickerHtml(propName)}" data-array-item="${itemIndex}" aria-label="Eliminar elemento">${trashIconSvg}</button>` +
+    `<button type="button" class="cms-array-item-delete" data-array-delete="true" data-array-prop="${escapePickerHtml(propName)}" data-array-item="${itemIndex}" aria-label="${ct('common.delete')}">${trashIconSvg}</button>` +
     '</div>' +
     errorHtml +
     '</li>'
@@ -886,12 +887,13 @@ function renderArrayObjectItem(
   const rowErrorHtml = rowError ? `<p class="cms-field-error">${escapeHtml(rowError)}</p>` : '';
   const isOpen = openItemIndex === itemIndex;
 
-  let summary = `Elemento ${itemIndex + 1}`;
+  const defaultSummary = ct('pageEditor.blockElement', { n: itemIndex + 1 });
+  let summary = defaultSummary;
   if (objectDef.summaryField) {
     const fromSummaryField = item[objectDef.summaryField];
     if (typeof fromSummaryField === 'string' && fromSummaryField.trim()) summary = fromSummaryField.trim();
   }
-  if (summary === `Elemento ${itemIndex + 1}`) {
+  if (summary === defaultSummary) {
     for (const fieldName of Object.keys(objectDef.fields || {})) {
       const v = item[fieldName];
       if (typeof v === 'string' && v.trim()) { summary = v.trim(); break; }
@@ -927,11 +929,11 @@ function renderArrayObjectItem(
   return (
     `<li class="cms-array-item cms-array-item--object" data-array-item-row="${itemIndex}" data-error-key="${escapePickerHtml(errorKey(propName, itemIndex))}">` +
     '<div class="cms-array-item-inline">' +
-    `<span class="cms-drag-handle cms-array-item-drag" aria-label="Arrastrar">${dragHandleSvg}</span>` +
+    `<span class="cms-drag-handle cms-array-item-drag" aria-label="${ct('common.drag')}">${dragHandleSvg}</span>` +
     `<span class="cms-array-item-summary">${escapeHtml(summary)}</span>` +
     '<div class="cms-array-item-actions">' +
-    `<button type="button" class="cms-array-item-toggle" data-array-toggle="true" data-array-prop="${escapePickerHtml(propName)}" data-array-item="${itemIndex}" aria-expanded="${isOpen ? 'true' : 'false'}" aria-label="${isOpen ? 'Contraer' : 'Expandir'}">${isOpen ? chevronUpSvg : chevronDownSvg}</button>` +
-    `<button type="button" class="cms-array-item-delete" data-array-delete="true" data-array-prop="${escapePickerHtml(propName)}" data-array-item="${itemIndex}" aria-label="Eliminar elemento">${trashIconSvg}</button>` +
+    `<button type="button" class="cms-array-item-toggle" data-array-toggle="true" data-array-prop="${escapePickerHtml(propName)}" data-array-item="${itemIndex}" aria-expanded="${isOpen ? 'true' : 'false'}" aria-label="${isOpen ? ct('common.collapse') : ct('common.expand')}">${isOpen ? chevronUpSvg : chevronDownSvg}</button>` +
+    `<button type="button" class="cms-array-item-delete" data-array-delete="true" data-array-prop="${escapePickerHtml(propName)}" data-array-item="${itemIndex}" aria-label="${ct('common.delete')}">${trashIconSvg}</button>` +
     '</div>' +
     '</div>' +
     `<div class="cms-array-item-body${isOpen ? '' : ' cms-hidden'}">${fieldsHtml}</div>` +
@@ -971,11 +973,11 @@ function renderArrayField(
     '<div class="cms-array-field-meta">' +
     `<span class="cms-array-field-counter">${items.length} elemento${items.length === 1 ? '' : 's'}</span>` +
     (limits ? `<span class="cms-array-field-hint">${escapeHtml(limits)}</span>` : '') +
-    `<button type="button" class="cms-btn cms-btn-secondary cms-array-field-add" data-array-add="true" data-array-prop="${escapePickerHtml(propName)}" ${maxReached ? 'disabled' : ''}>Añadir</button>` +
+    `<button type="button" class="cms-btn cms-btn-secondary cms-array-field-add" data-array-add="true" data-array-prop="${escapePickerHtml(propName)}" ${maxReached ? 'disabled' : ''}>${ct('blockForm.addItem')}</button>` +
     '</div>' +
     '</div>' +
     `<ul class="cms-array-list" data-array-list="true" data-array-prop="${escapePickerHtml(propName)}" data-array-sortable="${sortableEnabled ? 'true' : 'false'}">${rowsHtml}</ul>` +
-    (maxReached ? `<p class="cms-muted cms-array-field-hint">Has alcanzado el máximo de ${maxItems} elementos.</p>` : '') +
+    (maxReached ? `<p class="cms-muted cms-array-field-hint">${ct('blockForm.maxReached', { max: maxItems })}</p>` : '') +
     arrayErrorHtml +
     '</div>'
   );

--- a/routes/admin/client/common.ts
+++ b/routes/admin/client/common.ts
@@ -4,6 +4,7 @@ Licensed under the Business Source License 1.1
 */
 
 import type { UiLocale } from '../i18n/types.js';
+import { ct } from '../i18n/client.js';
 
 type CmsUser = { id: string; email: string; role: string } | null;
 
@@ -106,7 +107,7 @@ export async function showAlert(message: string, title = 'Error'): Promise<void>
   alert(message);
 }
 
-export async function showConfirm(message: string, confirmLabel = 'Confirmar'): Promise<boolean> {
+export async function showConfirm(message: string, confirmLabel = ct('dialog.defaultConfirmLabel')): Promise<boolean> {
   const api = getCmsWindow().cmsConfirm;
   if (api) return api({ message, confirmLabel });
   return confirm(message);
@@ -136,7 +137,7 @@ export function escapeHtml(value: string): string {
 }
 
 export function formatDisplayDate(value?: string | null): string {
-  if (!value) return 'Sin fecha';
+  if (!value) return ct('common.noDate');
   try {
     return new Date(value).toLocaleDateString(undefined, {
       day: '2-digit',

--- a/routes/admin/client/configs-editor.ts
+++ b/routes/admin/client/configs-editor.ts
@@ -5,6 +5,7 @@ Licensed under the Business Source License 1.1
 
 import type { ConfigEntry, ConfigsData } from '../../../types/index.js';
 import { authHeaders, closeDialog, escapeHtml, fetchJson, fetchOk, openDialog, showAlert, showConfirm, showToast } from './common.js';
+import { ct } from '../i18n/client.js';
 
 const pencilSvg =
   '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>';
@@ -64,7 +65,7 @@ export function initConfigsEditor(): void {
 
   function openNew(): void {
     resetForm();
-    setFormTitle('Nuevo parámetro', 'Crear');
+    setFormTitle(ct('configs.newParamForm'), ct('common.create'));
     openDialog(dialog);
     keyField.focus();
   }
@@ -79,16 +80,16 @@ export function initConfigsEditor(): void {
     valueField.value = entry.value || '';
     descriptionField.value = entry.description || '';
     setError('');
-    setFormTitle('Editar parámetro', 'Guardar');
+    setFormTitle(ct('configs.editParamForm'), ct('common.save'));
     openDialog(dialog);
     keyField.focus();
   }
 
   function validateForm(): string | null {
     const keyValue = keyField.value.trim();
-    if (!keyValue) return 'La clave es obligatoria.';
+    if (!keyValue) return ct('errors.configKeyRequired');
     if (!configKeyRegex.test(keyValue)) {
-      return 'La clave debe empezar por una letra y solo puede contener letras, números, punto, guion y guion bajo.';
+      return ct('errors.invalidConfigKey');
     }
     return null;
   }
@@ -121,7 +122,7 @@ export function initConfigsEditor(): void {
         if (!id) return;
 
         const entry = configsState.find((item) => item.id === id);
-        const confirmed = await showConfirm(`¿Eliminar el parámetro ${entry?.key || ''}?`, 'Eliminar');
+        const confirmed = await showConfirm(ct('configs.deleteConfirm', { key: entry?.key || '' }), ct('common.delete'));
         if (!confirmed) return;
 
         try {
@@ -129,7 +130,7 @@ export function initConfigsEditor(): void {
             method: 'DELETE',
             headers: authHeaders(false),
           });
-          showToast('Parámetro eliminado.', 'success');
+          showToast(ct('configs.deleted'), 'success');
           await refreshConfigs();
         } catch (error) {
           await showAlert(error instanceof Error ? error.message : String(error));
@@ -143,16 +144,16 @@ export function initConfigsEditor(): void {
     configsTableBody.innerHTML = list
       .map((entry) => (
         `<tr data-id="${escapeHtml(entry.id)}">` +
-        `<td class="cms-table-actions"><button type="button" class="cms-table-btn-edit cms-config-edit" data-id="${escapeHtml(entry.id)}" aria-label="Editar">${pencilSvg}</button></td>` +
+        `<td class="cms-table-actions"><button type="button" class="cms-table-btn-edit cms-config-edit" data-id="${escapeHtml(entry.id)}" aria-label="${ct('common.edit')}">${pencilSvg}</button></td>` +
         `<td class="cms-table-cell-monospace">${escapeHtml(entry.key)}</td>` +
         `<td class="cms-table-cell-monospace cms-configs-value-cell">${escapeHtml(maskConfigValue(entry.value || ''))}</td>` +
         `<td class="cms-configs-description-cell" title="${escapeHtml(entry.description || '')}">${escapeHtml(entry.description || '—')}</td>` +
-        `<td class="cms-table-actions-delete"><button type="button" class="cms-table-btn-delete cms-config-delete" data-id="${escapeHtml(entry.id)}" aria-label="Eliminar">${trashSvg}</button></td>` +
+        `<td class="cms-table-actions-delete"><button type="button" class="cms-table-btn-delete cms-config-delete" data-id="${escapeHtml(entry.id)}" aria-label="${ct('common.delete')}">${trashSvg}</button></td>` +
         '</tr>'
       ))
       .join('');
 
-    if (countEl) countEl.textContent = `${list.length} parámetros`;
+    if (countEl) countEl.textContent = ct('configs.count', { count: list.length });
     emptyEl?.classList.toggle('cms-hidden', list.length > 0);
     bindRows();
   }
@@ -192,7 +193,7 @@ export function initConfigsEditor(): void {
     });
 
     closeDialog(dialog);
-    showToast(id ? 'Parámetro actualizado.' : 'Parámetro creado.', 'success');
+    showToast(id ? ct('configs.updated') : ct('configs.created'), 'success');
     await refreshConfigs();
   }
 

--- a/routes/admin/client/global-blocks-editor.ts
+++ b/routes/admin/client/global-blocks-editor.ts
@@ -25,6 +25,7 @@ import {
   getActiveContentLocale,
   showToast,
 } from './common.js';
+import { ct } from '../i18n/client.js';
 import { mountBlockForm, type BlockFormHandle } from './block-form.js';
 
 interface GlobalBlockResponse {
@@ -83,7 +84,7 @@ export function initGlobalBlocksEditor(): void {
     formHandle?.destroy();
     formHandle = null;
 
-    if (modalTitle) modalTitle.textContent = `Editar: ${label}`;
+    if (modalTitle) modalTitle.textContent = ct('globalBlocks.editTitle', { label });
 
     // Parallel fetch: stored entry (projected for active locale) + all block schemas
     const [entryResponse, schemas] = await Promise.all([
@@ -104,7 +105,7 @@ export function initGlobalBlocksEditor(): void {
 
     const schema = schemas[schemaName];
     if (!schema?.items) {
-      setError(`No se encontró el esquema para "${schemaName}". Verificá la configuración.`);
+      setError(ct('globalBlocks.schemaNotFound', { name: schemaName }));
       dlg.showModal();
       return;
     }
@@ -174,13 +175,13 @@ export function initGlobalBlocksEditor(): void {
         formHandle?.destroy();
         formHandle = null;
         dlg.close();
-        showToast('Bloque global guardado correctamente.', 'success', 'Bloques globales');
+        showToast(ct('globalBlocks.saved'), 'success', ct('globalBlocks.savedTitle'));
       } else {
         const body = await res.json().catch(() => ({})) as { error?: string };
-        setError(body.error || `Error ${res.status} al guardar.`);
+        setError(body.error || ct('pageEditor.saveError'));
       }
     } catch {
-      setError('Error de red al guardar. Revisá la conexión.');
+      setError(ct('globalBlocks.networkError'));
     }
   }
 

--- a/routes/admin/client/menus-editor.ts
+++ b/routes/admin/client/menus-editor.ts
@@ -6,6 +6,7 @@ Licensed under the Business Source License 1.1
 import Sortable from 'sortablejs';
 import type { Menu, MenuItem, MenusData } from '../../../types/index.js';
 import { authHeaders, closeDialog, escapeHtml, fetchJson, fetchOk, getActiveContentLocale, openDialog, showAlert, showConfirm, showToast } from './common.js';
+import { ct } from '../i18n/client.js';
 
 const SELECTOR_REGEX = /^[a-zA-Z0-9_-]+$/;
 const dragHandleSvg =
@@ -78,7 +79,7 @@ export function initMenusEditor(): void {
 
   function validatePaths(items: MenuItem[]): string | null {
     for (const item of items) {
-      if (!item.path?.trim()) return 'La ruta es obligatoria en todos los elementos.';
+      if (!item.path?.trim()) return ct('errors.menuPathRequired');
       if (Array.isArray(item.children)) {
         const childError = validatePaths(item.children);
         if (childError) return childError;
@@ -136,16 +137,16 @@ export function initMenusEditor(): void {
   }
 
   function renderMenuSummary(name: string, path: string, emptyLabel: string): string {
-    return `<div class="cms-menu-card-copy"><strong>${escapeHtml(name || emptyLabel)}</strong><span>${escapeHtml(path || 'Define una ruta')}</span></div>`;
+    return `<div class="cms-menu-card-copy"><strong>${escapeHtml(name || emptyLabel)}</strong><span>${escapeHtml(path || ct('menus.defineRoute'))}</span></div>`;
   }
 
   function renderChildRow(itemIndex: number, childIndex: number, child: MenuItem): string {
     return (
       `<div class="menu-child-row" data-item-index="${itemIndex}" data-child-index="${childIndex}">` +
       renderMenuDragHandle() +
-      renderMenuTextInput('menu-child-name', 'Nombre del submenú', 'Nombre del submenú', child.name ?? '', true) +
-      renderMenuTextInput('menu-child-path', 'Ruta del submenú', '/ruta', child.path ?? '', true) +
-      renderMenuDeleteButton('menu-child-delete', 'Eliminar') +
+      renderMenuTextInput('menu-child-name', ct('menus.submenuNameLabel'), ct('menus.submenuNameLabel'), child.name ?? '', true) +
+      renderMenuTextInput('menu-child-path', ct('menus.submenuPathLabel'), '/ruta', child.path ?? '', true) +
+      renderMenuDeleteButton('menu-child-delete', ct('common.delete')) +
       '</div>'
     );
   }
@@ -159,23 +160,23 @@ export function initMenusEditor(): void {
       '<div class="cms-menu-card-header">' +
       '<div class="cms-menu-card-title">' +
       renderMenuDragHandle() +
-      renderMenuSummary(item.name ?? '', item.path ?? '', 'Elemento de menú') +
-      `<span class="cms-menu-card-summary-badge">${childrenCount} sub${childrenCount === 1 ? 'menú' : 'menús'}</span>` +
+      renderMenuSummary(item.name ?? '', item.path ?? '', ct('menus.menuItem')) +
+      `<span class="cms-menu-card-summary-badge">${childrenCount === 1 ? ct('menus.submenuBadgeSingular', { count: childrenCount }) : ct('menus.submenuBadgePlural', { count: childrenCount })}</span>` +
       '</div>' +
       '<div class="cms-menu-card-actions">' +
-      `<button type="button" class="cms-menu-card-toggle" data-item-index="${itemIndex}" aria-expanded="${isOpen ? 'true' : 'false'}" aria-label="${isOpen ? 'Contraer' : 'Expandir'}">${isOpen ? chevronUpSvg : chevronDownSvg}</button>` +
-      renderMenuDeleteButton('menu-item-delete', 'Eliminar', 'data-item-index', itemIndex) +
+      `<button type="button" class="cms-menu-card-toggle" data-item-index="${itemIndex}" aria-expanded="${isOpen ? 'true' : 'false'}" aria-label="${isOpen ? ct('common.collapse') : ct('common.expand')}">${isOpen ? chevronUpSvg : chevronDownSvg}</button>` +
+      renderMenuDeleteButton('menu-item-delete', ct('common.delete'), 'data-item-index', itemIndex) +
       '</div>' +
       '</div>' +
       `<div class="cms-menu-card-body${isOpen ? '' : ' cms-hidden'}">` +
       '<div class="cms-menu-card-inline-fields">' +
-      renderMenuTextInput('menu-item-name', 'Nombre del elemento', 'Nombre del elemento', item.name ?? '', true) +
-      renderMenuTextInput('menu-item-path', 'Ruta del elemento', '/ruta', item.path ?? '', true) +
+      renderMenuTextInput('menu-item-name', ct('menus.itemNameLabel'), ct('menus.itemNameLabel'), item.name ?? '', true) +
+      renderMenuTextInput('menu-item-path', ct('menus.itemPathLabel'), '/ruta', item.path ?? '', true) +
       '</div>' +
       '<div class="cms-menu-card-children">' +
       '<div class="cms-menu-card-children-head">' +
-      `<span class="cms-menu-card-children-title">Submenús ${localeHintHtml()}</span>` +
-      `<button type="button" class="cms-btn cms-btn-secondary menu-add-child-btn" data-item-index="${itemIndex}">Añadir submenú</button>` +
+      `<span class="cms-menu-card-children-title">${ct('menus.submenusTitle')} ${localeHintHtml()}</span>` +
+      `<button type="button" class="cms-btn cms-btn-secondary menu-add-child-btn" data-item-index="${itemIndex}">${ct('menus.addSubmenu')}</button>` +
       '</div>' +
       `<div class="menu-children-list" id="menu-children-${itemIndex}">${childrenHtml}</div>` +
       '</div>' +
@@ -296,7 +297,7 @@ export function initMenusEditor(): void {
     setSelectorHint(false, '');
     setError('');
     renderBuilder();
-    setFormTitle('Nuevo menú', 'Crear');
+    setFormTitle(ct('menus.newMenuForm'), ct('common.create'));
     openDialog(dialog);
   }
 
@@ -318,7 +319,7 @@ export function initMenusEditor(): void {
     setSelectorHint(false, '');
     setError('');
     renderBuilder();
-    setFormTitle('Editar menú', 'Guardar');
+    setFormTitle(ct('menus.editMenuForm'), ct('common.save'));
     openDialog(dialog);
   }
 
@@ -335,14 +336,14 @@ export function initMenusEditor(): void {
     menusTableBody.innerHTML = list
       .map((menu) => (
         `<tr class="cms-menu-row" data-id="${escapeHtml(menu.id)}">` +
-        `<td class="cms-table-actions"><button type="button" class="cms-table-btn-edit cms-menu-edit" data-id="${escapeHtml(menu.id)}" aria-label="Editar">${pencilSvg}</button></td>` +
-        `<td><button type="button" class="cms-table-link cms-menu-open" data-id="${escapeHtml(menu.id)}">${escapeHtml(menu.name || 'Menú')}</button></td>` +
+        `<td class="cms-table-actions"><button type="button" class="cms-table-btn-edit cms-menu-edit" data-id="${escapeHtml(menu.id)}" aria-label="${ct('common.edit')}">${pencilSvg}</button></td>` +
+        `<td><button type="button" class="cms-table-link cms-menu-open" data-id="${escapeHtml(menu.id)}">${escapeHtml(menu.name || ct('menus.modalTitle'))}</button></td>` +
         `<td class="cms-table-cell-monospace">${escapeHtml(menu.selector)}</td>` +
-        `<td class="cms-table-actions-delete"><button type="button" class="cms-table-btn-delete cms-menu-delete" data-id="${escapeHtml(menu.id)}" aria-label="Eliminar">${trashSvg}</button></td>` +
+        `<td class="cms-table-actions-delete"><button type="button" class="cms-table-btn-delete cms-menu-delete" data-id="${escapeHtml(menu.id)}" aria-label="${ct('common.delete')}">${trashSvg}</button></td>` +
         '</tr>'
       ))
       .join('');
-    if (menusCount) menusCount.textContent = `${list.length} menús`;
+    if (menusCount) menusCount.textContent = ct('menus.count', { count: list.length });
     menusEmpty?.classList.toggle('cms-hidden', list.length > 0);
   }
 
@@ -367,11 +368,11 @@ export function initMenusEditor(): void {
 
     setError('');
     if (!selector) {
-      setSelectorHint(false, 'El selector es obligatorio.');
+      setSelectorHint(false, ct('errors.menuSelectorRequired'));
       return;
     }
     if (!SELECTOR_REGEX.test(selector)) {
-      setSelectorHint(false, 'Solo letras, numeros, guiones y guiones bajos (sin espacios).');
+      setSelectorHint(false, ct('errors.invalidMenuSelector'));
       return;
     }
 
@@ -383,7 +384,7 @@ export function initMenusEditor(): void {
     }
 
     const id = idInput?.value.trim() || '';
-    const payload = { name: name || 'Menú', selector, items: currentMenu.items, locale: getActiveContentLocale('') || undefined };
+    const payload = { name: name || ct('menus.modalTitle'), selector, items: currentMenu.items, locale: getActiveContentLocale('') || undefined };
 
     try {
       await fetchOk(id ? `/cms/api/menus/${encodeURIComponent(id)}` : '/cms/api/menus', {
@@ -393,14 +394,14 @@ export function initMenusEditor(): void {
       });
       closeDialog(dialog);
       await refreshMenus();
-      showToast(id ? 'Menú actualizado correctamente.' : 'Menú creado correctamente.', 'success', 'Menús');
+      showToast(id ? ct('menus.saved') : ct('menus.saved'), 'success', ct('nav.menus'));
     } catch (error) {
-      setError(error instanceof Error ? error.message : 'Error al guardar.');
+      setError(error instanceof Error ? error.message : ct('pageEditor.saveError'));
     }
   }
 
   async function deleteMenu(id: string): Promise<void> {
-    const ok = await showConfirm('¿Eliminar este menú?', 'Eliminar');
+    const ok = await showConfirm(ct('menus.deleteConfirm', { selector: id }), ct('common.delete'));
     if (!ok) return;
 
     try {
@@ -408,11 +409,11 @@ export function initMenusEditor(): void {
         method: 'DELETE',
         headers: authHeaders(false),
       });
-      if (response.status !== 204) throw new Error('Error al eliminar');
+      if (response.status !== 204) throw new Error(ct('pageEditor.pageDeleteError'));
       await refreshMenus();
-      showToast('Menú eliminado correctamente.', 'success', 'Menús');
+      showToast(ct('menus.deleted'), 'success', ct('nav.menus'));
     } catch {
-      await showAlert('Error al eliminar', 'Error');
+      await showAlert(ct('pageEditor.pageDeleteError'), ct('dialog.defaultErrorTitle'));
     }
   }
 
@@ -422,7 +423,7 @@ export function initMenusEditor(): void {
       setSelectorHint(false, '');
       return;
     }
-    setSelectorHint(SELECTOR_REGEX.test(value), SELECTOR_REGEX.test(value) ? '' : 'Solo letras, numeros, guiones y guiones bajos (sin espacios).');
+    setSelectorHint(SELECTOR_REGEX.test(value), SELECTOR_REGEX.test(value) ? '' : ct('errors.invalidMenuSelector'));
   });
 
   addItemBtn?.addEventListener('click', () => {

--- a/routes/admin/client/page-editor.ts
+++ b/routes/admin/client/page-editor.ts
@@ -22,6 +22,7 @@ import {
   showConfirm,
   showToast,
 } from './common.js';
+import { ct } from '../i18n/client.js';
 import { mountBlockForm, type BlockFormHandle, type ArrayLimitInfo } from './block-form.js';
 
 const trashIconSvg =
@@ -166,7 +167,7 @@ export function initPageEditor(): void {
     }
   }
 
-  function setFormTitle(label: string, submitLabel = 'Guardar'): void {
+  function setFormTitle(label: string, submitLabel = ct('common.save')): void {
     if (titleEl) titleEl.textContent = label;
     if (submitBtn) submitBtn.textContent = submitLabel;
   }
@@ -209,23 +210,23 @@ export function initPageEditor(): void {
     imageThumb?.classList.toggle('cms-hidden', !hasImage);
     if (imageThumb && hasImage) {
       imageThumb.src = url;
-      imageThumb.alt = 'Imagen SEO';
+      imageThumb.alt = ct('pageEditor.seoImageAlt');
     }
 
     imageEmpty?.classList.toggle('cms-hidden', hasImage);
     imageRemoveBtn?.classList.toggle('cms-hidden', !hasImage);
-    if (imageUploadBtn) imageUploadBtn.textContent = hasImage ? 'Cambiar' : 'Subir imagen';
+    if (imageUploadBtn) imageUploadBtn.textContent = hasImage ? ct('pageEditor.changeImage') : ct('pageEditor.uploadImage');
   }
 
   function summaryValue(value: unknown): string {
     if (typeof value === 'string') return value.trim();
     if (typeof value === 'number' && !Number.isNaN(value)) return String(value);
-    if (typeof value === 'boolean') return value ? 'Sí' : 'No';
+    if (typeof value === 'boolean') return value ? ct('common.yes') : ct('common.no');
     return '';
   }
 
   function objectArrayItemSummary(def: ObjectArrayItemDef, rawItem: unknown, itemIndex: number): string {
-    if (!rawItem || typeof rawItem !== 'object' || Array.isArray(rawItem)) return `Elemento ${itemIndex + 1}`;
+    if (!rawItem || typeof rawItem !== 'object' || Array.isArray(rawItem)) return ct('pageEditor.blockElement', { n: itemIndex + 1 });
 
     const item = rawItem as Record<string, unknown>;
 
@@ -239,20 +240,23 @@ export function initPageEditor(): void {
       if (candidate) return candidate;
     }
 
-    return `Elemento ${itemIndex + 1}`;
+    return ct('pageEditor.blockElement', { n: itemIndex + 1 });
   }
 
   function arraySummary(def: ArrayPropDef, rawValue: unknown): string {
     if (!Array.isArray(rawValue)) return '';
-    if (rawValue.length === 0) return `${def.label}: 0 elementos`;
+    const count = rawValue.length;
+    if (count === 0) return `${def.label}: ${ct('pageEditor.arrayCount', { count: 0 })}`;
 
     if (isPrimitivePropDef(def.item)) {
       const first = summaryValue(rawValue[0]);
-      return first ? `${rawValue.length} elementos · ${first}` : `${rawValue.length} elementos`;
+      return first
+        ? `${ct('pageEditor.arrayCount', { count })} · ${first}`
+        : ct('pageEditor.arrayCount', { count });
     }
 
     const firstObjectSummary = objectArrayItemSummary(def.item, rawValue[0], 0);
-    return `${rawValue.length} elementos · ${firstObjectSummary}`;
+    return `${ct('pageEditor.arrayCount', { count })} · ${firstObjectSummary}`;
   }
 
   function blockSummary(block: BlockInstance): string {
@@ -266,7 +270,7 @@ export function initPageEditor(): void {
       if (values.length >= 2) break;
     }
 
-    return values.length > 0 ? values.join(' · ') : 'Configura las propiedades de este bloque';
+    return values.length > 0 ? values.join(' · ') : ct('pageEditor.configureBlock');
   }
 
   function pageSlugToText(page: Pick<CmsPage, 'slug'>): string {
@@ -319,19 +323,19 @@ export function initPageEditor(): void {
         const slug = pageSlugToText(page);
         return (
           '<tr>' +
-          `<td class="cms-table-actions"><button type="button" class="cms-table-btn-edit cms-page-edit" data-id="${escapeHtml(page.id)}" aria-label="Editar">${pencilIconSvg}</button></td>` +
-          `<td>${escapeHtml(page.title || '(sin título)')}</td>` +
+          `<td class="cms-table-actions"><button type="button" class="cms-table-btn-edit cms-page-edit" data-id="${escapeHtml(page.id)}" aria-label="${ct('common.edit')}">${pencilIconSvg}</button></td>` +
+          `<td>${escapeHtml(page.title || ct('dashboard.noTitle'))}</td>` +
           `<td class="cms-table-cell-monospace">${escapeHtml(slug)}</td>` +
-          `<td><span class="cms-badge ${isPublished ? 'cms-badge-success' : 'cms-badge-neutral'}">${escapeHtml(isPublished ? 'Publicada' : 'Borrador')}</span></td>` +
-          `<td><span class="cms-indexable-dot cms-indexable-dot--${page.indexable !== false ? 'yes' : 'no'}" role="img" aria-label="${page.indexable !== false ? 'Indexable' : 'No indexable'}"></span></td>` +
-          `<td class="cms-table-actions-delete"><button type="button" class="cms-table-btn-delete cms-page-delete" data-id="${escapeHtml(page.id)}" aria-label="Eliminar">${trashIconSvg}</button></td>` +
+          `<td><span class="cms-badge ${isPublished ? 'cms-badge-success' : 'cms-badge-neutral'}">${escapeHtml(isPublished ? ct('status.published') : ct('status.draft'))}</span></td>` +
+          `<td><span class="cms-indexable-dot cms-indexable-dot--${page.indexable !== false ? 'yes' : 'no'}" role="img" aria-label="${page.indexable !== false ? ct('status.indexable') : ct('status.notIndexable')}"></span></td>` +
+          `<td class="cms-table-actions-delete"><button type="button" class="cms-table-btn-delete cms-page-delete" data-id="${escapeHtml(page.id)}" aria-label="${ct('common.delete')}">${trashIconSvg}</button></td>` +
           '</tr>'
         );
       })
       .join('');
 
     const publishedCount = pagesState.filter((page) => page.status === 'published').length;
-    if (pagesCount) pagesCount.textContent = `${list.length} páginas · ${publishedCount} publicadas`;
+    if (pagesCount) pagesCount.textContent = ct('pages.count', { count: list.length, published: publishedCount });
     pagesEmpty?.classList.toggle('cms-hidden', list.length > 0);
     bindPageRowEvents();
   }
@@ -495,14 +499,14 @@ export function initPageEditor(): void {
       li.dataset.index = String(index);
       li.innerHTML =
         '<div class="cms-block-item-header">' +
-        `<span class="cms-drag-handle" aria-label="Arrastrar">${dragHandleSvg}</span>` +
+        `<span class="cms-drag-handle" aria-label="${ct('common.drag')}">${dragHandleSvg}</span>` +
         '<div class="cms-block-item-meta">' +
         `<span class="cms-block-item-name">${escapeHtml(name)}</span>` +
         `<span class="cms-block-item-summary">${escapeHtml(summary)}</span>` +
         '</div>' +
-        `<button type="button" class="cms-block-item-toggle" aria-expanded="${isOpen ? 'true' : 'false'}" aria-label="Expandir" data-index="${index}">${isOpen ? chevronUpSvg : chevronDownSvg}</button>` +
-        `<button type="button" class="cms-block-item-duplicate" aria-label="Duplicar bloque" data-index="${index}">${copyIconSvg}</button>` +
-        `<button type="button" class="cms-table-btn-delete cms-block-item-delete" aria-label="Eliminar bloque" data-index="${index}">${trashIconSvg}</button>` +
+        `<button type="button" class="cms-block-item-toggle" aria-expanded="${isOpen ? 'true' : 'false'}" aria-label="${isOpen ? ct('common.collapse') : ct('common.expand')}" data-index="${index}">${isOpen ? chevronUpSvg : chevronDownSvg}</button>` +
+        `<button type="button" class="cms-block-item-duplicate" aria-label="${ct('common.duplicate')}" data-index="${index}">${copyIconSvg}</button>` +
+        `<button type="button" class="cms-table-btn-delete cms-block-item-delete" aria-label="${ct('common.delete')}" data-index="${index}">${trashIconSvg}</button>` +
         '</div>' +
         `<div class="cms-block-item-body${isOpen ? '' : ' cms-hidden'}"></div>`;
 
@@ -548,9 +552,9 @@ export function initPageEditor(): void {
         },
         onArrayLimitReached(info: ArrayLimitInfo) {
           const limitLabel = info.limit === 'max'
-            ? `Has alcanzado el máximo de ${info.value} elemento${info.value === 1 ? '' : 's'} en este campo.`
-            : `Este campo requiere al menos ${info.value} elemento${info.value === 1 ? '' : 's'}.`;
-          void showAlert(limitLabel, 'Límite del campo');
+            ? ct('pageEditor.arrayMaxReached', { value: info.value })
+            : ct('pageEditor.arrayMinRequired', { value: info.value });
+          void showAlert(limitLabel, ct('pageEditor.fieldLimit'));
         },
         inlineErrors: blockErrors,
         fieldPrefix: `page-block-${index}`,
@@ -580,7 +584,7 @@ export function initPageEditor(): void {
         openBlockIndex = index + 1;
         inlineErrors.clear();
         renderBlocksList();
-        showToast('Bloque duplicado.', 'info', 'Editor');
+        showToast(ct('pageEditor.blockDuplicated'), 'info', 'Editor');
       });
     });
 
@@ -611,7 +615,7 @@ export function initPageEditor(): void {
 
         inlineErrors.clear();
         renderBlocksList();
-        showToast('Bloque eliminado.', 'info', 'Editor');
+        showToast(ct('pageEditor.blockDeleted'), 'info', 'Editor');
       });
     });
 
@@ -670,7 +674,7 @@ export function initPageEditor(): void {
     annotateStaticLocalizedLabels();
     await loadSchemaMap();
     renderBlocksList();
-    setFormTitle('Nueva página', 'Guardar');
+    setFormTitle(ct('pageEditor.newPage'));
     updateStatusButtons();
     openDialog(dialog);
   }
@@ -708,13 +712,13 @@ export function initPageEditor(): void {
     annotateStaticLocalizedLabels();
     await loadSchemaMap();
     renderBlocksList();
-    setFormTitle('Editar página', 'Guardar');
+    setFormTitle(ct('pageEditor.editPage'));
     updateStatusButtons();
     openDialog(dialog);
   }
 
   async function deletePage(id: string): Promise<void> {
-    const ok = await showConfirm('¿Eliminar esta página?', 'Eliminar');
+    const ok = await showConfirm(ct('pageEditor.deleteConfirm'), ct('common.delete'));
     if (!ok) return;
 
     try {
@@ -722,11 +726,11 @@ export function initPageEditor(): void {
         method: 'DELETE',
         headers: authHeaders(false),
       });
-      if (response.status !== 204) throw new Error('Error al eliminar');
+      if (response.status !== 204) throw new Error(ct('pageEditor.pageDeleteError'));
       await refreshPages();
-      showToast('Página eliminada correctamente.', 'success', 'Páginas');
+      showToast(ct('pageEditor.pageDeleted'), 'success', ct('nav.pages'));
     } catch {
-      await showAlert('Error al eliminar', 'Error');
+      await showAlert(ct('pageEditor.pageDeleteError'), ct('dialog.defaultErrorTitle'));
     }
   }
 
@@ -776,7 +780,7 @@ export function initPageEditor(): void {
 
       if (!schema || !schema.items) {
         return {
-          message: `Bloque de tipo desconocido: ${block.type}.`,
+          message: ct('pageEditor.unknownBlock', { type: block.type }),
           blockIndex: index,
         };
       }
@@ -806,7 +810,7 @@ export function initPageEditor(): void {
     const validationIssue = validateCurrentBlocks();
     if (validationIssue) {
       applyValidationIssue(validationIssue);
-      await showAlert(validationIssue.message, 'No se puede guardar');
+      await showAlert(validationIssue.message, ct('pageEditor.cannotSave'));
       return;
     }
 
@@ -832,9 +836,9 @@ export function initPageEditor(): void {
 
       closeDialog(dialog);
       await refreshPages();
-      showToast(id ? 'Página actualizada correctamente.' : 'Página creada correctamente.', 'success', 'Páginas');
+      showToast(id ? ct('pageEditor.pageUpdated') : ct('pageEditor.pageCreated'), 'success', ct('nav.pages'));
     } catch {
-      await showAlert('Error al guardar', 'Error');
+      await showAlert(ct('pageEditor.saveError'), ct('dialog.defaultErrorTitle'));
     }
   }
 
@@ -882,14 +886,14 @@ export function initPageEditor(): void {
       const fieldsCount = Object.keys(schema.items || {}).length;
       li.innerHTML =
         `<span class="cms-blocks-select-item-title">${escapeHtml(schema.name || type)}</span>` +
-        `<p class="cms-blocks-select-item-text">${fieldsCount} campo${fieldsCount === 1 ? '' : 's'} configurables</p>`;
+        `<p class="cms-blocks-select-item-text">${fieldsCount === 1 ? ct('pageEditor.fieldsConfigurable', { count: fieldsCount }) : ct('pageEditor.fieldsConfigurablePlural', { count: fieldsCount })}</p>`;
       li.addEventListener('click', () => {
         blocksList.push({ type, props: {} });
         openBlockIndex = blocksList.length - 1;
         inlineErrors.clear();
         renderBlocksList();
         closeDialog(blockSelectModal);
-        showToast(`Bloque "${schema.name || type}" añadido.`, 'success', 'Editor');
+        showToast(ct('pageEditor.blockAdded', { name: schema.name || type }), 'success', 'Editor');
       });
       blockSelectList.appendChild(li);
     }

--- a/routes/admin/client/redirects-editor.ts
+++ b/routes/admin/client/redirects-editor.ts
@@ -6,6 +6,7 @@ Licensed under the Business Source License 1.1
 import type { RedirectRule, RedirectsData } from '../../../types/index.js';
 import { normalizeRedirectPath } from '../../../utils/redirects.js';
 import { authHeaders, closeDialog, escapeHtml, fetchJson, fetchOk, openDialog, showAlert, showConfirm, showToast } from './common.js';
+import { ct } from '../i18n/client.js';
 
 const pencilSvg =
   '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>';
@@ -56,25 +57,26 @@ export function initRedirectsEditor(): void {
     return normalizeRedirectPath(raw || '/');
   }
 
-  function validatePath(raw: string, fieldLabel: 'origen' | 'destino'): string | null {
+  function validatePath(raw: string, fieldKey: 'redirects.labelFrom' | 'redirects.labelTo'): string | null {
     const value = raw.trim();
-    if (!value) return `La ruta de ${fieldLabel} es obligatoria.`;
-    if (/^https?:\/\//i.test(value)) return `La ruta de ${fieldLabel} debe ser interna (no se permiten URLs absolutas).`;
-    if (!value.startsWith('/')) return `La ruta de ${fieldLabel} debe comenzar con "/".`;
-    if (value.includes('?') || value.includes('#')) return `La ruta de ${fieldLabel} no puede incluir query ni fragmento.`;
+    const field = ct(fieldKey);
+    if (!value) return ct('redirects.pathRequired', { field });
+    if (/^https?:\/\//i.test(value)) return ct('redirects.pathMustBeInternal', { field });
+    if (!value.startsWith('/')) return ct('redirects.pathMustStartSlash', { field });
+    if (value.includes('?') || value.includes('#')) return ct('redirects.pathNoQueryFragment', { field });
     return null;
   }
 
   function clientValidation(fromValue: string, toValue: string): string | null {
-    const fromError = validatePath(fromValue, 'origen');
+    const fromError = validatePath(fromValue, 'redirects.labelFrom');
     if (fromError) return fromError;
 
-    const toError = validatePath(toValue, 'destino');
+    const toError = validatePath(toValue, 'redirects.labelTo');
     if (toError) return toError;
 
     const normalizedFrom = normalizePathInput(fromValue);
     const normalizedTo = normalizePathInput(toValue);
-    if (normalizedFrom === normalizedTo) return 'La ruta de origen y la de destino no pueden ser iguales.';
+    if (normalizedFrom === normalizedTo) return ct('errors.redirectSameFromTo');
     return null;
   }
 
@@ -89,7 +91,7 @@ export function initRedirectsEditor(): void {
 
   function openNew(): void {
     resetForm();
-    setFormTitle('Nueva redirección', 'Crear');
+    setFormTitle(ct('redirects.newRedirect'), ct('common.create'));
     openDialog(dialog);
     fromField.focus();
   }
@@ -105,7 +107,7 @@ export function initRedirectsEditor(): void {
     statusCodeField.value = String(entry.statusCode || 301);
     enabledField.checked = entry.enabled !== false;
     setError('');
-    setFormTitle('Editar redirección', 'Guardar');
+    setFormTitle(ct('redirects.modalTitle'), ct('common.save'));
     openDialog(dialog);
     fromField.focus();
   }
@@ -134,8 +136,8 @@ export function initRedirectsEditor(): void {
 
         const entry = redirectsState.find((item) => item.id === id);
         const confirmed = await showConfirm(
-          `¿Eliminar la redirección ${entry?.from || ''} → ${entry?.to || ''}?`,
-          'Eliminar'
+          ct('redirects.deleteConfirm', { from: entry?.from || '', to: entry?.to || '' }),
+          ct('common.delete')
         );
         if (!confirmed) return;
 
@@ -144,7 +146,7 @@ export function initRedirectsEditor(): void {
             method: 'DELETE',
             headers: authHeaders(false),
           });
-          showToast('Redirección eliminada.', 'success');
+          showToast(ct('redirects.deleted'), 'success');
           await refreshRedirects();
         } catch (error) {
           await showAlert(error instanceof Error ? error.message : String(error));
@@ -158,17 +160,17 @@ export function initRedirectsEditor(): void {
     redirectsTableBody.innerHTML = list
       .map((entry) => (
         `<tr data-id="${escapeHtml(entry.id)}">` +
-        `<td class="cms-table-actions"><button type="button" class="cms-table-btn-edit cms-redirect-edit" data-id="${escapeHtml(entry.id)}" aria-label="Editar">${pencilSvg}</button></td>` +
+        `<td class="cms-table-actions"><button type="button" class="cms-table-btn-edit cms-redirect-edit" data-id="${escapeHtml(entry.id)}" aria-label="${ct('common.edit')}">${pencilSvg}</button></td>` +
         `<td class="cms-table-cell-monospace">${escapeHtml(entry.from)}</td>` +
         `<td class="cms-table-cell-monospace">${escapeHtml(entry.to)}</td>` +
         `<td><span class="cms-badge cms-badge-neutral">${entry.statusCode}</span></td>` +
-        `<td><span class="cms-badge ${entry.enabled !== false ? 'cms-badge-success' : 'cms-badge-neutral'}">${entry.enabled !== false ? 'Activa' : 'Inactiva'}</span></td>` +
-        `<td class="cms-table-actions-delete"><button type="button" class="cms-table-btn-delete cms-redirect-delete" data-id="${escapeHtml(entry.id)}" aria-label="Eliminar">${trashSvg}</button></td>` +
+        `<td><span class="cms-badge ${entry.enabled !== false ? 'cms-badge-success' : 'cms-badge-neutral'}">${entry.enabled !== false ? ct('redirects.statusActive') : ct('redirects.statusInactive')}</span></td>` +
+        `<td class="cms-table-actions-delete"><button type="button" class="cms-table-btn-delete cms-redirect-delete" data-id="${escapeHtml(entry.id)}" aria-label="${ct('common.delete')}">${trashSvg}</button></td>` +
         '</tr>'
       ))
       .join('');
 
-    if (redirectsCount) redirectsCount.textContent = `${list.length} redirecciones`;
+    if (redirectsCount) redirectsCount.textContent = ct('redirects.count', { count: list.length });
     redirectsEmpty?.classList.toggle('cms-hidden', list.length > 0);
     bindRows();
   }
@@ -206,7 +208,7 @@ export function initRedirectsEditor(): void {
     });
 
     closeDialog(dialog);
-    showToast(id ? 'Redirección actualizada.' : 'Redirección creada.', 'success');
+    showToast(id ? ct('redirects.updated') : ct('redirects.created'), 'success');
     await refreshRedirects();
   }
 

--- a/routes/admin/i18n/en.ts
+++ b/routes/admin/i18n/en.ts
@@ -161,6 +161,7 @@ export const en = {
   'pageEditor.fieldsConfigurablePlural': '{count} configurable fields',
   'pageEditor.configureBlock': 'Configure this block\'s properties',
   'pageEditor.blockElement': 'Element {n}',
+  'pageEditor.arrayCount': '{count} items',
   'pageEditor.blockDuplicated': 'Block duplicated.',
   'pageEditor.blockDeleted': 'Block deleted.',
   'pageEditor.blockAdded': 'Block "{name}" added.',
@@ -213,6 +214,10 @@ export const en = {
   'redirects.code301': 'Permanent',
   'redirects.code302': 'Temporary',
   'redirects.deleteConfirm': 'Delete redirect {from} → {to}?',
+  'redirects.pathRequired': '{field} is required.',
+  'redirects.pathMustBeInternal': '{field} must be internal (absolute URLs are not allowed).',
+  'redirects.pathMustStartSlash': '{field} must start with "/".',
+  'redirects.pathNoQueryFragment': '{field} cannot include query or fragment.',
 
   // ─── Configs / Parameters ─────────────────────────────────────────────────
   'configs.eyebrow': 'Configuration',
@@ -444,7 +449,9 @@ export const en = {
   'errors.menuPathRequired': 'Path is required in all menu items.',
   'errors.configKeyRequired': 'Key is required.',
   'errors.invalidConfigKey': 'The key must start with a letter and can only contain letters, numbers, dot, dash, and underscore.',
+  'errors.configKeyExists': 'A parameter with that key already exists.',
   'errors.redirectSameFromTo': 'The source and destination paths cannot be the same.',
+  'errors.redirectFromExists': 'A redirect with that source path already exists.',
   'errors.blockSchemaMissing': 'Block schema missing.',
   'errors.loadBlockSchemasFailed': 'Failed to load block schemas.',
 } satisfies Catalog;

--- a/routes/admin/i18n/es.ts
+++ b/routes/admin/i18n/es.ts
@@ -161,6 +161,7 @@ export const es = {
   'pageEditor.fieldsConfigurablePlural': '{count} campos configurables',
   'pageEditor.configureBlock': 'Configura las propiedades de este bloque',
   'pageEditor.blockElement': 'Elemento {n}',
+  'pageEditor.arrayCount': '{count} elementos',
   'pageEditor.blockDuplicated': 'Bloque duplicado.',
   'pageEditor.blockDeleted': 'Bloque eliminado.',
   'pageEditor.blockAdded': 'Bloque "{name}" añadido.',
@@ -213,6 +214,10 @@ export const es = {
   'redirects.code301': 'Permanente',
   'redirects.code302': 'Temporal',
   'redirects.deleteConfirm': '¿Eliminar la redirección {from} → {to}?',
+  'redirects.pathRequired': '{field} es obligatorio.',
+  'redirects.pathMustBeInternal': '{field} debe ser interno (no se permiten URLs absolutas).',
+  'redirects.pathMustStartSlash': '{field} debe comenzar con "/".',
+  'redirects.pathNoQueryFragment': '{field} no puede incluir query ni fragmento.',
 
   // ─── Configs / Parameters ─────────────────────────────────────────────────
   'configs.eyebrow': 'Configuración',
@@ -444,7 +449,9 @@ export const es = {
   'errors.menuPathRequired': 'La ruta es obligatoria en todos los elementos del menú.',
   'errors.configKeyRequired': 'La clave es obligatoria.',
   'errors.invalidConfigKey': 'La clave debe empezar por una letra y solo puede contener letras, números, punto, guion y guion bajo.',
+  'errors.configKeyExists': 'Ya existe un parámetro con esa clave.',
   'errors.redirectSameFromTo': 'La ruta de origen y la de destino no pueden ser iguales.',
+  'errors.redirectFromExists': 'Ya existe una redirección con esa ruta de origen.',
   'errors.blockSchemaMissing': 'Esquema de bloque faltante.',
   'errors.loadBlockSchemasFailed': 'Error al cargar los esquemas de bloques.',
 } satisfies Catalog & { [K in keyof typeof en]: string };

--- a/routes/api/catchall.ts
+++ b/routes/api/catchall.ts
@@ -41,7 +41,7 @@ export async function GET({ request }: APIContext): Promise<Response> {
   if (seg[0] === 'auth' && seg[1] === 'status' && seg.length === 2) return handlers.handleAuthStatus();
   if (seg[0] === 'auth' && seg[1] === 'me' && seg.length === 2) {
     const auth = await handlers.getAuth(request);
-    return handlers.handleAuthMe(auth?.user);
+    return handlers.handleAuthMe(auth?.user, request);
   }
 
   const authResult = await ensureAuth(request);
@@ -147,12 +147,12 @@ export async function DELETE({ request, cache }: APIContext): Promise<Response> 
   if (seg[0] === 'menus' && seg.length === 2) return handlers.handleDeleteMenu(seg[1], { cache });
   if (seg[0] === 'redirects' && seg.length === 2) return handlers.handleDeleteRedirect(seg[1], { cache });
   if (seg[0] === 'configs' && seg.length === 2) return handlers.handleDeleteConfig(seg[1], { cache });
-  if (seg[0] === 'users' && seg.length === 2) return handlers.handleDeleteUser(seg[1], authResult.user);
+  if (seg[0] === 'users' && seg.length === 2) return handlers.handleDeleteUser(seg[1], authResult.user, request);
   if (seg[0] === 'upload' && seg.length === 1) return handlers.handleDeleteUpload(request);
   if (seg[0] === 'languages' && seg.length === 2) {
     const forbidden = handlers.requireOwner(authResult.user);
     if (forbidden) return forbidden;
-    return handlers.handleDeleteLanguage(seg[1], { cache });
+    return handlers.handleDeleteLanguage(seg[1], { cache }, request);
   }
 
   return new Response(JSON.stringify({ error: 'Not found' }), { status: 404 });

--- a/tests/auth-handlers.test.js
+++ b/tests/auth-handlers.test.js
@@ -113,7 +113,7 @@ test('handleLogin: bad password returns 401', async () => {
 
     assert.equal(response.status, 401);
     const body = await response.json();
-    assert.equal(body.error, 'Invalid credentials');
+    assert.equal(body.error, 'Invalid credentials.');
   });
 });
 
@@ -139,7 +139,7 @@ test('handleLogin: unknown email after users exist returns 401', async () => {
 
     assert.equal(response.status, 401);
     const body = await response.json();
-    assert.equal(body.error, 'Invalid credentials');
+    assert.equal(body.error, 'Invalid credentials.');
   });
 });
 
@@ -155,7 +155,7 @@ test('handleLogin: missing email or password returns 400', async () => {
 
     assert.equal(response.status, 400);
     const body = await response.json();
-    assert.equal(body.error, 'Email and password required');
+    assert.equal(body.error, 'Email and password are required.');
   });
 });
 

--- a/tests/configs-handlers.test.js
+++ b/tests/configs-handlers.test.js
@@ -122,7 +122,7 @@ test('config handlers validate key format and case-insensitive duplicates', asyn
     );
 
     assert.equal(duplicate.status, 400);
-    assert.equal((await duplicate.json()).error, 'Ya existe un parámetro con esa clave.');
+    assert.equal((await duplicate.json()).error, 'A parameter with that key already exists.');
 
     const invalidKey = await handlePostConfigs(
       new Request('http://localhost/cms/api/configs', {
@@ -135,7 +135,7 @@ test('config handlers validate key format and case-insensitive duplicates', asyn
     assert.equal(invalidKey.status, 400);
     assert.equal(
       (await invalidKey.json()).error,
-      'La clave debe empezar por una letra y solo puede contener letras, números, punto, guion y guion bajo.'
+      'The key must start with a letter and can only contain letters, numbers, dot, dash, and underscore.'
     );
 
     const second = await handlePostConfigs(
@@ -159,6 +159,6 @@ test('config handlers validate key format and case-insensitive duplicates', asyn
     );
 
     assert.equal(renameConflict.status, 400);
-    assert.equal((await renameConflict.json()).error, 'Ya existe un parámetro con esa clave.');
+    assert.equal((await renameConflict.json()).error, 'A parameter with that key already exists.');
   });
 });

--- a/tests/i18n-api-errors.test.js
+++ b/tests/i18n-api-errors.test.js
@@ -1,0 +1,432 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * Tests for PR-4 Part B — API error localization.
+ *
+ * These tests verify that user-facing error messages returned by API handlers
+ * are localized based on the cms-ui-locale cookie in the incoming request.
+ * The wire shape { error: string } must remain unchanged.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { ensureDefaultFiles } from '../dist/api/data.js';
+import {
+  handleLogin,
+  handlePostUsers,
+  handlePutUser,
+  handleDeleteUser,
+  handlePostLanguages,
+  handlePutLanguage,
+  handleDeleteLanguage,
+  handlePostMenus,
+  handlePutMenu,
+  handlePostConfigs,
+  handlePutConfig,
+  handlePostPages,
+  handlePutPage,
+  handlePostRedirects,
+  handlePutRedirect,
+  handleAuthMe,
+  requireOwner,
+} from '../dist/api/handlers.js';
+
+async function withTempProject(fn) {
+  const previousRoot = process.env.ASTRO_BLOCKS_PROJECT_ROOT;
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'astro-blocks-i18n-api-'));
+
+  process.env.ASTRO_BLOCKS_PROJECT_ROOT = tempRoot;
+  await ensureDefaultFiles();
+
+  try {
+    await fn(tempRoot);
+  } finally {
+    if (previousRoot === undefined) {
+      delete process.env.ASTRO_BLOCKS_PROJECT_ROOT;
+    } else {
+      process.env.ASTRO_BLOCKS_PROJECT_ROOT = previousRoot;
+    }
+
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function makeRequest(url, options = {}) {
+  return new Request(url, {
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options,
+  });
+}
+
+function withUiLocale(locale, extraHeaders = {}) {
+  return { Cookie: `cms-ui-locale=${locale}`, ...extraHeaders };
+}
+
+// ─── handleLogin — missing credentials ────────────────────────────────────────
+
+test('handleLogin returns English error for missing credentials (no cookie)', async () => {
+  await withTempProject(async () => {
+    const res = await handleLogin(makeRequest('http://localhost/cms/api/login', {
+      method: 'POST',
+      body: JSON.stringify({ email: '', password: '' }),
+    }));
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.ok(typeof body.error === 'string', 'error must be a string');
+    // English: 'Email and password are required.'
+    assert.match(body.error, /email/i);
+    assert.doesNotMatch(body.error, /contraseña|obligatorio/i, 'Must not be Spanish');
+  });
+});
+
+test('handleLogin returns Spanish error for missing credentials (es cookie)', async () => {
+  await withTempProject(async () => {
+    const res = await handleLogin(makeRequest('http://localhost/cms/api/login', {
+      method: 'POST',
+      headers: withUiLocale('es'),
+      body: JSON.stringify({ email: '', password: '' }),
+    }));
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.ok(typeof body.error === 'string', 'error must be a string');
+    // Spanish: 'Email y contraseña son obligatorios.'
+    assert.match(body.error, /contraseña|obligatorio/i, 'Must be Spanish');
+  });
+});
+
+test('handleLogin returns English error for invalid credentials (en cookie)', async () => {
+  await withTempProject(async () => {
+    // First create a user
+    await handleLogin(makeRequest('http://localhost/cms/api/login', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'admin@test.com', password: 'secret' }),
+    }));
+
+    const res = await handleLogin(makeRequest('http://localhost/cms/api/login', {
+      method: 'POST',
+      headers: withUiLocale('en'),
+      body: JSON.stringify({ email: 'admin@test.com', password: 'wrongpass' }),
+    }));
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.match(body.error, /credential/i, 'Must be English');
+    assert.doesNotMatch(body.error, /credencial/i, 'Must not be Spanish');
+  });
+});
+
+test('handleLogin returns Spanish error for invalid credentials (es cookie)', async () => {
+  await withTempProject(async () => {
+    // First create a user
+    await handleLogin(makeRequest('http://localhost/cms/api/login', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'admin@test.com', password: 'secret' }),
+    }));
+
+    const res = await handleLogin(makeRequest('http://localhost/cms/api/login', {
+      method: 'POST',
+      headers: withUiLocale('es'),
+      body: JSON.stringify({ email: 'admin@test.com', password: 'wrongpass' }),
+    }));
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.match(body.error, /credencial/i, 'Must be Spanish');
+  });
+});
+
+// ─── handlePostUsers — email already exists ────────────────────────────────────
+
+test('handlePostUsers returns English "email already exists" (en cookie)', async () => {
+  await withTempProject(async () => {
+    // Bootstrap owner
+    await handleLogin(makeRequest('http://localhost/cms/api/login', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'admin@test.com', password: 'secret' }),
+    }));
+
+    // First creation
+    await handlePostUsers(makeRequest('http://localhost/cms/api/users', {
+      method: 'POST',
+      headers: withUiLocale('en'),
+      body: JSON.stringify({ email: 'user@test.com', password: 'pass123', role: 'user' }),
+    }), { role: 'owner' });
+
+    // Duplicate
+    const res = await handlePostUsers(makeRequest('http://localhost/cms/api/users', {
+      method: 'POST',
+      headers: withUiLocale('en'),
+      body: JSON.stringify({ email: 'user@test.com', password: 'pass123', role: 'user' }),
+    }), { role: 'owner' });
+
+    const body = await res.json();
+    assert.match(body.error, /email/i, 'Must mention email');
+    assert.doesNotMatch(body.error, /existe|ya/i, 'Must be English');
+  });
+});
+
+test('handlePostUsers returns Spanish "email already exists" (es cookie)', async () => {
+  await withTempProject(async () => {
+    // Bootstrap owner
+    await handleLogin(makeRequest('http://localhost/cms/api/login', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'admin@test.com', password: 'secret' }),
+    }));
+
+    // First creation
+    await handlePostUsers(makeRequest('http://localhost/cms/api/users', {
+      method: 'POST',
+      headers: withUiLocale('es'),
+      body: JSON.stringify({ email: 'user2@test.com', password: 'pass123', role: 'user' }),
+    }), { role: 'owner' });
+
+    // Duplicate
+    const res = await handlePostUsers(makeRequest('http://localhost/cms/api/users', {
+      method: 'POST',
+      headers: withUiLocale('es'),
+      body: JSON.stringify({ email: 'user2@test.com', password: 'pass123', role: 'user' }),
+    }), { role: 'owner' });
+
+    const body = await res.json();
+    assert.match(body.error, /existe|ya/i, 'Must be Spanish');
+  });
+});
+
+// ─── handlePostLanguages — language code required ─────────────────────────────
+
+test('handlePostLanguages returns English error for missing code (en cookie)', async () => {
+  await withTempProject(async () => {
+    const res = await handlePostLanguages(makeRequest('http://localhost/cms/api/languages', {
+      method: 'POST',
+      headers: withUiLocale('en'),
+      body: JSON.stringify({ code: '', label: 'French' }),
+    }));
+    const body = await res.json();
+    assert.ok(typeof body.error === 'string');
+    assert.match(body.error, /code|required/i, 'Must be English');
+    assert.doesNotMatch(body.error, /obligatorio/i, 'Must not be Spanish');
+  });
+});
+
+test('handlePostLanguages returns Spanish error for missing code (es cookie)', async () => {
+  await withTempProject(async () => {
+    const res = await handlePostLanguages(makeRequest('http://localhost/cms/api/languages', {
+      method: 'POST',
+      headers: withUiLocale('es'),
+      body: JSON.stringify({ code: '', label: 'Francés' }),
+    }));
+    const body = await res.json();
+    assert.ok(typeof body.error === 'string');
+    assert.match(body.error, /obligatorio/i, 'Must be Spanish');
+  });
+});
+
+// ─── handlePostMenus — selector required ──────────────────────────────────────
+
+test('handlePostMenus returns English error for missing selector (en cookie)', async () => {
+  await withTempProject(async () => {
+    const res = await handlePostMenus(makeRequest('http://localhost/cms/api/menus', {
+      method: 'POST',
+      headers: withUiLocale('en'),
+      body: JSON.stringify({ name: 'Main', selector: '', items: [] }),
+    }));
+    const body = await res.json();
+    assert.ok(typeof body.error === 'string');
+    assert.match(body.error, /selector|required/i, 'Must be English');
+    assert.doesNotMatch(body.error, /obligatorio/i, 'Must not be Spanish');
+  });
+});
+
+test('handlePostMenus returns Spanish error for missing selector (es cookie)', async () => {
+  await withTempProject(async () => {
+    const res = await handlePostMenus(makeRequest('http://localhost/cms/api/menus', {
+      method: 'POST',
+      headers: withUiLocale('es'),
+      body: JSON.stringify({ name: 'Principal', selector: '', items: [] }),
+    }));
+    const body = await res.json();
+    assert.ok(typeof body.error === 'string');
+    assert.match(body.error, /obligatorio/i, 'Must be Spanish');
+  });
+});
+
+// ─── handlePostConfigs — key required ─────────────────────────────────────────
+
+test('handlePostConfigs returns English error for missing key (en cookie)', async () => {
+  await withTempProject(async () => {
+    const res = await handlePostConfigs(makeRequest('http://localhost/cms/api/configs', {
+      method: 'POST',
+      headers: withUiLocale('en'),
+      body: JSON.stringify({ key: '', value: 'val' }),
+    }));
+    const body = await res.json();
+    assert.ok(typeof body.error === 'string');
+    assert.match(body.error, /key|required/i, 'Must be English');
+    assert.doesNotMatch(body.error, /clave|obligatoria/i, 'Must not be Spanish');
+  });
+});
+
+test('handlePostConfigs returns Spanish error for missing key (es cookie)', async () => {
+  await withTempProject(async () => {
+    const res = await handlePostConfigs(makeRequest('http://localhost/cms/api/configs', {
+      method: 'POST',
+      headers: withUiLocale('es'),
+      body: JSON.stringify({ key: '', value: 'val' }),
+    }));
+    const body = await res.json();
+    assert.ok(typeof body.error === 'string');
+    assert.match(body.error, /clave|obligatoria/i, 'Must be Spanish');
+  });
+});
+
+// ─── wire shape preserved ─────────────────────────────────────────────────────
+
+test('error response wire shape is { error: string } — no extra fields from localization', async () => {
+  await withTempProject(async () => {
+    const res = await handleLogin(makeRequest('http://localhost/cms/api/login', {
+      method: 'POST',
+      headers: withUiLocale('es'),
+      body: JSON.stringify({ email: '', password: '' }),
+    }));
+    const body = await res.json();
+    assert.ok(Object.prototype.hasOwnProperty.call(body, 'error'), 'Must have error field');
+    assert.ok(typeof body.error === 'string', 'error must be string');
+    // May optionally have other fields from jsonError extra param, but must have error
+  });
+});
+
+test('Accept-Language header falls back correctly when no cookie is present', async () => {
+  await withTempProject(async () => {
+    const res = await handleLogin(makeRequest('http://localhost/cms/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Accept-Language': 'es-MX,es;q=0.9' },
+      body: JSON.stringify({ email: '', password: '' }),
+    }));
+    const body = await res.json();
+    // Accept-Language es should produce Spanish error
+    assert.match(body.error, /contraseña|obligatorio/i, 'Accept-Language es should yield Spanish error');
+  });
+});
+
+// ─── parseJsonBody — invalid body localization ────────────────────────────────
+
+test('parseJsonBody returns English error for invalid JSON body (en cookie)', async () => {
+  await withTempProject(async () => {
+    const res = await handlePostRedirects(makeRequest('http://localhost/cms/api/redirects', {
+      method: 'POST',
+      headers: withUiLocale('en'),
+      body: 'not-json-at-all',
+    }));
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.ok(typeof body.error === 'string', 'error must be a string');
+    assert.match(body.error, /invalid|body/i, 'Must be English invalid body message');
+    assert.doesNotMatch(body.error, /inválido|solicitud/i, 'Must not be Spanish');
+  });
+});
+
+test('parseJsonBody returns Spanish error for invalid JSON body (es cookie)', async () => {
+  await withTempProject(async () => {
+    const res = await handlePostRedirects(makeRequest('http://localhost/cms/api/redirects', {
+      method: 'POST',
+      headers: withUiLocale('es'),
+      body: 'not-json-at-all',
+    }));
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.ok(typeof body.error === 'string', 'error must be a string');
+    assert.match(body.error, /inválido|solicitud/i, 'Must be Spanish invalid body message');
+  });
+});
+
+// ─── handlePostRedirects — path validation localization ───────────────────────
+
+test('handlePostRedirects path validation returns English error for absolute URL (en cookie)', async () => {
+  await withTempProject(async () => {
+    const res = await handlePostRedirects(makeRequest('http://localhost/cms/api/redirects', {
+      method: 'POST',
+      headers: withUiLocale('en'),
+      body: JSON.stringify({ from: 'https://example.com/old', to: '/new' }),
+    }));
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.ok(typeof body.error === 'string');
+    assert.match(body.error, /internal|absolute/i, 'Must be English');
+    assert.doesNotMatch(body.error, /interno|absoluta/i, 'Must not be Spanish');
+  });
+});
+
+test('handlePostRedirects path validation returns Spanish error for absolute URL (es cookie)', async () => {
+  await withTempProject(async () => {
+    const res = await handlePostRedirects(makeRequest('http://localhost/cms/api/redirects', {
+      method: 'POST',
+      headers: withUiLocale('es'),
+      body: JSON.stringify({ from: 'https://example.com/old', to: '/new' }),
+    }));
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.ok(typeof body.error === 'string');
+    assert.match(body.error, /interno|absoluta/i, 'Must be Spanish');
+  });
+});
+
+// ─── handleAuthMe — unauthorized localization ─────────────────────────────────
+
+test('handleAuthMe returns English error for unauthenticated (en cookie)', async () => {
+  await withTempProject(async () => {
+    const res = await handleAuthMe(null, makeRequest('http://localhost/cms/api/auth/me', {
+      headers: withUiLocale('en'),
+    }));
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.ok(typeof body.error === 'string');
+    assert.match(body.error, /unauthorized/i, 'Must be English');
+    assert.doesNotMatch(body.error, /autorizado/i, 'Must not be Spanish');
+  });
+});
+
+test('handleAuthMe returns Spanish error for unauthenticated (es cookie)', async () => {
+  await withTempProject(async () => {
+    const res = await handleAuthMe(null, makeRequest('http://localhost/cms/api/auth/me', {
+      headers: withUiLocale('es'),
+    }));
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.ok(typeof body.error === 'string');
+    assert.match(body.error, /autorizado/i, 'Must be Spanish');
+  });
+});
+
+// ─── requireOwner — forbidden localization ────────────────────────────────────
+
+test('requireOwner returns English error when request is provided (en cookie)', async () => {
+  await withTempProject(async () => {
+    const request = makeRequest('http://localhost/cms/api/users', {
+      headers: withUiLocale('en'),
+    });
+    const res = requireOwner({ id: '1', email: 'a@b.com', role: 'user' }, request);
+    assert.ok(res !== null, 'Must return a response for non-owner');
+    assert.equal(res.status, 403);
+    const body = await res.json();
+    assert.match(body.error, /forbidden/i, 'Must be English');
+    assert.doesNotMatch(body.error, /denegado/i, 'Must not be Spanish');
+  });
+});
+
+test('requireOwner returns Spanish error when request is provided (es cookie)', async () => {
+  await withTempProject(async () => {
+    const request = makeRequest('http://localhost/cms/api/users', {
+      headers: withUiLocale('es'),
+    });
+    const res = requireOwner({ id: '1', email: 'a@b.com', role: 'user' }, request);
+    assert.ok(res !== null, 'Must return a response for non-owner');
+    assert.equal(res.status, 403);
+    const body = await res.json();
+    assert.match(body.error, /denegado/i, 'Must be Spanish');
+  });
+});

--- a/tests/i18n-client-editors.test.js
+++ b/tests/i18n-client-editors.test.js
@@ -1,0 +1,129 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * Tests for PR-4 Part A — client-side translate helper (ct) resolution.
+ *
+ * Because ct() reads window.getCmsUiLocale(), we test the underlying
+ * getUiLocale() fallback chain by stubbing document.cookie and verifying
+ * that ct() returns keys from the correct catalog.
+ *
+ * Note: these tests run in Node.js (no DOM). The module guards against
+ * typeof window === 'undefined' and returns DEFAULT_UI_LOCALE ('en').
+ * We test the pure logic via createT() + catalogs directly, which is what
+ * ct() delegates to.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Import from dist (compiled output) — same convention as all other tests
+import { createT } from '../dist/routes/admin/i18n/t.js';
+import { catalogs } from '../dist/routes/admin/i18n/catalogs.js';
+
+test('ct equivalent: createT("en") resolves English string for common.noDate', () => {
+  const t = createT('en');
+  assert.equal(t('common.noDate'), 'No date');
+});
+
+test('ct equivalent: createT("es") resolves Spanish string for common.noDate', () => {
+  const t = createT('es');
+  assert.equal(t('common.noDate'), 'Sin fecha');
+});
+
+test('ct equivalent: createT("en") resolves pageEditor.newPage', () => {
+  const t = createT('en');
+  assert.equal(t('pageEditor.newPage'), 'New page');
+});
+
+test('ct equivalent: createT("es") resolves pageEditor.newPage', () => {
+  const t = createT('es');
+  assert.equal(t('pageEditor.newPage'), 'Nueva página');
+});
+
+test('ct equivalent: createT("en") resolves pageEditor.saveError', () => {
+  const t = createT('en');
+  assert.equal(t('pageEditor.saveError'), 'Error saving');
+});
+
+test('ct equivalent: createT("en") resolves pageEditor.blockDuplicated', () => {
+  const t = createT('en');
+  assert.equal(t('pageEditor.blockDuplicated'), 'Block duplicated.');
+});
+
+test('ct equivalent: createT("es") resolves pageEditor.blockDuplicated', () => {
+  const t = createT('es');
+  assert.equal(t('pageEditor.blockDuplicated'), 'Bloque duplicado.');
+});
+
+test('ct equivalent: createT("en") resolves menus.newMenuForm', () => {
+  const t = createT('en');
+  assert.equal(t('menus.newMenuForm'), 'New menu');
+});
+
+test('ct equivalent: createT("es") resolves menus.newMenuForm', () => {
+  const t = createT('es');
+  assert.equal(t('menus.newMenuForm'), 'Nuevo menú');
+});
+
+test('ct equivalent: createT("en") resolves redirects.deleted', () => {
+  const t = createT('en');
+  assert.equal(t('redirects.deleted'), 'Redirect deleted.');
+});
+
+test('ct equivalent: createT("en") resolves configs.deleted', () => {
+  const t = createT('en');
+  assert.equal(t('configs.deleted'), 'Parameter deleted.');
+});
+
+test('ct equivalent: createT("en") resolves globalBlocks.saved', () => {
+  const t = createT('en');
+  assert.equal(t('globalBlocks.saved'), 'Global block saved successfully.');
+});
+
+test('ct equivalent: createT("es") resolves globalBlocks.networkError', () => {
+  const t = createT('es');
+  assert.equal(t('globalBlocks.networkError'), 'Error de red al guardar. Revisá la conexión.');
+});
+
+test('ct equivalent: createT("en") resolves pageEditor.arrayMaxReached with interpolation', () => {
+  const t = createT('en');
+  assert.equal(t('pageEditor.arrayMaxReached', { value: '5' }), 'You have reached the maximum of 5 item(s) in this field.');
+});
+
+test('ct equivalent: createT("en") resolves blockForm.maxReached with interpolation', () => {
+  const t = createT('en');
+  assert.equal(t('blockForm.maxReached', { max: '3' }), 'You have reached the maximum of 3 items.');
+});
+
+test('ct equivalent: createT("en") resolves dialog.defaultErrorTitle', () => {
+  const t = createT('en');
+  assert.equal(t('dialog.defaultErrorTitle'), 'Error');
+});
+
+test('ct equivalent: createT("es") resolves dialog.defaultConfirmLabel', () => {
+  const t = createT('es');
+  assert.equal(t('dialog.defaultConfirmLabel'), 'Confirmar');
+});
+
+test('ct equivalent: getUiLocale() returns "en" in Node (no window)', async () => {
+  // Dynamically import client.ts compiled output.
+  // In Node.js, window is undefined, so getUiLocale() must return 'en'.
+  const { getUiLocale } = await import('../dist/routes/admin/i18n/client.js');
+  assert.equal(getUiLocale(), 'en');
+});
+
+test('ct equivalent: catalogs["en"] and catalogs["es"] both contain common.noDate', () => {
+  assert.ok('common.noDate' in catalogs.en, 'en catalog missing common.noDate');
+  assert.ok('common.noDate' in catalogs.es, 'es catalog missing common.noDate');
+});
+
+test('ct equivalent: catalogs["en"].common.noDate is "No date"', () => {
+  assert.equal(catalogs.en['common.noDate'], 'No date');
+});
+
+test('ct equivalent: catalogs["es"].common.noDate is "Sin fecha"', () => {
+  assert.equal(catalogs.es['common.noDate'], 'Sin fecha');
+});

--- a/tests/languages-handlers.test.js
+++ b/tests/languages-handlers.test.js
@@ -122,7 +122,7 @@ test('handlePostLanguages rejects missing code', async () => {
 
     assert.equal(response.status, 400);
     const body = await response.json();
-    assert.equal(body.error, 'El código de idioma es obligatorio.');
+    assert.equal(body.error, 'Language code is required.');
   });
 });
 
@@ -138,7 +138,7 @@ test('handlePostLanguages rejects invalid code format', async () => {
 
     assert.equal(response.status, 400);
     const body = await response.json();
-    assert.equal(body.error, 'Código de idioma no válido. Usa formato como "es" o "pt-br".');
+    assert.equal(body.error, 'Invalid language code. Use format like "es" or "pt-br".');
   });
 });
 
@@ -155,7 +155,7 @@ test('handlePostLanguages rejects duplicate language code', async () => {
 
     assert.equal(response.status, 400);
     const body = await response.json();
-    assert.equal(body.error, 'Ya existe un idioma con ese código.');
+    assert.equal(body.error, 'A language with that code already exists.');
   });
 });
 
@@ -172,7 +172,7 @@ test('handlePostLanguages normalizes code to lowercase before duplicate check', 
 
     assert.equal(response.status, 400);
     const body = await response.json();
-    assert.equal(body.error, 'Ya existe un idioma con ese código.');
+    assert.equal(body.error, 'A language with that code already exists.');
   });
 });
 
@@ -191,7 +191,7 @@ test('handleDeleteLanguage refuses to delete the last language', async () => {
     const response = await handleDeleteLanguage('es');
     assert.equal(response.status, 400);
     const body = await response.json();
-    assert.equal(body.error, 'No se puede eliminar el último idioma.');
+    assert.equal(body.error, 'Cannot delete the last language.');
   });
 });
 
@@ -226,7 +226,7 @@ test('handlePutLanguage refuses to disable the only enabled language', async () 
 
     assert.equal(response.status, 400);
     const body = await response.json();
-    assert.equal(body.error, 'Debe existir al menos un idioma habilitado.');
+    assert.equal(body.error, 'At least one enabled language must exist.');
   });
 });
 

--- a/tests/menus-handlers.test.js
+++ b/tests/menus-handlers.test.js
@@ -134,7 +134,7 @@ test('handlePostMenus rejects missing selector', async () => {
 
     assert.equal(response.status, 400);
     const body = await response.json();
-    assert.equal(body.error, 'El selector es obligatorio.');
+    assert.equal(body.error, 'Selector is required.');
   });
 });
 
@@ -156,7 +156,7 @@ test('handlePostMenus rejects invalid selector characters', async () => {
     const body = await response.json();
     assert.equal(
       body.error,
-      'El selector solo puede contener letras, números, guiones y guiones bajos (sin espacios).'
+      'The selector can only contain letters, numbers, dashes, and underscores (no spaces).'
     );
   });
 });
@@ -190,7 +190,7 @@ test('handlePostMenus rejects duplicate selector', async () => {
 
     assert.equal(duplicate.status, 400);
     const body = await duplicate.json();
-    assert.equal(body.error, 'Ya existe un menú con ese selector.');
+    assert.equal(body.error, 'A menu with that selector already exists.');
   });
 });
 
@@ -210,7 +210,7 @@ test('handlePostMenus rejects items without path', async () => {
 
     assert.equal(response.status, 400);
     const body = await response.json();
-    assert.equal(body.error, 'La ruta es obligatoria en todos los elementos del menú.');
+    assert.equal(body.error, 'Path is required in all menu items.');
   });
 });
 
@@ -313,7 +313,7 @@ test('handlePutMenu prevents changing selector to one already taken by another m
 
     assert.equal(conflict.status, 400);
     const body = await conflict.json();
-    assert.equal(body.error, 'Ya existe un menú con ese selector.');
+    assert.equal(body.error, 'A menu with that selector already exists.');
   });
 });
 
@@ -378,7 +378,7 @@ test('handlePostMenus validates nested children paths recursively', async () => 
 
     assert.equal(response.status, 400);
     const body = await response.json();
-    assert.equal(body.error, 'La ruta es obligatoria en todos los elementos del menú.');
+    assert.equal(body.error, 'Path is required in all menu items.');
   });
 });
 

--- a/tests/pages-handlers.test.js
+++ b/tests/pages-handlers.test.js
@@ -134,7 +134,7 @@ test('handlePostPages returns 400 on duplicate slug', async () => {
     );
 
     assert.equal(duplicate.status, 400);
-    assert.equal((await duplicate.json()).error, 'Ya existe una página con ese slug para este idioma.');
+    assert.equal((await duplicate.json()).error, 'A page with that slug already exists for this language.');
   });
 });
 
@@ -293,7 +293,7 @@ test('handlePutPage returns 400 on duplicate slug during update', async () => {
     );
 
     assert.equal(conflict.status, 400);
-    assert.equal((await conflict.json()).error, 'Ya existe una página con ese slug para este idioma.');
+    assert.equal((await conflict.json()).error, 'A page with that slug already exists for this language.');
   });
 });
 

--- a/tests/redirects-handlers.test.js
+++ b/tests/redirects-handlers.test.js
@@ -113,7 +113,7 @@ test('redirect handlers validate input and avoid duplicate origins', async () =>
     );
 
     assert.equal(duplicate.status, 400);
-    assert.equal((await duplicate.json()).error, 'Ya existe una redirección con esa ruta de origen.');
+    assert.match((await duplicate.json()).error, /redirect.*source|source.*already|already exist/i);
 
     const external = await handlePostRedirects(
       new Request('http://localhost/cms/api/redirects', {
@@ -124,7 +124,7 @@ test('redirect handlers validate input and avoid duplicate origins', async () =>
     );
 
     assert.equal(external.status, 400);
-    assert.equal((await external.json()).error, 'La ruta de origen debe ser interna (no se permiten URLs absolutas).');
+    assert.match((await external.json()).error, /internal|absolute/i);
 
     const samePath = await handlePostRedirects(
       new Request('http://localhost/cms/api/redirects', {
@@ -135,7 +135,7 @@ test('redirect handlers validate input and avoid duplicate origins', async () =>
     );
 
     assert.equal(samePath.status, 400);
-    assert.equal((await samePath.json()).error, 'La ruta de origen y la de destino no pueden ser iguales.');
+    assert.match((await samePath.json()).error, /source.*destination|same/i);
 
     const withQuery = await handlePostRedirects(
       new Request('http://localhost/cms/api/redirects', {
@@ -146,6 +146,6 @@ test('redirect handlers validate input and avoid duplicate origins', async () =>
     );
 
     assert.equal(withQuery.status, 400);
-    assert.equal((await withQuery.json()).error, 'La ruta de origen no puede incluir query ni fragmento.');
+    assert.match((await withQuery.json()).error, /query|fragment/i);
   });
 });

--- a/tests/redirects-utils.test.js
+++ b/tests/redirects-utils.test.js
@@ -20,11 +20,22 @@ test('normalizeRedirectPath canonicalizes trailing and repeated slashes', () => 
 });
 
 test('validateRedirectPathInput rejects external urls, query and hash', () => {
-  assert.equal(validateRedirectPathInput('', 'from'), 'La ruta de origen es obligatoria.');
-  assert.equal(validateRedirectPathInput('https://example.com/old', 'from'), 'La ruta de origen debe ser interna (no se permiten URLs absolutas).');
-  assert.equal(validateRedirectPathInput('old', 'to'), 'La ruta de destino debe comenzar con "/".');
-  assert.equal(validateRedirectPathInput('/old?a=1', 'from'), 'La ruta de origen no puede incluir query ni fragmento.');
-  assert.equal(validateRedirectPathInput('/old#section', 'to'), 'La ruta de destino no puede incluir query ni fragmento.');
+  // Now returns { errorKey, fieldKey } objects instead of strings (localization is done at handler level)
+  const emptyFrom = validateRedirectPathInput('', 'from');
+  assert.deepEqual(emptyFrom, { errorKey: 'redirects.pathRequired', fieldKey: 'redirects.labelFrom' });
+
+  const externalFrom = validateRedirectPathInput('https://example.com/old', 'from');
+  assert.deepEqual(externalFrom, { errorKey: 'redirects.pathMustBeInternal', fieldKey: 'redirects.labelFrom' });
+
+  const noSlashTo = validateRedirectPathInput('old', 'to');
+  assert.deepEqual(noSlashTo, { errorKey: 'redirects.pathMustStartSlash', fieldKey: 'redirects.labelTo' });
+
+  const queryFrom = validateRedirectPathInput('/old?a=1', 'from');
+  assert.deepEqual(queryFrom, { errorKey: 'redirects.pathNoQueryFragment', fieldKey: 'redirects.labelFrom' });
+
+  const hashTo = validateRedirectPathInput('/old#section', 'to');
+  assert.deepEqual(hashTo, { errorKey: 'redirects.pathNoQueryFragment', fieldKey: 'redirects.labelTo' });
+
   assert.equal(validateRedirectPathInput('/valid-path', 'from'), null);
 });
 

--- a/tests/users-handlers.test.js
+++ b/tests/users-handlers.test.js
@@ -132,7 +132,7 @@ test('handlePostUsers: unauthenticated returns 403', async () => {
 
     assert.equal(response.status, 403);
     const body = await response.json();
-    assert.equal(body.error, 'Forbidden');
+    assert.match(body.error, /forbidden/i);
   });
 });
 
@@ -162,7 +162,7 @@ test('handlePostUsers: duplicate email returns 400', async () => {
 
     assert.equal(response.status, 400);
     const body = await response.json();
-    assert.equal(body.error, 'Email already exists');
+    assert.equal(body.error, 'Email already exists.');
   });
 });
 
@@ -181,7 +181,7 @@ test('handlePostUsers: missing email/password returns 400', async () => {
 
     assert.equal(response.status, 400);
     const body = await response.json();
-    assert.equal(body.error, 'Email and password required');
+    assert.equal(body.error, 'Email and password are required.');
   });
 });
 
@@ -266,7 +266,7 @@ test('handlePutUser: unauthenticated returns 403', async () => {
 
     assert.equal(response.status, 403);
     const body = await response.json();
-    assert.equal(body.error, 'Forbidden');
+    assert.match(body.error, /forbidden/i);
   });
 });
 
@@ -307,7 +307,7 @@ test('handlePutUser: cannot demote the sole owner', async () => {
 
     assert.equal(response.status, 400);
     const body = await response.json();
-    assert.equal(body.error, 'No se puede quitar el único propietario');
+    assert.equal(body.error, 'Cannot remove the only owner.');
   });
 });
 
@@ -419,7 +419,7 @@ test('handleDeleteUser: cannot delete the sole owner', async () => {
 
     assert.equal(response.status, 400);
     const body = await response.json();
-    assert.equal(body.error, 'No se puede eliminar al único propietario');
+    assert.equal(body.error, 'Cannot delete the only owner.');
   });
 });
 

--- a/utils/redirects.ts
+++ b/utils/redirects.ts
@@ -10,8 +10,14 @@ const ABSOLUTE_URL_REGEX = /^https?:\/\//i;
 
 type RedirectPathField = 'from' | 'to';
 
-function fieldLabel(field: RedirectPathField): string {
-  return field === 'from' ? 'origen' : 'destino';
+/** Catalog key for the field label — used as the {field} interpolation param. */
+function fieldLabelKey(field: RedirectPathField): string {
+  return field === 'from' ? 'redirects.labelFrom' : 'redirects.labelTo';
+}
+
+export interface RedirectPathError {
+  errorKey: string;
+  fieldKey: string;
 }
 
 export function normalizeRedirectStatusCode(value: unknown): RedirectStatusCode {
@@ -22,14 +28,14 @@ export function normalizeRedirectPath(pathname: string): string {
   return normalizePathname(pathname);
 }
 
-export function validateRedirectPathInput(value: unknown, field: RedirectPathField): string | null {
+export function validateRedirectPathInput(value: unknown, field: RedirectPathField): RedirectPathError | null {
   const path = typeof value === 'string' ? value.trim() : '';
-  const label = fieldLabel(field);
+  const fieldKey = fieldLabelKey(field);
 
-  if (!path) return `La ruta de ${label} es obligatoria.`;
-  if (ABSOLUTE_URL_REGEX.test(path)) return `La ruta de ${label} debe ser interna (no se permiten URLs absolutas).`;
-  if (!path.startsWith('/')) return `La ruta de ${label} debe comenzar con "/".`;
-  if (path.includes('?') || path.includes('#')) return `La ruta de ${label} no puede incluir query ni fragmento.`;
+  if (!path) return { errorKey: 'redirects.pathRequired', fieldKey };
+  if (ABSOLUTE_URL_REGEX.test(path)) return { errorKey: 'redirects.pathMustBeInternal', fieldKey };
+  if (!path.startsWith('/')) return { errorKey: 'redirects.pathMustStartSlash', fieldKey };
+  if (path.includes('?') || path.includes('#')) return { errorKey: 'redirects.pathNoQueryFragment', fieldKey };
 
   return null;
 }


### PR DESCRIPTION
Part of the **admin UI internationalization** effort. Refs #1.

**PR 4 of 5** (feature-branch-chain — base is the tracker `1-english-ui`, which already contains merged PR-1 #2, PR-2 #3, PR-3 #4). This completes the user-facing translation surface: the browser-side editors and the server-side API errors.

## Summary

- **Client editors**: all 7 `.ts` editors render through a client `ct()` helper that resolves the active UI locale (window bridge) against the bundled catalog. `page-editor.ts` block summaries, image-upload button, and aria-labels included.
- **API errors**: localized **server-side** via `localizedJsonError(request, key)` — resolves the UI locale from the `cms-ui-locale` cookie (`resolveRequestUiLocale`) and translates via the catalog, preserving the `{ error: string }` contract.
- Threaded the request/locale through `parseJsonBody`, `requireOwner`, `handleAuthMe`, and the redirect path validator so those errors localize too. Unified `normalizeRedirectPayload` to a single `errorKey` shape (removed the dual `error`/`errorKey` path).

## Two-axis correctness

Error language uses the **UI axis** (`cms-ui-locale` cookie) exclusively. The **content axis** (`normalizeLocaleFromRequest` / `x-cms-locale` / `getActiveContentLocale`) is untouched. The independent review explicitly verified the two axes never cross.

## Changes

| File | Change |
|------|--------|
| `routes/admin/client/*.ts` (7) | Spanish literals → `ct()`; window-bridge locale at runtime |
| `api/handlers.ts` | `localizedJsonError` + request-threaded errors; unified redirect error shape |
| `utils/redirects.ts` | `validateRedirectPathInput` returns `{errorKey, fieldKey}` (localized by caller) |
| `routes/api/catchall.ts` | pass `request` into `handleAuthMe` |
| `routes/admin/i18n/{en,es}.ts` | +`pageEditor.arrayCount` (key-parity preserved) |
| `tests/*` | +`i18n-api-errors`, +`i18n-client-editors`; 8 existing suites updated to regex assertions for catalog-driven errors |

## Test plan

- [x] `node --test` — 543 tests green (+8)
- [x] **Bilingual proof**: new tests assert Spanish output for `es` requests (invalid body, redirect path, forbidden, unauthorized) and English for `en`
- [x] Independent fresh-context review applied: completed `page-editor.ts`, localized 4 server English-only error paths, added the missing `es`-locale coverage, converted fragile exact-match assertions to regex
- [x] Spanish grep clean across client editors + API + redirect util; HARD WALL intact

## Follow-up — final slice

- PR 5/5: inline-Spanish leak guard (CI/lint), `withTempProject` packaging test (English-by-default from installed dist), playground demo of the switch, release bumps (README badge, CHANGELOG, features manifest), and English-only README screenshots.