### PR TITLE
feat(media): Slice A — foundation utils for non-image file uploads

### DIFF
--- a/tests/allowed-file-types.test.js
+++ b/tests/allowed-file-types.test.js
@@ -1,0 +1,98 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * allowed-file-types.test.js
+ * Unit tests for utils/file-types.ts constants.
+ * Tests import from ../dist/ after build.
+ *
+ * RED phase: written before the implementation exists.
+ *
+ * Spec: R1.1 (D1, D2). Note: R1.3-A, R1.5-A tests are in Slice C (need plugin/handlers).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { DEFAULT_ALLOWED_FILE_TYPES, RASTER_MIME, DOCUMENT_MIME_TO_EXT, MIME_TO_EXT } from '../dist/utils/file-types.js';
+
+// ─── R1.1-A: DEFAULT_ALLOWED_FILE_TYPES export is correct ────────────────────
+
+test('R1.1-A: DEFAULT_ALLOWED_FILE_TYPES has exactly 6 entries', () => {
+  assert.equal(DEFAULT_ALLOWED_FILE_TYPES.length, 6);
+});
+
+test('R1.1-A: DEFAULT_ALLOWED_FILE_TYPES sorted equals expected 6 MIMEs', () => {
+  const expected = [
+    'application/pdf',
+    'image/gif',
+    'image/jpeg',
+    'image/png',
+    'image/svg+xml',
+    'image/webp',
+  ];
+  assert.deepEqual([...DEFAULT_ALLOWED_FILE_TYPES].sort(), expected);
+});
+
+test('R1.1-A: DEFAULT_ALLOWED_FILE_TYPES contains application/pdf', () => {
+  assert.ok(DEFAULT_ALLOWED_FILE_TYPES.includes('application/pdf'));
+});
+
+test('R1.1-A: DEFAULT_ALLOWED_FILE_TYPES contains all image variants', () => {
+  assert.ok(DEFAULT_ALLOWED_FILE_TYPES.includes('image/jpeg'));
+  assert.ok(DEFAULT_ALLOWED_FILE_TYPES.includes('image/png'));
+  assert.ok(DEFAULT_ALLOWED_FILE_TYPES.includes('image/webp'));
+  assert.ok(DEFAULT_ALLOWED_FILE_TYPES.includes('image/gif'));
+  assert.ok(DEFAULT_ALLOWED_FILE_TYPES.includes('image/svg+xml'));
+});
+
+test('R1.1-A: DEFAULT_ALLOWED_FILE_TYPES has no duplicates', () => {
+  const unique = new Set(DEFAULT_ALLOWED_FILE_TYPES);
+  assert.equal(unique.size, DEFAULT_ALLOWED_FILE_TYPES.length);
+});
+
+// ─── RASTER_MIME set ──────────────────────────────────────────────────────────
+
+test('RASTER_MIME contains image/jpeg, image/png, image/webp', () => {
+  assert.ok(RASTER_MIME.has('image/jpeg'));
+  assert.ok(RASTER_MIME.has('image/png'));
+  assert.ok(RASTER_MIME.has('image/webp'));
+});
+
+test('RASTER_MIME does NOT contain image/gif', () => {
+  assert.ok(!RASTER_MIME.has('image/gif'));
+});
+
+test('RASTER_MIME does NOT contain image/svg+xml', () => {
+  assert.ok(!RASTER_MIME.has('image/svg+xml'));
+});
+
+test('RASTER_MIME does NOT contain application/pdf', () => {
+  assert.ok(!RASTER_MIME.has('application/pdf'));
+});
+
+test('RASTER_MIME has exactly 3 entries', () => {
+  assert.equal(RASTER_MIME.size, 3);
+});
+
+// ─── DOCUMENT_MIME_TO_EXT ────────────────────────────────────────────────────
+
+test('DOCUMENT_MIME_TO_EXT maps application/pdf to .pdf', () => {
+  assert.equal(DOCUMENT_MIME_TO_EXT['application/pdf'], '.pdf');
+});
+
+// ─── MIME_TO_EXT (merged map) ─────────────────────────────────────────────────
+
+test('MIME_TO_EXT maps image/jpeg to .jpg', () => {
+  assert.ok(MIME_TO_EXT['image/jpeg'] === '.jpg' || MIME_TO_EXT['image/jpeg'] === '.jpeg');
+});
+
+test('MIME_TO_EXT maps image/png to .png', () => {
+  assert.equal(MIME_TO_EXT['image/png'], '.png');
+});
+
+test('MIME_TO_EXT maps application/pdf to .pdf (merged from DOCUMENT_MIME_TO_EXT)', () => {
+  assert.equal(MIME_TO_EXT['application/pdf'], '.pdf');
+});

--- a/tests/file-value.test.js
+++ b/tests/file-value.test.js
@@ -1,0 +1,258 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * file-value.test.js
+ * Unit tests for utils/file-value.ts pure helpers.
+ * Tests import from ../dist/ after build.
+ *
+ * RED phase: written before the implementation exists.
+ *
+ * Spec: D8, ADR-3, ADR-5.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  toFileValue,
+  parseFileValue,
+  serializeFileValueAttr,
+  isEmptyFileValue,
+  mediaEntryToFileValue,
+  fileDownloadUrl,
+} from '../dist/utils/file-value.js';
+
+// ─── toFileValue ──────────────────────────────────────────────────────────────
+
+test('toFileValue — passes through valid object with url', () => {
+  const result = toFileValue({ url: '/uploads/doc.pdf', filename: 'doc.pdf', mimeType: 'application/pdf' });
+  assert.equal(result.url, '/uploads/doc.pdf');
+  assert.equal(result.filename, 'doc.pdf');
+  assert.equal(result.mimeType, 'application/pdf');
+});
+
+test('toFileValue — passes through object with download flag', () => {
+  const result = toFileValue({ url: '/uploads/doc.pdf', download: true });
+  assert.equal(result.url, '/uploads/doc.pdf');
+  assert.equal(result.download, true);
+});
+
+test('toFileValue — empty string → sentinel { url: "" }', () => {
+  const result = toFileValue('');
+  assert.equal(result.url, '');
+});
+
+test('toFileValue — null → sentinel { url: "" }', () => {
+  const result = toFileValue(null);
+  assert.equal(result.url, '');
+});
+
+test('toFileValue — undefined → sentinel { url: "" }', () => {
+  const result = toFileValue(undefined);
+  assert.equal(result.url, '');
+});
+
+test('toFileValue — object without url → sentinel { url: "" }', () => {
+  const result = toFileValue({ filename: 'doc.pdf' });
+  assert.equal(result.url, '');
+});
+
+test('toFileValue — array → sentinel { url: "" }', () => {
+  const result = toFileValue(['/doc.pdf']);
+  assert.equal(result.url, '');
+});
+
+// ─── parseFileValue ───────────────────────────────────────────────────────────
+
+test('parseFileValue — empty string returns { url: "" }', () => {
+  const result = parseFileValue('');
+  assert.equal(result.url, '');
+});
+
+test('parseFileValue — valid JSON object with url returns parsed object', () => {
+  const raw = JSON.stringify({ url: '/uploads/doc.pdf', filename: 'doc.pdf' });
+  const result = parseFileValue(raw);
+  assert.equal(result.url, '/uploads/doc.pdf');
+  assert.equal(result.filename, 'doc.pdf');
+});
+
+test('parseFileValue — malformed JSON returns sentinel { url: "" }', () => {
+  const result = parseFileValue('{bad json');
+  assert.equal(result.url, '');
+});
+
+test('parseFileValue — JSON without url property returns sentinel', () => {
+  const raw = JSON.stringify({ filename: 'doc.pdf' });
+  const result = parseFileValue(raw);
+  assert.equal(result.url, '');
+});
+
+test('parseFileValue — round-trip with all fields', () => {
+  const original = {
+    url: '/uploads/2026/06/report.pdf',
+    filename: 'report.pdf',
+    mimeType: 'application/pdf',
+    download: true,
+  };
+  const result = parseFileValue(JSON.stringify(original));
+  assert.equal(result.url, original.url);
+  assert.equal(result.filename, original.filename);
+  assert.equal(result.mimeType, original.mimeType);
+  assert.equal(result.download, original.download);
+});
+
+test('parseFileValue — download field false is preserved', () => {
+  const raw = JSON.stringify({ url: '/uploads/doc.pdf', download: false });
+  const result = parseFileValue(raw);
+  assert.equal(result.download, false);
+});
+
+// ─── serializeFileValueAttr ───────────────────────────────────────────────────
+
+test('serializeFileValueAttr — no raw double-quote in output (critical breakout char)', () => {
+  const value = { url: '/uploads/doc.pdf', filename: 'my "report".pdf' };
+  const serialized = serializeFileValueAttr(value);
+  assert.ok(!serialized.includes('"'), 'must encode all double-quotes to prevent attribute breakout');
+});
+
+test('serializeFileValueAttr — round-trip through HTML attribute preserves data', () => {
+  const original = { url: '/uploads/doc.pdf', filename: 'report.pdf', mimeType: 'application/pdf', download: true };
+  const serialized = serializeFileValueAttr(original);
+  // Decode HTML entities (as browser would when reading .value)
+  const decoded = serialized
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+  const roundTripped = JSON.parse(decoded);
+  assert.equal(roundTripped.url, original.url);
+  assert.equal(roundTripped.filename, original.filename);
+  assert.equal(roundTripped.mimeType, original.mimeType);
+  assert.equal(roundTripped.download, original.download);
+});
+
+test('serializeFileValueAttr — encodes &, <, >, \', "', () => {
+  const value = { url: '/a&b<c>d"e\'f.pdf' };
+  const serialized = serializeFileValueAttr(value);
+  assert.ok(!serialized.includes('&b'), 'raw & must be encoded');
+  assert.ok(!serialized.includes('<c>'), 'raw < > must be encoded');
+  assert.ok(!serialized.includes('"e'), 'raw " must be encoded');
+});
+
+// ─── isEmptyFileValue ─────────────────────────────────────────────────────────
+
+test('isEmptyFileValue — { url: "" } is empty', () => {
+  assert.equal(isEmptyFileValue({ url: '' }), true);
+});
+
+test('isEmptyFileValue — {} is empty (missing url)', () => {
+  assert.equal(isEmptyFileValue({}), true);
+});
+
+test('isEmptyFileValue — { url: "/doc.pdf" } is not empty', () => {
+  assert.equal(isEmptyFileValue({ url: '/doc.pdf' }), false);
+});
+
+test('isEmptyFileValue — null is empty', () => {
+  assert.equal(isEmptyFileValue(null), true);
+});
+
+test('isEmptyFileValue — undefined is empty', () => {
+  assert.equal(isEmptyFileValue(undefined), true);
+});
+
+test('isEmptyFileValue — string is treated as empty (not a valid FileFieldValue object)', () => {
+  assert.equal(isEmptyFileValue('/doc.pdf'), true);
+});
+
+// ─── mediaEntryToFileValue ────────────────────────────────────────────────────
+
+test('mediaEntryToFileValue — maps entry with all relevant fields', () => {
+  const entry = {
+    id: '1',
+    url: '/uploads/2026/06/doc.pdf',
+    filename: 'doc.pdf',
+    size: 12345,
+    mimeType: 'application/pdf',
+    createdAt: '2026-06-29T00:00:00.000Z',
+    fileCategory: 'document',
+  };
+  const value = mediaEntryToFileValue(entry);
+  assert.equal(value.url, '/uploads/2026/06/doc.pdf');
+  assert.equal(value.filename, 'doc.pdf');
+  assert.equal(value.mimeType, 'application/pdf');
+});
+
+test('mediaEntryToFileValue — download field not set by default (false/undefined)', () => {
+  const entry = {
+    id: '1',
+    url: '/uploads/2026/06/doc.pdf',
+    filename: 'doc.pdf',
+    size: 12345,
+    mimeType: 'application/pdf',
+    createdAt: '2026-06-29T00:00:00.000Z',
+  };
+  const value = mediaEntryToFileValue(entry);
+  // download should be absent or false — never forced to true
+  assert.ok(value.download !== true, 'download must not be forced true from entry alone');
+});
+
+test('mediaEntryToFileValue — maps image entry (image/jpeg)', () => {
+  const entry = {
+    id: '2',
+    url: '/uploads/2026/06/photo.jpg',
+    filename: 'photo.jpg',
+    size: 5000,
+    mimeType: 'image/jpeg',
+    createdAt: '2026-06-29T00:00:00.000Z',
+  };
+  const value = mediaEntryToFileValue(entry);
+  assert.equal(value.url, '/uploads/2026/06/photo.jpg');
+  assert.equal(value.mimeType, 'image/jpeg');
+});
+
+// ─── fileDownloadUrl ──────────────────────────────────────────────────────────
+
+test('fileDownloadUrl — download=true appends ?download to plain url', () => {
+  const value = { url: '/uploads/2026/06/doc.pdf', download: true };
+  assert.equal(fileDownloadUrl(value), '/uploads/2026/06/doc.pdf?download');
+});
+
+test('fileDownloadUrl — download=false returns url unchanged', () => {
+  const value = { url: '/uploads/2026/06/doc.pdf', download: false };
+  assert.equal(fileDownloadUrl(value), '/uploads/2026/06/doc.pdf');
+});
+
+test('fileDownloadUrl — download=undefined returns url unchanged', () => {
+  const value = { url: '/uploads/2026/06/doc.pdf' };
+  assert.equal(fileDownloadUrl(value), '/uploads/2026/06/doc.pdf');
+});
+
+test('fileDownloadUrl — existing query string handled (no double ?)', () => {
+  const value = { url: '/uploads/2026/06/doc.pdf?foo=bar', download: true };
+  const result = fileDownloadUrl(value);
+  // Must not produce ??download or duplicate ?
+  assert.ok(!result.includes('??'), 'must not produce double question mark');
+  assert.ok(result.includes('download'), 'must include download param');
+  // Should produce ?foo=bar&download
+  assert.equal(result, '/uploads/2026/06/doc.pdf?foo=bar&download');
+});
+
+test('fileDownloadUrl — url already has ?download, download=true → no duplication', () => {
+  const value = { url: '/uploads/doc.pdf?download', download: true };
+  const result = fileDownloadUrl(value);
+  // Should not produce /uploads/doc.pdf?download&download or ?download?download
+  const downloadCount = (result.match(/download/g) || []).length;
+  assert.equal(downloadCount, 1, 'download must appear exactly once');
+});
+
+test('fileDownloadUrl — empty url + download=true → appends ?download', () => {
+  const value = { url: '', download: true };
+  // Should not crash; result is empty + ?download
+  const result = fileDownloadUrl(value);
+  assert.ok(result.includes('download'), 'download param must be in result even for empty url');
+});

--- a/tests/file-value.test.js
+++ b/tests/file-value.test.js
@@ -256,3 +256,37 @@ test('fileDownloadUrl — empty url + download=true → appends ?download', () =
   const result = fileDownloadUrl(value);
   assert.ok(result.includes('download'), 'download param must be in result even for empty url');
 });
+
+// ─── fileDownloadUrl — false-positive / double-append regression cases ────────
+
+test('fileDownloadUrl — ?downloadtoken=abc with download=true → appends &download (no false positive)', () => {
+  // ?downloadtoken is NOT the same as ?download — must still append
+  const value = { url: '/uploads/doc.pdf?downloadtoken=abc', download: true };
+  const result = fileDownloadUrl(value);
+  // Must still contain the original downloadtoken param
+  assert.ok(result.includes('downloadtoken=abc'), 'original downloadtoken param must be preserved');
+  // Must have the bare download param appended
+  const params = new URL(result, 'http://x').searchParams;
+  assert.ok(params.has('download'), 'must add the bare download param');
+});
+
+test('fileDownloadUrl — ?x=1&download=something with download=true → no double download param', () => {
+  // A download param with a value already exists — must not append a second one
+  const value = { url: '/uploads/doc.pdf?x=1&download=something', download: true };
+  const result = fileDownloadUrl(value);
+  // Count occurrences of the key "download" in the search string
+  const params = new URL(result, 'http://x').searchParams;
+  const keys = [...params.keys()].filter(k => k === 'download');
+  assert.equal(keys.length, 1, 'download key must appear exactly once');
+});
+
+test('fileDownloadUrl — ?download already present with download=true → idempotent, no &download appended', () => {
+  // Bare ?download already exists — must be idempotent
+  const value = { url: '/uploads/doc.pdf?download', download: true };
+  const result = fileDownloadUrl(value);
+  const params = new URL(result, 'http://x').searchParams;
+  const keys = [...params.keys()].filter(k => k === 'download');
+  assert.equal(keys.length, 1, 'download must appear exactly once (idempotent)');
+  // No extra &download should have been appended
+  assert.ok(!result.includes('&download'), 'must not append a second &download');
+});

--- a/tests/upload-gate.test.js
+++ b/tests/upload-gate.test.js
@@ -218,3 +218,42 @@ test('evaluateUpload — null derivedExtension with safe MIME not in allowlist �
   });
   assert.deepEqual(result, { ok: false, reason: 'unsupported' });
 });
+
+// ─── MIME case-insensitivity and content-type params ─────────────────────────
+
+test('evaluateUpload — TEXT/HTML (uppercase) → denied (case-insensitive denylist)', () => {
+  const result = evaluateUpload({
+    mimeType: 'TEXT/HTML',
+    derivedExtension: '.html',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: false, reason: 'denied' });
+});
+
+test('evaluateUpload — text/html; charset=utf-8 (with params) → denied (boundary guard)', () => {
+  const result = evaluateUpload({
+    mimeType: 'text/html; charset=utf-8',
+    derivedExtension: '.html',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: false, reason: 'denied' });
+});
+
+test('evaluateUpload — uppercase extension .HTML → denied (ext denylist case-insensitive)', () => {
+  const result = evaluateUpload({
+    mimeType: 'application/octet-stream',
+    derivedExtension: '.HTML',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: false, reason: 'denied' });
+});
+
+test('evaluateUpload — image/svg+xml in allowlist is NOT over-denied by boundary pattern', () => {
+  // Confirm the DANGEROUS_MIME_PATTERN boundary fix does not accidentally block SVG
+  const result = evaluateUpload({
+    mimeType: 'image/svg+xml',
+    derivedExtension: '.svg',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: true });
+});

--- a/tests/upload-gate.test.js
+++ b/tests/upload-gate.test.js
@@ -1,0 +1,220 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * upload-gate.test.js
+ * Unit tests for utils/upload-gate.ts — evaluateUpload denylist + allowlist gate.
+ * Tests import from ../dist/ after build.
+ *
+ * RED phase: written before the implementation exists.
+ *
+ * Spec scenarios: SEC-DENY-01, R2.3, R2.4 (ADR-4).
+ * Evaluation ORDER (locked):
+ *   1) denylist on MIME   → denied
+ *   2) denylist on ext    → denied
+ *   3) allowlist on MIME  → unsupported if absent
+ *   4) ok
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { evaluateUpload } from '../dist/utils/upload-gate.js';
+
+const DEFAULT_ALLOWED = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/svg+xml',
+  'image/gif',
+  'application/pdf',
+];
+
+// ─── Denylist MIME — always denied regardless of allowlist ────────────────────
+
+test('SEC-DENY-01: evaluateUpload — text/html → denied (denylist MIME)', () => {
+  const result = evaluateUpload({
+    mimeType: 'text/html',
+    derivedExtension: '.html',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: false, reason: 'denied' });
+});
+
+test('SEC-DENY-01: evaluateUpload — application/javascript → denied (denylist MIME)', () => {
+  const result = evaluateUpload({
+    mimeType: 'application/javascript',
+    derivedExtension: '.js',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: false, reason: 'denied' });
+});
+
+test('evaluateUpload — text/javascript → denied (denylist MIME variant)', () => {
+  const result = evaluateUpload({
+    mimeType: 'text/javascript',
+    derivedExtension: '.js',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: false, reason: 'denied' });
+});
+
+// ─── Denylist MIME beats allowlist — even if misconfigured ───────────────────
+
+test('evaluateUpload — denylist beats allowlist: text/html in allowed → still denied', () => {
+  const allowedWithDangerous = new Set([...DEFAULT_ALLOWED, 'text/html']);
+  const result = evaluateUpload({
+    mimeType: 'text/html',
+    derivedExtension: '.html',
+    allowed: allowedWithDangerous,
+  });
+  assert.deepEqual(result, { ok: false, reason: 'denied' });
+});
+
+test('evaluateUpload — denylist beats allowlist: application/javascript in allowed → still denied', () => {
+  const allowedWithDangerous = new Set([...DEFAULT_ALLOWED, 'application/javascript']);
+  const result = evaluateUpload({
+    mimeType: 'application/javascript',
+    derivedExtension: '.js',
+    allowed: allowedWithDangerous,
+  });
+  assert.deepEqual(result, { ok: false, reason: 'denied' });
+});
+
+// ─── Denylist extension — denied regardless of MIME ──────────────────────────
+
+test('evaluateUpload — .exe extension → denied (denylist ext)', () => {
+  const result = evaluateUpload({
+    mimeType: 'application/octet-stream',
+    derivedExtension: '.exe',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: false, reason: 'denied' });
+});
+
+test('evaluateUpload — .sh extension → denied (denylist ext)', () => {
+  const result = evaluateUpload({
+    mimeType: 'application/x-sh',
+    derivedExtension: '.sh',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: false, reason: 'denied' });
+});
+
+test('evaluateUpload — .bat extension → denied (denylist ext)', () => {
+  const result = evaluateUpload({
+    mimeType: 'application/x-bat',
+    derivedExtension: '.bat',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: false, reason: 'denied' });
+});
+
+test('evaluateUpload — .html extension with non-dangerous MIME → denied (ext denylist applies)', () => {
+  const result = evaluateUpload({
+    mimeType: 'application/octet-stream',
+    derivedExtension: '.html',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: false, reason: 'denied' });
+});
+
+// ─── Unsupported: MIME not in denylist, not in allowlist ─────────────────────
+
+test('evaluateUpload — application/msword not in allowlist → unsupported', () => {
+  const result = evaluateUpload({
+    mimeType: 'application/msword',
+    derivedExtension: '.doc',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: false, reason: 'unsupported' });
+});
+
+test('evaluateUpload — application/zip not in allowlist → unsupported', () => {
+  const result = evaluateUpload({
+    mimeType: 'application/zip',
+    derivedExtension: '.zip',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: false, reason: 'unsupported' });
+});
+
+// ─── Allowed: MIME passes both denylist and allowlist ────────────────────────
+
+test('evaluateUpload — image/jpeg in allowlist → ok', () => {
+  const result = evaluateUpload({
+    mimeType: 'image/jpeg',
+    derivedExtension: '.jpg',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: true });
+});
+
+test('evaluateUpload — image/png in allowlist → ok', () => {
+  const result = evaluateUpload({
+    mimeType: 'image/png',
+    derivedExtension: '.png',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: true });
+});
+
+test('evaluateUpload — application/pdf in default allowlist → ok', () => {
+  const result = evaluateUpload({
+    mimeType: 'application/pdf',
+    derivedExtension: '.pdf',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: true });
+});
+
+test('evaluateUpload — image/svg+xml in default allowlist → ok (SVG not in denylist)', () => {
+  const result = evaluateUpload({
+    mimeType: 'image/svg+xml',
+    derivedExtension: '.svg',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: true });
+});
+
+test('evaluateUpload — image/gif in default allowlist → ok', () => {
+  const result = evaluateUpload({
+    mimeType: 'image/gif',
+    derivedExtension: '.gif',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: true });
+});
+
+// ─── Evaluation order: ext denial fires even when MIME is safe ───────────────
+
+test('evaluateUpload — .svgz extension → denied (even though svg is allowed)', () => {
+  const result = evaluateUpload({
+    mimeType: 'image/svg+xml',
+    derivedExtension: '.svgz',
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: false, reason: 'denied' });
+});
+
+// ─── Null/absent derivedExtension handled gracefully ─────────────────────────
+
+test('evaluateUpload — null derivedExtension with safe MIME and in allowlist → ok', () => {
+  const result = evaluateUpload({
+    mimeType: 'application/pdf',
+    derivedExtension: null,
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: true });
+});
+
+test('evaluateUpload — null derivedExtension with safe MIME not in allowlist → unsupported', () => {
+  const result = evaluateUpload({
+    mimeType: 'application/msword',
+    derivedExtension: null,
+    allowed: new Set(DEFAULT_ALLOWED),
+  });
+  assert.deepEqual(result, { ok: false, reason: 'unsupported' });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -3,7 +3,7 @@ Copyright (c) 2026 Nauel Gómez Gamero
 Licensed under the Business Source License 1.1
 */
 
-export type PrimitivePropType = 'string' | 'text' | 'number' | 'boolean' | 'image' | 'link' | 'select';
+export type PrimitivePropType = 'string' | 'text' | 'number' | 'boolean' | 'image' | 'link' | 'select' | 'file';
 export type PropType = PrimitivePropType | 'array';
 
 export interface PrimitivePropDef {
@@ -12,6 +12,10 @@ export interface PrimitivePropDef {
   required?: boolean;
   options?: string[];
   localizable?: boolean;
+  /** For file props: allowed MIME types (subset of global allowedFileTypes). */
+  accept?: string[];
+  /** For file props: default download behavior — when true, fileDownloadUrl appends ?download. */
+  download?: boolean;
 }
 
 export interface ObjectArrayItemDef {
@@ -252,6 +256,19 @@ export interface ImageFieldValue {
   height?: number;
 }
 
+/**
+ * Represents the value stored for a file-type block prop.
+ * The `url` is the only required field; all other fields are optional.
+ * Mirrors ImageFieldValue — same hidden-input JSON pattern, different semantics.
+ */
+export interface FileFieldValue {
+  url: string;
+  filename?: string;
+  mimeType?: string;
+  /** When true, fileDownloadUrl appends ?download to trigger Content-Disposition: attachment. */
+  download?: boolean;
+}
+
 export interface MediaVariant {
   format: 'webp' | 'avif';
   width: number;
@@ -275,6 +292,13 @@ export interface MediaEntry {
   variants?: MediaVariant[];
   /** Processing status of variant generation. */
   status?: 'processing' | 'ready' | 'failed';
+  /**
+   * Discriminator for the media entry type.
+   * 'image' → mimeType starts with 'image/'.
+   * 'document' → all other file types (e.g. PDF).
+   * Derived from mimeType on load when absent (backward compat).
+   */
+  fileCategory?: 'image' | 'document';
 }
 
 export interface MediaData {
@@ -294,4 +318,10 @@ export interface AstroBlocksOptions {
   i18n?: {
     routingStrategy?: PublicRoutingStrategy;
   };
+  /**
+   * Global allowlist of MIME types accepted by the media upload endpoint.
+   * Defaults to DEFAULT_ALLOWED_FILE_TYPES when not provided.
+   * Values are lowercased and deduplicated by resolveOptions.
+   */
+  allowedFileTypes?: string[];
 }

--- a/utils/file-types.ts
+++ b/utils/file-types.ts
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * utils/file-types.ts
+ *
+ * Single source of truth for file-type constants used by the media subsystem.
+ *
+ * Exports:
+ *   - DEFAULT_ALLOWED_FILE_TYPES : default MIME allowlist for uploads
+ *   - RASTER_MIME                : Set of raster image MIMEs that go through sharp
+ *   - DOCUMENT_MIME_TO_EXT       : extension map for document file types
+ *   - MIME_TO_EXT                : merged extension map (images + documents)
+ *
+ * All values are read-only constants. Pure module — no side effects.
+ */
+
+/**
+ * Default MIME-type allowlist for the upload endpoint.
+ *
+ * Binding decision D1: 6 entries exactly.
+ * Named export per D2 so consumers can inspect or reference defaults without
+ * constructing the plugin config.
+ */
+export const DEFAULT_ALLOWED_FILE_TYPES: string[] = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/svg+xml',
+  'image/gif',
+  'application/pdf',
+];
+
+/**
+ * Set of raster image MIME types that are processed by sharp
+ * (variant generation, imageSize, width/height extraction).
+ *
+ * Binding decision D4: raster-only positive check.
+ * Any MIME not in this set skips sharp entirely (SVG, GIF, PDF, all documents).
+ */
+export const RASTER_MIME: Set<string> = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+]);
+
+/**
+ * Extension map for document (non-image) file types.
+ * Separate from image extension map for clarity; merged into MIME_TO_EXT below.
+ */
+export const DOCUMENT_MIME_TO_EXT: Record<string, string> = {
+  'application/pdf': '.pdf',
+};
+
+/**
+ * Extension map for image MIME types.
+ * Extension is always derived from the validated MIME type, never from the user filename.
+ */
+const IMAGE_MIME_TO_EXT: Record<string, string> = {
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/webp': '.webp',
+  'image/gif': '.gif',
+  'image/svg+xml': '.svg',
+  'image/avif': '.avif',
+};
+
+/**
+ * Merged MIME-to-extension map covering both images and documents.
+ * Use this map when deriving the stored file extension from the validated MIME type.
+ */
+export const MIME_TO_EXT: Record<string, string> = {
+  ...IMAGE_MIME_TO_EXT,
+  ...DOCUMENT_MIME_TO_EXT,
+};

--- a/utils/file-value.ts
+++ b/utils/file-value.ts
@@ -1,0 +1,193 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * utils/file-value.ts
+ *
+ * Pure helpers for the FileFieldValue contract (ADR-3, ADR-5).
+ * Mirrors utils/image-value.ts — same hidden-input JSON pattern, different semantics.
+ *
+ * Exports:
+ *   - toFileValue           : coerce any unknown input to a valid FileFieldValue
+ *   - parseFileValue        : deserialize the hidden-input JSON (never throws)
+ *   - serializeFileValueAttr: serialize FileFieldValue to a safe HTML attribute string
+ *   - isEmptyFileValue      : detect an "empty / no value" FileFieldValue
+ *   - mediaEntryToFileValue : project a MediaEntry → FileFieldValue snapshot
+ *   - fileDownloadUrl       : resolve the URL for an anchor href, appending ?download when needed
+ *
+ * All functions are deterministic and side-effect-free — safe to use in tests,
+ * UI, server handlers, and Astro component frontmatter.
+ */
+
+import type { FileFieldValue, MediaEntry } from '../types/index.js';
+
+/** Sentinel returned for null / undefined / malformed input. */
+const EMPTY: FileFieldValue = { url: '' };
+
+/**
+ * Coerce any unknown value to a valid FileFieldValue.
+ *
+ * Coercion rules:
+ *   - Already-conforming object (has string url) → returned with normalized optional fields
+ *   - null / undefined / non-object / missing url → EMPTY sentinel { url: '' }
+ *
+ * Note: unlike toImageValue, there is no legacy bare-string coercion for file values
+ * because file fields never stored bare URLs (new feature).
+ */
+export function toFileValue(value: unknown): FileFieldValue {
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    if (typeof obj.url === 'string') {
+      return {
+        url: obj.url,
+        ...(typeof obj.filename === 'string' && { filename: obj.filename }),
+        ...(typeof obj.mimeType === 'string' && { mimeType: obj.mimeType }),
+        ...(typeof obj.download === 'boolean' && { download: obj.download }),
+      };
+    }
+    return { ...EMPTY };
+  }
+
+  return { ...EMPTY };
+}
+
+/**
+ * Deserialize the hidden input value for a file field.
+ *
+ * The hidden input holds either:
+ *   a) A JSON-serialized FileFieldValue (standard format)
+ *   b) An empty string (no file selected)
+ *
+ * Returns a valid FileFieldValue in all cases — never throws.
+ */
+export function parseFileValue(raw: string): FileFieldValue {
+  if (!raw || raw.trim() === '') {
+    return { url: '' };
+  }
+
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (
+        parsed !== null &&
+        typeof parsed === 'object' &&
+        !Array.isArray(parsed) &&
+        typeof (parsed as Record<string, unknown>).url === 'string'
+      ) {
+        const obj = parsed as Record<string, unknown>;
+        return {
+          url: obj.url as string,
+          ...(typeof obj.filename === 'string' && { filename: obj.filename }),
+          ...(typeof obj.mimeType === 'string' && { mimeType: obj.mimeType }),
+          ...(typeof obj.download === 'boolean' && { download: obj.download }),
+        };
+      }
+    } catch {
+      // Malformed JSON → fall through to sentinel
+    }
+    return { url: '' };
+  }
+
+  // Non-JSON input (bare string) → not a valid FileFieldValue
+  return { url: '' };
+}
+
+/**
+ * Serialize a FileFieldValue into a string safe to embed in an HTML `value="..."` attribute.
+ *
+ * Applies the same HTML entity escaping as serializeImageValueAttr:
+ *   &  →  &amp;
+ *   <  →  &lt;
+ *   >  →  &gt;
+ *   "  →  &quot;   ← CRITICAL: prevents attribute breakout
+ *   '  →  &#39;
+ *
+ * The browser automatically decodes HTML entities when reading input.value, so
+ * parseFileValue(input.value) receives clean JSON — no explicit decoding needed.
+ */
+export function serializeFileValueAttr(value: FileFieldValue): string {
+  const json = JSON.stringify(value);
+  return json
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Return true when the FileFieldValue represents "no file selected".
+ *
+ * An empty value is:
+ *   - null / undefined
+ *   - not an object (e.g. a raw string)
+ *   - an object where url is absent or an empty string
+ */
+export function isEmptyFileValue(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value !== 'object' || Array.isArray(value)) return true;
+  const obj = value as Record<string, unknown>;
+  return typeof obj.url !== 'string' || obj.url === '';
+}
+
+/**
+ * Project a MediaEntry to a FileFieldValue snapshot (taken at pick time).
+ *
+ * Rules:
+ *   - url      → entry.url
+ *   - filename → entry.filename
+ *   - mimeType → entry.mimeType
+ *   - download → NOT set from entry (comes from schema's download meta at pick time)
+ */
+export function mediaEntryToFileValue(entry: MediaEntry): FileFieldValue {
+  return {
+    url: entry.url,
+    filename: entry.filename,
+    mimeType: entry.mimeType,
+  };
+}
+
+/**
+ * Resolve the URL to use for a file anchor href.
+ *
+ * When value.download === true, appends the ?download query parameter so the
+ * serving route (routes/uploads-get.ts) sets Content-Disposition: attachment.
+ *
+ * Handles existing query strings defensively:
+ *   - No existing query string → append ?download
+ *   - Existing query string    → append &download
+ *   - Already has ?download    → return url as-is (no duplication)
+ *
+ * When download is false or undefined, returns value.url unchanged.
+ *
+ * Usage in component frontmatter:
+ *   <a href={fileDownloadUrl(file)} download={file.download ? (file.filename ?? '') : undefined}>
+ */
+export function fileDownloadUrl(value: FileFieldValue): string {
+  const { url, download } = value;
+
+  if (!download) {
+    return url;
+  }
+
+  // Already has the ?download param — do not duplicate
+  if (url.includes('?download') || url.endsWith('&download') || url.includes('&download&') || url.includes('&download=')) {
+    // Check specifically for standalone 'download' param
+    try {
+      const hasDownload = url.includes('?download') ||
+        url.includes('&download') && !url.includes('&download=');
+      if (hasDownload) {
+        return url;
+      }
+    } catch {
+      // Defensive — fall through to appending
+    }
+  }
+
+  // Append ?download or &download depending on existing query string
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}download`;
+}

--- a/utils/file-value.ts
+++ b/utils/file-value.ts
@@ -151,6 +151,20 @@ export function mediaEntryToFileValue(entry: MediaEntry): FileFieldValue {
 }
 
 /**
+ * Returns true when the URL already carries a `download` search parameter
+ * (with or without a value), using the URL constructor for precise key
+ * matching — immune to false positives from params like `?downloadtoken=...`.
+ */
+function hasDownloadParam(url: string): boolean {
+  try {
+    const base = url.startsWith('http://') || url.startsWith('https://') ? undefined : 'http://x';
+    return new URL(url, base).searchParams.has('download');
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Resolve the URL to use for a file anchor href.
  *
  * When value.download === true, appends the ?download query parameter so the
@@ -159,7 +173,7 @@ export function mediaEntryToFileValue(entry: MediaEntry): FileFieldValue {
  * Handles existing query strings defensively:
  *   - No existing query string → append ?download
  *   - Existing query string    → append &download
- *   - Already has ?download    → return url as-is (no duplication)
+ *   - Already carries a `download` key → return url as-is (no duplication)
  *
  * When download is false or undefined, returns value.url unchanged.
  *
@@ -168,26 +182,8 @@ export function mediaEntryToFileValue(entry: MediaEntry): FileFieldValue {
  */
 export function fileDownloadUrl(value: FileFieldValue): string {
   const { url, download } = value;
-
-  if (!download) {
-    return url;
-  }
-
-  // Already has the ?download param — do not duplicate
-  if (url.includes('?download') || url.endsWith('&download') || url.includes('&download&') || url.includes('&download=')) {
-    // Check specifically for standalone 'download' param
-    try {
-      const hasDownload = url.includes('?download') ||
-        url.includes('&download') && !url.includes('&download=');
-      if (hasDownload) {
-        return url;
-      }
-    } catch {
-      // Defensive — fall through to appending
-    }
-  }
-
-  // Append ?download or &download depending on existing query string
+  if (!download) return url;
+  if (hasDownloadParam(url)) return url;
   const separator = url.includes('?') ? '&' : '?';
   return `${url}${separator}download`;
 }

--- a/utils/upload-gate.ts
+++ b/utils/upload-gate.ts
@@ -1,0 +1,122 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * utils/upload-gate.ts
+ *
+ * Hard denylist + allowlist gate for file uploads (ADR-4).
+ *
+ * Exports:
+ *   - DANGEROUS_EXTENSIONS : Set of always-denied file extensions
+ *   - DANGEROUS_MIME       : Set of always-denied MIME types
+ *   - evaluateUpload       : gate function returning ok | denied | unsupported
+ *
+ * Evaluation ORDER (locked — denylist always beats allowlist):
+ *   1. denylist on MIME           → { ok: false, reason: 'denied' }
+ *   2. denylist on derived ext    → { ok: false, reason: 'denied' }
+ *   3. allowlist membership (MIME)→ { ok: false, reason: 'unsupported' } if absent
+ *   4. { ok: true }
+ *
+ * Pure module — no I/O, no HTTP, no side effects. Safe to import in tests.
+ *
+ * Security note:
+ *   SVG (image/svg+xml) is NOT in the denylist. It is allowed in uploads and
+ *   served with Content-Disposition: attachment (XSS guard in the serving route).
+ *   SVGZ (.svgz) IS in the extension denylist — compressed SVG with gzip magic
+ *   bytes can bypass MIME sniffing in some browsers.
+ */
+
+/**
+ * File extensions that are always denied, regardless of the allowlist.
+ * All values are lowercase including the leading dot.
+ */
+export const DANGEROUS_EXTENSIONS: Set<string> = new Set([
+  '.html',
+  '.htm',
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.exe',
+  '.sh',
+  '.bat',
+  '.cmd',
+  '.com',
+  '.svgz',
+]);
+
+/**
+ * MIME types that are always denied, regardless of the allowlist.
+ * All values are lowercase.
+ */
+export const DANGEROUS_MIME: Set<string> = new Set([
+  'text/html',
+  'text/javascript',
+  'application/javascript',
+  'application/x-javascript',
+  'application/x-sh',
+  'application/x-bat',
+  'application/x-msdownload',
+  'application/x-msdos-program',
+  'application/x-executable',
+]);
+
+/**
+ * Regex for dangerous MIME type families not captured by the exact set above.
+ * Matches any MIME matching these patterns.
+ */
+const DANGEROUS_MIME_PATTERN =
+  /^(text\/(html|javascript)|application\/(javascript|x-javascript|x-sh|x-bat|x-msdownload|x-msdos-program|x-executable))/i;
+
+/** Input to evaluateUpload. */
+export interface EvaluateUploadInput {
+  /** The validated MIME type (lowercase, from Content-Type or sniffed). */
+  mimeType: string;
+  /**
+   * The extension derived from the validated MIME type (e.g. '.pdf').
+   * Pass null when no mapping exists (evaluateUpload skips extension denylist check).
+   */
+  derivedExtension: string | null;
+  /** The resolved allowlist set for this request. */
+  allowed: Set<string>;
+}
+
+/** Result of evaluateUpload. */
+export type EvaluateUploadResult =
+  | { ok: true }
+  | { ok: false; reason: 'denied' | 'unsupported' };
+
+/**
+ * Evaluate whether a file upload should be accepted, denied, or rejected as unsupported.
+ *
+ * Evaluation ORDER (locked):
+ *   1. Denylist on MIME type (exact set + family regex) → denied
+ *   2. Denylist on derived extension (exact set)         → denied
+ *   3. Allowlist membership on MIME type                 → unsupported if absent
+ *   4. ok
+ *
+ * The denylist always wins — even a misconfigured allowlist that includes a
+ * dangerous MIME cannot re-enable a denied type.
+ */
+export function evaluateUpload(input: EvaluateUploadInput): EvaluateUploadResult {
+  const { mimeType, derivedExtension, allowed } = input;
+
+  // Step 1: Denylist on MIME (exact set or family pattern)
+  if (DANGEROUS_MIME.has(mimeType) || DANGEROUS_MIME_PATTERN.test(mimeType)) {
+    return { ok: false, reason: 'denied' };
+  }
+
+  // Step 2: Denylist on derived extension
+  if (derivedExtension !== null && DANGEROUS_EXTENSIONS.has(derivedExtension.toLowerCase())) {
+    return { ok: false, reason: 'denied' };
+  }
+
+  // Step 3: Allowlist membership check
+  if (!allowed.has(mimeType)) {
+    return { ok: false, reason: 'unsupported' };
+  }
+
+  // Step 4: All checks passed
+  return { ok: true };
+}

--- a/utils/upload-gate.ts
+++ b/utils/upload-gate.ts
@@ -67,7 +67,7 @@ export const DANGEROUS_MIME: Set<string> = new Set([
  * Matches any MIME matching these patterns.
  */
 const DANGEROUS_MIME_PATTERN =
-  /^(text\/(html|javascript)|application\/(javascript|x-javascript|x-sh|x-bat|x-msdownload|x-msdos-program|x-executable))/i;
+  /^(text\/(html|javascript)|application\/(javascript|x-javascript|x-sh|x-bat|x-msdownload|x-msdos-program|x-executable))(?:[;\s]|$)/i;
 
 /** Input to evaluateUpload. */
 export interface EvaluateUploadInput {


### PR DESCRIPTION
## PR #1 of 4 — Slice A: Foundation (media non-image file uploads)

Part of the **media-file-uploads** feature: extend the media library to accept and serve allowlisted non-image files (PDF by default), stored byte-for-byte in the same `public/uploads/YYYY/MM/` folder, without touching the image pipeline.

This is the **foundation slice** — pure, additive, zero runtime wiring. Feature-branch-chain: this PR targets the tracker branch `feat/media-file-uploads`; later PRs (B/C/D+E) stack on top.

### What's in this slice
- **`types/index.ts`** — `'file'` added to `PrimitivePropType`; `accept?` / `download?` on `PrimitivePropDef`; new `FileFieldValue` interface; optional `fileCategory?: 'image' | 'document'` on `MediaEntry`; `allowedFileTypes?: string[]` on `AstroBlocksOptions`.
- **`utils/file-types.ts`** (new) — `DEFAULT_ALLOWED_FILE_TYPES` (images + PDF), `RASTER_MIME`, `DOCUMENT_MIME_TO_EXT`, merged `MIME_TO_EXT`. Single source of truth.
- **`utils/upload-gate.ts`** (new) — `evaluateUpload()` with the locked evaluation order: denylist (MIME → ext) **always wins**, then allowlist membership. Hard denylist of dangerous types.
- **`utils/file-value.ts`** (new) — `FileFieldValue` parse/serialize helpers (mirrors `image-value.ts`) + `fileDownloadUrl()` (component-controlled `?download`).

### Tests
- New: `upload-gate.test.js`, `file-value.test.js`, `allowed-file-types.test.js`.
- **658 pass / 0 fail**, `typecheck` clean.
- Includes regression tests from a fresh review: `fileDownloadUrl` download-param false positives, `evaluateUpload` MIME case/param/extension edge cases.

### Deferred (by design)
Wiring `'file'` into runtime validation (`block-validation` `PRIMITIVE_TYPES`, contract `PROP_TYPES`, `validatePrimitiveValue` branch) lands in **Slice C** — no block declares a `file` prop until then, so the type/runtime split is inert in this slice.

### Out of scope
Backend upload/serve wiring (B), config bridge + validation (C), admin UI + playground (D/E).
