### PR TITLE
feat(media): Slice D+E — admin UI, file picker, DownloadButton playground

### DIFF
--- a/docs/media.md
+++ b/docs/media.md
@@ -231,6 +231,137 @@ The plugin injects a file-serving route at `/uploads/[...path]`. Do **not** crea
 | `variants` | `MediaVariant[]?` | Generated responsive variants: `{ format: 'webp' \| 'avif', width, url }` |
 | `status` | `'processing' \| 'ready' \| 'failed'?` | Variant generation status |
 
+---
+
+## Non-image file uploads (PDF and document support)
+
+### Allowed file types
+
+By default, AstroBlocks accepts uploads of these MIME types:
+
+```
+image/jpeg  image/png  image/webp  image/svg+xml  image/gif  application/pdf
+```
+
+You can override the list via the `allowedFileTypes` plugin option:
+
+```ts
+// astro.config.ts
+astroBlocks({
+  allowedFileTypes: ['image/jpeg', 'image/png', 'application/pdf'],
+})
+```
+
+**Rules:**
+
+- The list is deduplicated and lowercased automatically.
+- An explicitly empty array (`[]`) is accepted: every upload will be rejected (a warning is emitted).
+- The hard security denylist (HTML, JavaScript, executables, shell scripts) is **always enforced** regardless of this setting — those types can never be re-enabled.
+
+### The `file` block prop type
+
+Use `type: 'file'` for block props that hold non-image file references:
+
+```ts
+// YourComponent.schema.ts
+import { defineBlockSchema } from '@astroblocks/astro-blocks/contract';
+
+export const schema = defineBlockSchema(
+  {
+    name: 'Download Button',
+    icon: 'FileDown',
+    items: {
+      file: {
+        type: 'file',
+        label: 'PDF Document',
+        accept: ['application/pdf'],   // optional per-component MIME filter
+        download: true,                // optional: default download behaviour
+      },
+      label: { type: 'string', label: 'Button Label' },
+    },
+  },
+  new URL('./DownloadButton.astro', import.meta.url).href
+);
+```
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `accept` | `string[]` | Optional MIME allowlist for this prop. Must be a subset of `allowedFileTypes`; out-of-allowlist entries are silently dropped (warn-and-drop at startup). Omit to allow the full global allowlist. |
+| `download` | `boolean` | When `true`, the admin picker seeds `FileFieldValue.download = true`, which causes `fileDownloadUrl` to append `?download` to the URL, triggering `Content-Disposition: attachment` on the server. |
+
+### Rendering a file prop
+
+```astro
+---
+// DownloadButton.astro
+import { fileDownloadUrl } from '@astroblocks/astro-blocks/getFileValue';
+import type { FileFieldValue } from '@astroblocks/astro-blocks/contract';
+
+const { file, label = 'Download' } = Astro.props as { file?: FileFieldValue; label?: string };
+const href = file?.url ? fileDownloadUrl(file) : undefined;
+---
+
+{href && (
+  <a href={href} download={file?.download ? (file.filename ?? '') : undefined}>
+    {label}
+  </a>
+)}
+```
+
+**`fileDownloadUrl(value: FileFieldValue): string`** — resolves the URL for a file anchor:
+- When `value.download === true`: appends `?download` (server sets `Content-Disposition: attachment`).
+- When `value.download` is false or absent: returns `value.url` unchanged (browser-inline by default for PDF).
+
+```ts
+import { fileDownloadUrl } from '@astroblocks/astro-blocks/getFileValue';
+import type { FileFieldValue } from '@astroblocks/astro-blocks/contract';
+```
+
+### The `FileFieldValue` shape
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `url` | `string` | Public path to the uploaded file (e.g. `/uploads/2026/06/abcd-brochure.pdf`) |
+| `filename` | `string?` | Original filename as uploaded |
+| `mimeType` | `string?` | Validated MIME type |
+| `download` | `boolean?` | When `true`, `fileDownloadUrl` appends `?download` to force attachment |
+
+### PDF serving behaviour
+
+| Request | Content-Disposition |
+| --- | --- |
+| `GET /uploads/.../doc.pdf` | none (browser-inline by default) |
+| `GET /uploads/.../doc.pdf?download` | `attachment` |
+| `GET /uploads/.../image.svg` | `attachment` (XSS guard, unchanged) |
+| `GET /uploads/.../unknown.xyz` | none; `Content-Type: application/octet-stream` |
+
+### Security denylist
+
+The following types are **always rejected** regardless of `allowedFileTypes`:
+
+| MIME | Extension |
+| --- | --- |
+| `text/html` | `.html`, `.htm` |
+| `text/javascript`, `application/javascript`, `application/x-javascript` | `.js`, `.mjs` |
+| `application/x-sh`, `application/x-bat`, `application/x-executable` | `.sh`, `.bat`, `.cmd`, `.exe` |
+| `application/x-msdownload`, `application/x-msdos-program` | `.com` |
+
+The denylist check runs **before** the allowlist check. It cannot be disabled via configuration.
+
+### Document tiles in the media library
+
+Non-image uploads display an accessible document tile instead of a broken `<img>`. The tile:
+
+- Uses `role="img"` + `aria-label="<filename> (<mimeType> document)"` for screen readers.
+- Shows an inline document SVG icon marked `aria-hidden="true"`.
+- Shows the filename in the card name for sighted users (same as image cards).
+
+### Playground example
+
+See `playgrounds/basic/src/components/DownloadButton.astro` and `DownloadButton.schema.ts` for a working end-to-end example of the `file` prop type.
+
+---
+
 ### API endpoints
 
 All endpoints live under `/cms/api/` and require authentication (a valid CMS session token).
@@ -251,6 +382,7 @@ Uploads are validated **before** any disk write: the MIME type must be in the al
 | Setting | Default | Purpose |
 | --- | --- | --- |
 | `ASTRO_BLOCKS_MAX_UPLOAD_BYTES` | `5242880` (5 MB) | Maximum accepted upload size, in bytes. Set as an environment variable. |
+| `allowedFileTypes` (plugin option) | `['image/jpeg','image/png','image/webp','image/svg+xml','image/gif','application/pdf']` | MIME types accepted at upload. Override in the plugin config; see [Non-image file uploads](#non-image-file-uploads-pdf-and-document-support). |
 
 ---
 

--- a/meta/features.json
+++ b/meta/features.json
@@ -230,6 +230,16 @@
       "sinceVersion": "3.1.0",
       "updatedIn": "3.1.0",
       "docsPath": "#cms-routes"
+    },
+    {
+      "id": "non-image-file-uploads",
+      "title": "Non-image file uploads (PDF and document support)",
+      "summary": "Upload and serve non-image files such as PDFs alongside images. Configurable allowedFileTypes, hard security denylist, 'file' block prop type with per-component MIME accept and download flag, fileDownloadUrl helper, and accessible document tiles in the media library.",
+      "category": "media",
+      "status": "alpha",
+      "sinceVersion": "3.1.1",
+      "updatedIn": "3.1.1",
+      "docsPath": "docs/media.md"
     }
   ]
 }

--- a/playgrounds/basic/astro.config.mjs
+++ b/playgrounds/basic/astro.config.mjs
@@ -6,6 +6,7 @@ import { schema as contentListSchema } from './src/components/ContentList.schema
 import { schema as globalHeaderSchema } from './src/components/GlobalHeader.schema.ts';
 import { schema as globalFooterSchema } from './src/components/GlobalFooter.schema.ts';
 import { schema as mediaShowcaseSchema } from './src/components/MediaShowcase.schema.ts';
+import { schema as downloadButtonSchema } from './src/components/DownloadButton.schema.ts';
 
 export default defineConfig({
   output: 'static',
@@ -22,7 +23,7 @@ export default defineConfig({
   integrations: [
     astroBlocks({
       layoutPath: './src/layouts/Layout.astro',
-      blocks: [heroSchema, contentListSchema, mediaShowcaseSchema],
+      blocks: [heroSchema, contentListSchema, mediaShowcaseSchema, downloadButtonSchema],
       globalBlocks: [
         { slug: 'header-cta', schema: globalHeaderSchema, label: 'Header CTA' },
         { slug: 'footer-extra', schema: globalFooterSchema, label: 'Footer content' },

--- a/playgrounds/basic/src/components/DownloadButton.astro
+++ b/playgrounds/basic/src/components/DownloadButton.astro
@@ -1,0 +1,74 @@
+---
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * DownloadButton — demonstrates the 'file' prop type with download: true.
+ *
+ * When a PDF is picked via the admin block editor:
+ *   - file.download === true  → fileDownloadUrl appends ?download so the server
+ *     sets Content-Disposition: attachment (server-side enforcement).
+ *   - The HTML download attribute is the client-side hint (defense in depth).
+ *
+ * Manual verification steps:
+ *   1. Add a DownloadButton block in /cms/pages
+ *   2. Pick a PDF from the media library (or upload one)
+ *   3. The rendered anchor should trigger a download, not inline viewing
+ *   4. Inspect the network tab — the server response should carry
+ *      Content-Disposition: attachment when ?download is present
+ */
+
+import { fileDownloadUrl } from '@astroblocks/astro-blocks/getFileValue';
+import type { FileFieldValue } from '@astroblocks/astro-blocks/contract';
+
+export interface Props {
+  file?: FileFieldValue;
+  label?: string;
+}
+
+const { file, label = 'Download' } = Astro.props;
+
+// fileDownloadUrl returns value.url as-is when download is false/undefined,
+// and appends ?download when value.download === true.
+const href = file && file.url ? fileDownloadUrl(file) : undefined;
+// HTML download attribute: client-side hint (filename or empty string).
+// Only set when file.download is true (matches the prop schema meta).
+const downloadAttr = file?.download ? (file.filename ?? '') : undefined;
+---
+
+{href && (
+  <a
+    class="download-button"
+    href={href}
+    download={downloadAttr}
+  >
+    {label}
+  </a>
+)}
+
+<style>
+  .download-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.55rem 1.1rem;
+    background: var(--color-primary, #2C53B8);
+    color: #fff;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    text-decoration: none;
+    transition: background 120ms ease;
+  }
+
+  .download-button:hover {
+    background: color-mix(in srgb, var(--color-primary, #2C53B8) 85%, black);
+  }
+
+  .download-button:focus-visible {
+    outline: 2px solid var(--color-primary, #2C53B8);
+    outline-offset: 2px;
+  }
+</style>

--- a/playgrounds/basic/src/components/DownloadButton.schema.ts
+++ b/playgrounds/basic/src/components/DownloadButton.schema.ts
@@ -1,0 +1,18 @@
+import { defineBlockSchema } from '@astroblocks/astro-blocks/contract';
+
+export const schema = defineBlockSchema(
+  {
+    name: 'Download Button',
+    icon: 'FileDown',
+    items: {
+      file: {
+        type: 'file',
+        label: 'PDF File',
+        accept: ['application/pdf'],
+        download: true,
+      },
+      label: { type: 'string', label: 'Button Label' },
+    },
+  },
+  new URL('./DownloadButton.astro', import.meta.url).href
+);

--- a/routes/admin/client/block-form.ts
+++ b/routes/admin/client/block-form.ts
@@ -32,7 +32,7 @@ Licensed under the Business Source License 1.1
  */
 
 import Sortable, { type SortableEvent } from 'sortablejs';
-import type { ArrayPropDef, ImageFieldValue, ObjectArrayItemDef, PrimitivePropDef, PropDef } from '../../../types/index.js';
+import type { ArrayPropDef, FileFieldValue, ImageFieldValue, ObjectArrayItemDef, PrimitivePropDef, PropDef } from '../../../types/index.js';
 import {
   isObjectArrayItemDef,
   isPrimitivePropDef,
@@ -41,8 +41,10 @@ import { isSchemaPropLocalizable } from '../../../utils/localization.js';
 import { escapeHtml, getActiveContentLocale, getCmsToken } from './common.js';
 import { ct } from '../i18n/client.js';
 import { toImageValue, parseImageValue, mediaEntryToImageValue, serializeImageValueAttr } from '../../../utils/image-value.js';
+import { toFileValue, parseFileValue, mediaEntryToFileValue, serializeFileValueAttr, isEmptyFileValue } from '../../../utils/file-value.js';
 import { fetchMedia, formatBytes, formatDimensions, formatMediaDate } from './media-fetch.js';
 import type { MediaEntry as MediaFetchEntry } from './media-fetch.js';
+import { DEFAULT_ALLOWED_FILE_TYPES } from '../../../utils/file-types.js';
 
 // SVG icons (same as page-editor.ts and global-blocks-editor.ts)
 const trashIconSvg =
@@ -58,6 +60,12 @@ const xIconSvg =
 
 let pickerDialog: HTMLDialogElement | null = null;
 let activePickerInputId: string | null = null;
+// 'image' | 'file' — set when the picker dialog is opened so renderPickerGrid
+// and the grid's selection handler know which selectPicker* to call.
+let activePickerMode: 'image' | 'file' = 'image';
+// When picker mode is 'file', the effective MIME types the picker grid should
+// show. An empty array means "no restriction" (show all). Set on open.
+let activePickerAccept: string[] = [];
 
 // Re-alias the imported type so existing picker code can use 'MediaEntry' name unchanged
 type MediaEntry = MediaFetchEntry;
@@ -313,6 +321,29 @@ function updateImageFieldDom(hiddenInput: HTMLInputElement, url: string): void {
 }
 
 /**
+ * Update a file field's visible DOM IN PLACE to reflect the new value.
+ * Mirror of updateImageFieldDom for the 'file' prop type.
+ */
+function updateFileFieldDom(hiddenInput: HTMLInputElement, value: FileFieldValue): void {
+  const field = hiddenInput.closest<HTMLElement>('.cms-file-field');
+  if (!field) return;
+  const hasValue = !isEmptyFileValue(value);
+  const displayName = hasValue ? (value.filename ?? imageFilenameFromUrl(value.url)) : '';
+  field.classList.toggle('cms-file-field--has-value', hasValue);
+
+  const nameEl = field.querySelector<HTMLElement>('.cms-file-field-name');
+  if (nameEl) {
+    nameEl.classList.toggle('cms-file-field-name--empty', !hasValue);
+    nameEl.textContent = hasValue ? displayName : 'No file selected';
+    if (hasValue) nameEl.setAttribute('title', displayName);
+    else nameEl.removeAttribute('title');
+  }
+
+  const chooseLabel = field.querySelector<HTMLElement>('[data-file-choose-label]');
+  if (chooseLabel) chooseLabel.textContent = hasValue ? 'Replace' : 'Choose file';
+}
+
+/**
  * Seed the visible alt-override input for an image field from the current hidden-input JSON.
  * Reads parseImageValue(hidden.value).alt and sets the alt input value.
  */
@@ -366,6 +397,23 @@ function selectPickerImage(value: ImageFieldValue): void {
   closePickerDialog();
 }
 
+/**
+ * Select a file-field entry from the picker dialog.
+ * Mirror of selectPickerImage for the 'file' prop type (ADR-3).
+ * Writes the serialized FileFieldValue into the hidden input and closes the dialog.
+ */
+function selectPickerFile(value: FileFieldValue): void {
+  if (!activePickerInputId) return;
+  const hiddenInput = document.getElementById(activePickerInputId) as HTMLInputElement | null;
+  if (hiddenInput) {
+    hiddenInput.value = JSON.stringify(value);
+    updateFileFieldDom(hiddenInput, value);
+    hiddenInput.dispatchEvent(new Event('input', { bubbles: true }));
+    hiddenInput.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+  closePickerDialog();
+}
+
 // ─── Picker state (per dialog open) ─────────────────────────────────────────
 
 interface PickerState {
@@ -387,13 +435,21 @@ function renderPickerItem(entry: MediaEntry): string {
   const metaDims = dims !== '—' ? `<span class="cms-media-picker-meta-dim">${escapePickerHtml(dims)}</span><span class="cms-media-picker-meta-sep" aria-hidden="true">·</span>` : '';
   const metaRow = `<span class="cms-media-picker-meta cms-muted">${metaDims}<span class="cms-media-picker-meta-size">${escapePickerHtml(formatBytes(entry.size))}</span><span class="cms-media-picker-meta-sep" aria-hidden="true">·</span><span class="cms-media-picker-meta-type">${escapePickerHtml(entry.mimeType)}</span><span class="cms-media-picker-meta-sep" aria-hidden="true">·</span><span class="cms-media-picker-meta-date">${escapePickerHtml(formatMediaDate(entry.createdAt))}</span></span>`;
 
+  // For image entries: show <img> thumbnail. For document entries: show accessible doc tile.
+  const isDocEntry = !(entry as MediaEntry & { fileCategory?: string }).mimeType.startsWith('image/');
+  const thumbHtml = isDocEntry
+    ? `<div class="cms-media-picker-img cms-media-picker-doc-thumb" role="img" aria-label="${escapePickerHtml(entry.filename)}" aria-hidden="false"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg></div>`
+    : `<img src="${escapePickerHtml(entry.url)}" alt="${escapePickerHtml(entry.filename)}" class="cms-media-picker-img" loading="lazy" />`;
+
   return `<button type="button" class="cms-media-picker-item"
     data-picker-url="${escapePickerHtml(entry.url)}"
     data-picker-alt="${escapePickerHtml(entry.alt ?? '')}"
+    data-picker-mime="${escapePickerHtml(entry.mimeType)}"
+    data-picker-filename="${escapePickerHtml(entry.filename)}"
     ${entry.width !== undefined ? `data-picker-width="${entry.width}"` : ''}
     ${entry.height !== undefined ? `data-picker-height="${entry.height}"` : ''}
     aria-label="${escapePickerHtml(ct('blockForm.pickerSelectAriaLabel', { filename: entry.filename }))}">
-    <img src="${escapePickerHtml(entry.url)}" alt="${escapePickerHtml(entry.filename)}" class="cms-media-picker-img" loading="lazy" />
+    ${thumbHtml}
     <span class="cms-media-picker-name">${escapePickerHtml(entry.filename)}</span>
     ${metaRow}
   </button>`;
@@ -404,33 +460,59 @@ function renderPickerItem(entry: MediaEntry): string {
  * The search input and upload section live in separate stable containers
  * that this function does NOT touch — preventing the "search goes dead"
  * bug where innerHTML-replacement destroyed the bound event listener.
+ *
+ * In 'file' picker mode, entries are filtered to those whose mimeType is in
+ * activePickerAccept (the effectiveAccept for the field). In 'image' mode all
+ * entries are shown (existing behavior — no change).
  */
 function renderPickerGrid(gridContainer: HTMLElement, uploadSection: string): void {
   const { items, total } = pickerState;
+
+  // Filter entries for file-mode picks: only show entries whose mimeType is in effectiveAccept.
+  // Image-mode shows all entries (existing behavior unchanged).
+  const visibleItems = activePickerMode === 'file' && activePickerAccept.length > 0
+    ? items.filter((e) => activePickerAccept.includes(e.mimeType.toLowerCase()))
+    : items;
+
   const allLoaded = items.length >= total;
   const countText = total > 0
-    ? ct('blockForm.pickerCountOf', { shown: String(items.length), total: String(total) })
+    ? ct('blockForm.pickerCountOf', { shown: String(visibleItems.length), total: String(total) })
     : ct('blockForm.pickerCount0');
 
   const countRegion = `<p role="status" aria-live="polite" class="cms-media-picker-count cms-muted">${escapePickerHtml(countText)}</p>`;
 
-  if (items.length === 0) {
+  if (visibleItems.length === 0) {
     gridContainer.innerHTML = `${countRegion}<p class="cms-muted cms-media-picker-empty">${escapePickerHtml(ct('blockForm.pickerEmpty'))}</p>`;
     return;
   }
 
-  const gridItems = items.map(renderPickerItem).join('');
+  const gridItems = visibleItems.map(renderPickerItem).join('');
   const loadMoreBtn = allLoaded
     ? ''
     : `<button type="button" id="cms-picker-load-more" class="cms-btn cms-btn-secondary cms-media-picker-load-more">${escapePickerHtml(ct('blockForm.pickerLoadMore'))}</button>`;
 
   gridContainer.innerHTML = `${countRegion}<div class="cms-media-picker-grid">${gridItems}</div>${loadMoreBtn}`;
 
-  // Bind selection clicks
+  // Bind selection clicks — branch on picker mode to call the right selectPicker* handler.
   gridContainer.querySelectorAll<HTMLButtonElement>('[data-picker-url]').forEach((item) => {
     item.addEventListener('click', () => {
       const url = item.dataset.pickerUrl ?? '';
       if (!url) return;
+
+      if (activePickerMode === 'file') {
+        // File pick: build a FileFieldValue from the entry's data attributes.
+        const mimeType = item.dataset.pickerMime ?? '';
+        const filename = item.dataset.pickerFilename ?? '';
+        // The schema-level download default is not available here — it was seeded
+        // into the def at render time. We preserve whatever download flag was in
+        // the hidden input (set from def.download when the field was rendered);
+        // just pick the file metadata without overriding the download flag.
+        const fileValue: FileFieldValue = { url, mimeType: mimeType || undefined, filename: filename || undefined };
+        selectPickerFile(fileValue);
+        return;
+      }
+
+      // Image pick (unchanged behavior):
       const alt = item.dataset.pickerAlt ?? '';
       const w = item.dataset.pickerWidth !== undefined ? Math.floor(Number(item.dataset.pickerWidth)) : undefined;
       const h = item.dataset.pickerHeight !== undefined ? Math.floor(Number(item.dataset.pickerHeight)) : undefined;
@@ -473,11 +555,18 @@ async function pickerLoadPage(gridContainer: HTMLElement, uploadSection: string,
   renderPickerGrid(gridContainer, uploadSection);
 }
 
-async function openPickerDialog(triggerBtn: HTMLButtonElement, inputId: string): Promise<void> {
+async function openPickerDialog(
+  triggerBtn: HTMLButtonElement,
+  inputId: string,
+  mode: 'image' | 'file' = 'image',
+  effectiveAccept: string[] = [],
+): Promise<void> {
   if (!pickerDialog) mountPickerDialog();
   if (!pickerDialog) return;
 
   activePickerInputId = inputId;
+  activePickerMode = mode;
+  activePickerAccept = effectiveAccept;
 
   // Reset picker state for fresh open.
   // pickerReqSeq is NOT reset here — it is monotonically increasing (module-level).
@@ -514,12 +603,19 @@ async function openPickerDialog(triggerBtn: HTMLButtonElement, inputId: string):
     </div>
   `;
 
+  // Determine the accept attribute for the upload input inside the picker.
+  // Image mode: restrict to image/* (existing behavior).
+  // File mode: use the effectiveAccept for this field (joined MIME list) or fall back to '*/*'.
+  const pickerUploadAccept = mode === 'file'
+    ? (effectiveAccept.length > 0 ? effectiveAccept.join(',') : '*/*')
+    : 'image/*';
+
   // Render upload section into its stable zone
   uploadContainer.innerHTML = `
     <div class="cms-media-picker-upload">
       <span class="cms-media-picker-upload-label" id="cms-picker-upload-label">${escapePickerHtml(ct('blockForm.pickerUploadLabel'))}</span>
       <div class="cms-media-picker-upload-row">
-        <input type="file" id="cms-picker-file-input" accept="image/*" class="cms-media-picker-file-input" aria-labelledby="cms-picker-upload-label" />
+        <input type="file" id="cms-picker-file-input" accept="${escapePickerHtml(pickerUploadAccept)}" class="cms-media-picker-file-input" aria-labelledby="cms-picker-upload-label" />
         <button type="button" id="cms-picker-choose-btn" class="cms-btn cms-btn-secondary" aria-controls="cms-picker-file-input">${escapePickerHtml(ct('blockForm.pickerChooseFile'))}</button>
         <span class="cms-media-picker-filename" id="cms-picker-filename" aria-live="polite">${escapePickerHtml(ct('blockForm.pickerNoFileSelected'))}</span>
         <button type="button" id="cms-picker-upload-btn" class="cms-btn cms-btn-primary" disabled>${escapePickerHtml(ct('blockForm.pickerUpload'))}</button>
@@ -584,10 +680,19 @@ async function openPickerDialog(triggerBtn: HTMLButtonElement, inputId: string):
           const uploadBody = await uploadRes.json() as { url?: string; entry?: MediaEntry };
           if (uploadBody.url) {
             const entry = uploadBody.entry;
-            const value: ImageFieldValue = entry
-              ? mediaEntryToImageValue(entry)
-              : { url: uploadBody.url, alt: '' };
-            selectPickerImage(value);
+            if (activePickerMode === 'file') {
+              // File-mode upload: produce a FileFieldValue from the entry.
+              const fileValue: FileFieldValue = entry
+                ? mediaEntryToFileValue(entry)
+                : { url: uploadBody.url };
+              selectPickerFile(fileValue);
+            } else {
+              // Image-mode upload (unchanged behavior):
+              const value: ImageFieldValue = entry
+                ? mediaEntryToImageValue(entry)
+                : { url: uploadBody.url, alt: '' };
+              selectPickerImage(value);
+            }
           }
         }
       } finally {
@@ -690,6 +795,10 @@ function parseFieldValue(input: HTMLInputElement | HTMLTextAreaElement | HTMLSel
   if (input instanceof HTMLInputElement && input.dataset.imageValue !== undefined) {
     return parseImageValue(input.value);
   }
+  // File field: hidden input carries JSON FileFieldValue (marked with data-file-value)
+  if (input instanceof HTMLInputElement && input.dataset.fileValue !== undefined) {
+    return parseFileValue(input.value);
+  }
   return input.value;
 }
 
@@ -697,6 +806,8 @@ function defaultPrimitiveValue(def: PrimitivePropDef): unknown {
   if (def.type === 'boolean') return false;
   if (def.type === 'number') return '';
   if (def.type === 'select') return Array.isArray(def.options) && def.options.length > 0 ? def.options[0] : '';
+  if (def.type === 'file') return { url: '' };
+  if (def.type === 'image') return { url: '', alt: '' };
   return '';
 }
 
@@ -790,6 +901,86 @@ function imageFieldHtml(
   );
 }
 
+// ─── Global allowlist (for file-prop effectiveAccept) ────────────────────────
+// Read once at module load; falls back to DEFAULT_ALLOWED_FILE_TYPES when the
+// vite.define env var is absent (e.g. no build or test context).
+let _globalAllowlist: string[] | null = null;
+
+function getGlobalAllowlist(): string[] {
+  if (_globalAllowlist) return _globalAllowlist;
+  // import.meta.env.ASTRO_BLOCKS_ALLOWED_FILE_TYPES is injected by vite.define at build time.
+  // Casting through unknown avoids TS complaints about the ImportMeta type not having
+  // an index signature — this is safe because vite.define replaces the literal at build time.
+  const metaEnv = (import.meta as unknown as { env?: Record<string, unknown> }).env ?? {};
+  const raw: string = (metaEnv.ASTRO_BLOCKS_ALLOWED_FILE_TYPES as string) ?? '';
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        _globalAllowlist = parsed as string[];
+        return _globalAllowlist;
+      }
+    } catch { /* ignore */ }
+  }
+  _globalAllowlist = DEFAULT_ALLOWED_FILE_TYPES;
+  return _globalAllowlist;
+}
+
+/**
+ * Compute the effectiveAccept for a file field:
+ *   - If def.accept is provided: intersection with global allowlist (warn-and-drop per ADR-6)
+ *   - If def.accept is omitted: full global allowlist
+ *
+ * This is the client-side enforcement of the accept ∩ allowlist rule.
+ */
+function computeEffectiveAccept(def: PrimitivePropDef): string[] {
+  const globalAllowlist = getGlobalAllowlist();
+  if (!def.accept || def.accept.length === 0) return globalAllowlist;
+  return def.accept.filter((m) => globalAllowlist.includes(m.toLowerCase()));
+}
+
+// Icon for file fields (document)
+const filePickerIconSvg =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>';
+
+/**
+ * Render a file field as a compact horizontal control (mirrors imageFieldHtml).
+ *
+ * The hidden input carries the full JSON-serialized FileFieldValue.
+ * Data attributes on the choose button carry the effectiveAccept so the
+ * openPickerDialog call can enforce the accept ∩ allowlist at render time.
+ */
+function fileFieldHtml(
+  id: string,
+  attrs: string,
+  value: FileFieldValue,
+  effectiveAccept: string[],
+): string {
+  const hasValue = !isEmptyFileValue(value);
+  const displayName = hasValue ? (value.filename ?? imageFilenameFromUrl(value.url)) : '';
+  const stateClass = hasValue ? ' cms-file-field--has-value' : '';
+  const nameHtml = hasValue
+    ? `<span class="cms-file-field-name" title="${escapePickerHtml(displayName)}">${escapeHtml(displayName)}</span>`
+    : `<span class="cms-file-field-name cms-file-field-name--empty">No file selected</span>`;
+  const chooseLabel = hasValue ? 'Replace' : 'Choose file';
+  // Serialize effectiveAccept as a JSON string in a data attribute so the picker
+  // click handler can recover it without keeping additional module-level state per field.
+  const acceptAttr = escapePickerHtml(JSON.stringify(effectiveAccept));
+
+  return (
+    `<div class="cms-file-field${stateClass}" data-file-field="${escapePickerHtml(id)}">` +
+    `<input type="text" id="${id}" ${attrs} class="cms-media-value cms-hidden" value="${serializeFileValueAttr(value)}" tabindex="-1" aria-hidden="true" data-file-value="1">` +
+    `<div class="cms-file-field-detail">` +
+    nameHtml +
+    `<div class="cms-file-field-actions">` +
+    `<button type="button" class="cms-btn cms-btn-secondary cms-file-field-choose" data-file-picker-for="${escapePickerHtml(id)}" data-file-accept="${acceptAttr}" aria-label="Choose file">${filePickerIconSvg}<span data-file-choose-label>${escapeHtml(chooseLabel)}</span></button>` +
+    `<button type="button" class="cms-btn cms-btn-secondary cms-file-field-clear" data-file-picker-clear="${escapePickerHtml(id)}" aria-label="Clear file">Clear</button>` +
+    `</div>` +
+    `</div>` +
+    `</div>`
+  );
+}
+
 function primitiveInputHtml(def: PrimitivePropDef, value: unknown, id: string, attrs: string, rows = 2): string {
   if (def.type === 'text') {
     return `<textarea id="${id}" ${attrs} class="cms-input" rows="${rows}">${escapeHtml(String(value ?? ''))}</textarea>`;
@@ -812,6 +1003,13 @@ function primitiveInputHtml(def: PrimitivePropDef, value: unknown, id: string, a
     // the root) so selectPickerImage / Clear can update it IN PLACE without a full re-render.
     const imageValue = toImageValue(value);
     return imageFieldHtml(id, attrs, imageValue, isSchemaPropLocalizable(def));
+  }
+  if (def.type === 'file') {
+    // ADDITIVE branch — does NOT touch the image path above.
+    // Compute effectiveAccept: def.accept ∩ globalAllowlist (or full global if omitted).
+    const effectiveAccept = computeEffectiveAccept(def);
+    const fileValue = toFileValue(value);
+    return fileFieldHtml(id, attrs, fileValue, effectiveAccept);
   }
   const textValue = typeof value === 'string' ? value : String(value ?? '');
   return `<input type="text" id="${id}" ${attrs} class="cms-input" value="${escapePickerHtml(textValue)}">`;
@@ -1179,7 +1377,7 @@ export function mountBlockForm(options: BlockFormOptions): BlockFormHandle {
       btn.addEventListener('click', () => {
         const inputId = btn.dataset.pickerFor;
         if (!inputId) return;
-        openPickerDialog(btn, inputId).catch(() => { /* no-op */ });
+        openPickerDialog(btn, inputId, 'image', []).catch(() => { /* no-op */ });
       });
     });
 
@@ -1195,6 +1393,38 @@ export function mountBlockForm(options: BlockFormOptions): BlockFormHandle {
           updateImageFieldDom(hiddenInput, '');
           seedAltInput(hiddenInput, '');
           seedCaptionInput(hiddenInput, '');
+          hiddenInput.dispatchEvent(new Event('input', { bubbles: true }));
+          hiddenInput.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+      });
+    });
+
+    // File field — "Choose file" button opens the picker dialog in file mode
+    container.querySelectorAll<HTMLButtonElement>('[data-file-picker-for]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const inputId = btn.dataset.filePickerFor;
+        if (!inputId) return;
+        // Recover effectiveAccept from the data-file-accept attribute (set at render time)
+        let effectiveAccept: string[] = [];
+        try {
+          const raw = btn.dataset.fileAccept ?? '[]';
+          const parsed = JSON.parse(raw) as unknown;
+          if (Array.isArray(parsed)) effectiveAccept = parsed as string[];
+        } catch { /* ignore */ }
+        openPickerDialog(btn, inputId, 'file', effectiveAccept).catch(() => { /* no-op */ });
+      });
+    });
+
+    // File field — "Clear" button resets value to empty
+    container.querySelectorAll<HTMLButtonElement>('[data-file-picker-clear]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const inputId = btn.dataset.filePickerClear;
+        if (!inputId) return;
+        const hiddenInput = container.querySelector<HTMLInputElement>(`#${CSS.escape(inputId)}`);
+        if (hiddenInput) {
+          const emptyValue: FileFieldValue = { url: '' };
+          hiddenInput.value = JSON.stringify(emptyValue);
+          updateFileFieldDom(hiddenInput, emptyValue);
           hiddenInput.dispatchEvent(new Event('input', { bubbles: true }));
           hiddenInput.dispatchEvent(new Event('change', { bubbles: true }));
         }

--- a/routes/admin/client/block-form.ts
+++ b/routes/admin/client/block-form.ts
@@ -44,7 +44,7 @@ import { toImageValue, parseImageValue, mediaEntryToImageValue, serializeImageVa
 import { toFileValue, parseFileValue, mediaEntryToFileValue, serializeFileValueAttr, isEmptyFileValue } from '../../../utils/file-value.js';
 import { fetchMedia, formatBytes, formatDimensions, formatMediaDate } from './media-fetch.js';
 import type { MediaEntry as MediaFetchEntry } from './media-fetch.js';
-import { DEFAULT_ALLOWED_FILE_TYPES } from '../../../utils/file-types.js';
+import { DEFAULT_ALLOWED_FILE_TYPES, intersectAccept } from '../../../utils/file-types.js';
 
 // SVG icons (same as page-editor.ts and global-blocks-editor.ts)
 const trashIconSvg =
@@ -931,12 +931,14 @@ function getGlobalAllowlist(): string[] {
  *   - If def.accept is provided: intersection with global allowlist (warn-and-drop per ADR-6)
  *   - If def.accept is omitted: full global allowlist
  *
- * This is the client-side enforcement of the accept ∩ allowlist rule.
+ * Delegates to intersectAccept() which normalises both sides to lowercase, so
+ * mixed-case schema entries like `'Application/PDF'` are correctly matched
+ * against the lowercase global allowlist. The returned values are always
+ * lowercase, ensuring consistent comparison in renderPickerGrid and in the
+ * data-file-accept attribute.
  */
 function computeEffectiveAccept(def: PrimitivePropDef): string[] {
-  const globalAllowlist = getGlobalAllowlist();
-  if (!def.accept || def.accept.length === 0) return globalAllowlist;
-  return def.accept.filter((m) => globalAllowlist.includes(m.toLowerCase()));
+  return intersectAccept(def.accept, getGlobalAllowlist());
 }
 
 // Icon for file fields (document)

--- a/routes/admin/client/media.ts
+++ b/routes/admin/client/media.ts
@@ -46,6 +46,10 @@ function escapeAttr(s: string): string {
   return s.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
+// Document SVG icon — rendered inside accessible document tiles (aria-hidden).
+const docIconSvg =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" class="cms-media-doc-icon"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>';
+
 function renderCard(entry: MediaEntry): string {
   const dims = formatDimensions(entry.width, entry.height);
   const metaDims = dims !== '—' ? `<span class="cms-media-card-meta-dim">${escapeHtml(dims)}</span><span class="cms-media-card-meta-sep" aria-hidden="true">·</span>` : '';
@@ -58,11 +62,23 @@ function renderCard(entry: MediaEntry): string {
   const deleteLbl = escapeAttr(`${ct('media.deleteLabel')} ${entry.filename}`);
   const altPlaceholder = escapeAttr(ct('media.altPlaceholder'));
 
+  // Determine whether this entry is an image or a document file.
+  // Prefer the stored fileCategory field (set by the backend since Slice B);
+  // fall back to MIME-type derivation for any legacy entries loaded without it.
+  const isDocument = (entry as MediaEntry & { fileCategory?: string }).fileCategory === 'document'
+    || (!(entry as MediaEntry & { fileCategory?: string }).fileCategory && !entry.mimeType.startsWith('image/'));
+
+  // Thumbnail section: <img> for images, accessible document tile for non-images.
+  // Per accessibility skill (WCAG 1.1 text alternatives):
+  //   - The decorative icon carries aria-hidden="true"
+  //   - The container carries role="img" + descriptive aria-label
+  const thumbHtml = isDocument
+    ? `<div class="cms-media-card-thumb cms-media-card-thumb--doc" role="img" aria-label="${escapeAttr(entry.filename)} (${escapeAttr(entry.mimeType)} document)">${docIconSvg}</div>`
+    : `<div class="cms-media-card-thumb"><img src="${escapeAttr(entry.url)}" alt="${escapeAttr(entry.filename)}" class="cms-media-card-img" loading="lazy" /></div>`;
+
   return `
     <div class="cms-media-card" role="listitem" data-media-url="${escapeAttr(entry.url)}" data-media-id="${escapeAttr(entry.id)}">
-      <div class="cms-media-card-thumb">
-        <img src="${escapeAttr(entry.url)}" alt="${escapeAttr(entry.filename)}" class="cms-media-card-img" loading="lazy" />
-      </div>
+      ${thumbHtml}
       <div class="cms-media-card-info">
         <span class="cms-media-card-name" title="${escapeAttr(entry.filename)}">${escapeHtml(entry.filename)}</span>
         ${metaRow}

--- a/routes/admin/media.astro
+++ b/routes/admin/media.astro
@@ -11,6 +11,22 @@ import { Image as ImageIcon } from '@lucide/astro';
 import { loadMedia, loadSite } from '../../api/data.js';
 import { resolveUiLocale } from './i18n/resolve.js';
 import { createT } from './i18n/t.js';
+import { DEFAULT_ALLOWED_FILE_TYPES } from '../../utils/file-types.js';
+
+// Build the dynamic accept attribute for the upload dropzone.
+// Reads the global allowlist injected by vite.define at build time;
+// falls back to DEFAULT_ALLOWED_FILE_TYPES when the env var is absent (dev/test).
+const _rawAllowedTypes: string = import.meta.env.ASTRO_BLOCKS_ALLOWED_FILE_TYPES ?? '';
+const _parsedAllowedTypes: string[] = (() => {
+  if (_rawAllowedTypes) {
+    try {
+      const parsed = JSON.parse(_rawAllowedTypes) as unknown;
+      if (Array.isArray(parsed) && parsed.length > 0) return parsed as string[];
+    } catch { /* ignore */ }
+  }
+  return DEFAULT_ALLOWED_FILE_TYPES;
+})();
+const uploadAccept = _parsedAllowedTypes.join(',');
 
 const site = await loadSite();
 const mediaData = await loadMedia();
@@ -85,7 +101,7 @@ function formatMediaDate(isoString: string): string {
         <input
           type="file"
           id="cms-media-file-input"
-          accept="image/*"
+          accept={uploadAccept}
           class="cms-hidden"
           aria-label={t('media.fileInputAriaLabel')}
           multiple
@@ -125,16 +141,30 @@ function formatMediaDate(isoString: string): string {
         </div>
       ) : (
         <div id="cms-media-grid" class="cms-media-grid" aria-label={t('media.imageLibraryAriaLabel')} role="list">
-          {uploads.map((entry) => (
+          {uploads.map((entry) => {
+            // Prefer the stored fileCategory field (Slice B); derive from MIME for legacy entries.
+            const isDocument = (entry as typeof entry & { fileCategory?: string }).fileCategory === 'document'
+              || (!(entry as typeof entry & { fileCategory?: string }).fileCategory && !entry.mimeType.startsWith('image/'));
+            return (
             <div class="cms-media-card" role="listitem" data-media-url={entry.url} data-media-id={entry.id}>
-              <div class="cms-media-card-thumb">
-                <img
-                  src={entry.url}
-                  alt={entry.filename}
-                  class="cms-media-card-img"
-                  loading="lazy"
-                />
-              </div>
+              {isDocument ? (
+                <div
+                  class="cms-media-card-thumb cms-media-card-thumb--doc"
+                  role="img"
+                  aria-label={`${entry.filename} (${entry.mimeType} document)`}
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" class="cms-media-doc-icon"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
+                </div>
+              ) : (
+                <div class="cms-media-card-thumb">
+                  <img
+                    src={entry.url}
+                    alt={entry.filename}
+                    class="cms-media-card-img"
+                    loading="lazy"
+                  />
+                </div>
+              )}
               <div class="cms-media-card-info">
                 <span class="cms-media-card-name" title={entry.filename}>{entry.filename}</span>
                 <div class="cms-media-card-meta cms-muted" aria-label={t('media.imageMetaAriaLabel')}>
@@ -175,7 +205,7 @@ function formatMediaDate(isoString: string): string {
                 </button>
               </div>
             </div>
-          ))}
+          ); })}
         </div>
       )}
     </div>

--- a/styles/cms-admin.css
+++ b/styles/cms-admin.css
@@ -4406,6 +4406,69 @@ Licensed under the Business Source License 1.1
   display: none;
 }
 
+/* ─── File field (mirrors image-field; no image preview) ────────────────────── */
+/* A compact horizontal control for 'file' type block props. The hidden input
+   carries a JSON-serialized FileFieldValue (same pattern as image). */
+
+.cms-file-field {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0;
+}
+
+.cms-file-field-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.cms-file-field-name {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--cms-text-strong, #111827);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cms-file-field-name--empty {
+  color: var(--cms-text-muted, #6b7280);
+  font-weight: 400;
+}
+
+.cms-file-field-actions {
+  display: flex;
+  gap: 0.375rem;
+  flex-wrap: wrap;
+}
+
+.cms-file-field-choose,
+.cms-file-field-clear {
+  font-size: 0.78rem;
+  padding: 0.25rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+/* Clear is hidden until a value is selected */
+.cms-file-field:not(.cms-file-field--has-value) .cms-file-field-clear {
+  display: none;
+}
+
+/* Picker doc thumb (for non-image entries in the picker grid) */
+.cms-media-picker-doc-thumb {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--cms-surface-alt, #f7f8fc);
+  color: var(--cms-text-muted, #6b7280);
+  opacity: 0.75;
+}
+
 /* ─── Media page ────────────────────────────────────────────────────────────── */
 /* Source of truth for the /cms/media asset grid. Cards mirror .cms-card so the
    library reads as discrete, tokenized tiles (never a fused 1px-separator grid). */
@@ -4477,6 +4540,19 @@ Licensed under the Business Source License 1.1
   height: 100%;
   object-fit: cover;
   display: block;
+}
+
+/* Document tile: accessible placeholder shown instead of a broken <img>
+   for non-image entries (PDFs, etc.). Role and aria-label are set in JS. */
+.cms-media-card-thumb--doc {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--cms-text-muted, #6b7280);
+}
+
+.cms-media-doc-icon {
+  opacity: 0.55;
 }
 
 .cms-media-card-info {

--- a/tests/allowed-file-types.test.js
+++ b/tests/allowed-file-types.test.js
@@ -16,7 +16,7 @@ Licensed under the Business Source License 1.1
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { DEFAULT_ALLOWED_FILE_TYPES, RASTER_MIME, DOCUMENT_MIME_TO_EXT, MIME_TO_EXT } from '../dist/utils/file-types.js';
+import { DEFAULT_ALLOWED_FILE_TYPES, RASTER_MIME, DOCUMENT_MIME_TO_EXT, MIME_TO_EXT, intersectAccept } from '../dist/utils/file-types.js';
 
 // ─── R1.1-A: DEFAULT_ALLOWED_FILE_TYPES export is correct ────────────────────
 
@@ -164,4 +164,38 @@ test('R1.5-A: getAllowedFileTypes falls back to DEFAULT_ALLOWED_FILE_TYPES when 
     else process.env.ASTRO_BLOCKS_PROJECT_ROOT = previousRoot;
     await rm(tempRoot, { recursive: true, force: true });
   }
+});
+
+// ─── intersectAccept — case-insensitive accept intersection ───────────────────
+
+const ALLOWLIST = ['application/pdf', 'image/jpeg', 'image/png'];
+
+test('intersectAccept: mixed-case accept entry is lowercased and matched', () => {
+  const result = intersectAccept(['Application/PDF'], ALLOWLIST);
+  assert.deepEqual(result, ['application/pdf']);
+});
+
+test('intersectAccept: all-lowercase accept entry is passed through unchanged', () => {
+  const result = intersectAccept(['image/jpeg', 'application/pdf'], ALLOWLIST);
+  assert.deepEqual(result, ['image/jpeg', 'application/pdf']);
+});
+
+test('intersectAccept: accept entry not in allowlist is excluded', () => {
+  const result = intersectAccept(['application/pdf', 'video/mp4'], ALLOWLIST);
+  assert.deepEqual(result, ['application/pdf']);
+});
+
+test('intersectAccept: all accept entries out of allowlist returns empty array', () => {
+  const result = intersectAccept(['video/mp4', 'text/plain'], ALLOWLIST);
+  assert.deepEqual(result, []);
+});
+
+test('intersectAccept: omitted accept (undefined) returns full allowlist', () => {
+  const result = intersectAccept(undefined, ALLOWLIST);
+  assert.deepEqual(result, ALLOWLIST);
+});
+
+test('intersectAccept: empty accept array returns full allowlist', () => {
+  const result = intersectAccept([], ALLOWLIST);
+  assert.deepEqual(result, ALLOWLIST);
 });

--- a/tests/download-button-playground.test.js
+++ b/tests/download-button-playground.test.js
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * tests/download-button-playground.test.js
+ *
+ * Structural tests for the DownloadButton playground component (Slice E).
+ * Spec: R9.1-A, R9.2-A — file-existence and schema-declaration checks.
+ *
+ * No build needed — these are synchronous fs assertions on source files.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const COMPONENTS_DIR = path.join(ROOT, 'playgrounds', 'basic', 'src', 'components');
+
+// ─── R9.1-A — DownloadButton.astro exists ────────────────────────────────────
+
+test('R9.1-A: DownloadButton.astro exists in playground components', () => {
+  const filePath = path.join(COMPONENTS_DIR, 'DownloadButton.astro');
+  assert.ok(
+    fs.existsSync(filePath),
+    `Expected file to exist: ${filePath}`,
+  );
+});
+
+// ─── R9.2-A — DownloadButton.schema.ts exists and has correct declarations ───
+
+test('R9.2-A: DownloadButton.schema.ts exists in playground components', () => {
+  const filePath = path.join(COMPONENTS_DIR, 'DownloadButton.schema.ts');
+  assert.ok(
+    fs.existsSync(filePath),
+    `Expected file to exist: ${filePath}`,
+  );
+});
+
+test("R9.2-A: DownloadButton.schema.ts declares a prop with type 'file'", () => {
+  const filePath = path.join(COMPONENTS_DIR, 'DownloadButton.schema.ts');
+  const content = fs.readFileSync(filePath, 'utf-8');
+  assert.match(
+    content,
+    /type:\s*['"]file['"]/,
+    "Schema should contain type: 'file' declaration",
+  );
+});
+
+test("R9.2-A: DownloadButton.schema.ts includes 'application/pdf' in accept", () => {
+  const filePath = path.join(COMPONENTS_DIR, 'DownloadButton.schema.ts');
+  const content = fs.readFileSync(filePath, 'utf-8');
+  assert.match(
+    content,
+    /application\/pdf/,
+    "Schema should contain 'application/pdf' in accept array",
+  );
+});
+
+test('R9.2-A: DownloadButton.schema.ts declares download: true', () => {
+  const filePath = path.join(COMPONENTS_DIR, 'DownloadButton.schema.ts');
+  const content = fs.readFileSync(filePath, 'utf-8');
+  assert.match(
+    content,
+    /download:\s*true/,
+    "Schema should contain download: true",
+  );
+});
+
+// ─── DownloadButton.astro uses fileDownloadUrl ────────────────────────────────
+
+test('DownloadButton.astro imports or references fileDownloadUrl', () => {
+  const filePath = path.join(COMPONENTS_DIR, 'DownloadButton.astro');
+  const content = fs.readFileSync(filePath, 'utf-8');
+  assert.match(
+    content,
+    /fileDownloadUrl/,
+    "DownloadButton.astro should reference fileDownloadUrl helper",
+  );
+});
+
+// ─── R8.1-A — media.astro does NOT contain hardcoded accept="image/*" ────────
+
+test('R8.1-A: routes/admin/media.astro does not contain hardcoded accept="image/*"', () => {
+  const filePath = path.join(ROOT, 'routes', 'admin', 'media.astro');
+  const content = fs.readFileSync(filePath, 'utf-8');
+  assert.ok(
+    !content.includes('accept="image/*"'),
+    'media.astro must not contain hardcoded accept="image/*" — it should be dynamic',
+  );
+});
+
+// ─── R8.2-A — media.ts contains a non-image (document) branch ────────────────
+
+test('R8.2-A: routes/admin/client/media.ts contains non-image (document) card branch', () => {
+  const filePath = path.join(ROOT, 'routes', 'admin', 'client', 'media.ts');
+  const content = fs.readFileSync(filePath, 'utf-8');
+  assert.match(
+    content,
+    /fileCategory|document|non.?image/i,
+    "media.ts should contain a conditional branch for non-image (document) entries",
+  );
+});

--- a/utils/file-types.ts
+++ b/utils/file-types.ts
@@ -75,3 +75,28 @@ export const MIME_TO_EXT: Record<string, string> = {
   ...IMAGE_MIME_TO_EXT,
   ...DOCUMENT_MIME_TO_EXT,
 };
+
+/**
+ * Compute the intersection of a schema-defined accept list and a global allowlist.
+ *
+ * Both sides are normalised to lowercase before comparison so that a schema
+ * entry like `'Application/PDF'` matches a lowercase allowlist entry like
+ * `'application/pdf'`. The returned values are always lowercase.
+ *
+ * Behaviour:
+ *   - `accept` omitted or empty  → returns the full `allowlist` unchanged
+ *   - `accept` provided          → returns `accept` lowercased, keeping only
+ *                                  entries that appear in `allowlist`
+ *
+ * @param accept    - MIME types from the schema prop definition (may be mixed-case)
+ * @param allowlist - Global allowed MIME types (expected to be lowercase)
+ */
+export function intersectAccept(
+  accept: string[] | undefined,
+  allowlist: string[],
+): string[] {
+  if (!accept || accept.length === 0) return allowlist;
+  return accept
+    .map((m) => m.toLowerCase())
+    .filter((m) => allowlist.includes(m));
+}


### PR DESCRIPTION
## PR #4 of 4 — Slices D+E: Admin UI + playground (media non-image file uploads)

Final PR of the chain. Stacks on **PR #3**. Wires the admin UI and ships the playground demo + docs. Completes the feature.

### What's in this slice
**Admin UI (Slice D)**
- **`routes/admin/media.astro`** — upload dropzone `accept` is now dynamic from the global allowlist (`ASTRO_BLOCKS_ALLOWED_FILE_TYPES`, fallback `image/*`).
- **`routes/admin/client/media.ts`** — media grid cards branch on `fileCategory`: images keep `<img>`; documents render an **accessible tile** (`role="img"` + descriptive `aria-label`, decorative SVG `aria-hidden`, visible filename) instead of a broken image. All strings escaped (same path as the image card).
- **`routes/admin/client/block-form.ts`** — additive `file`-prop picker (image flow untouched): file field render, `selectPickerFile`, dynamic `accept`, and **`accept ∩ allowlist` enforcement** at two points (input + grid filtering). The intersection is case-insensitive via the new pure `intersectAccept` helper — this is the real enforcement that Slice C's `validateFileProps` advisory warns about.
- **`styles/cms-admin.css`** — doc tile + file field styles.

**Playground + docs (Slice E)**
- **`playgrounds/basic` `DownloadButton`** (`.astro` + `.schema.ts`) — demonstrates the `file` prop (`accept: ['application/pdf']`, `download: true`) rendering `<a href={fileDownloadUrl(file)} download>`, importing from the published `./getFileValue` export. Registered in the playground config (per the "every feature ships a playground demo" convention).
- **`docs/media.md`** — new "Non-image file uploads" section (allowedFileTypes, `file` prop, `FileFieldValue`, `fileDownloadUrl`, serving table, denylist, doc tiles).
- **`meta/features.json`** — additive `non-image-file-uploads` feature entry (no version bump).

### Tests
- **723 pass / 0 fail**, `typecheck` clean.
- New: 8 structural playground tests + 6 `intersectAccept` unit tests (mixed-case, out-of-allowlist, omitted → full allowlist, all-excluded → []).

### Manual QA (browser-runtime, not unit-testable)
OS file-picker `accept` restriction; doc tile render after API fetch; file-prop picker open/select/clear cycle; upload-in-picker producing a `FileFieldValue`; DownloadButton triggering an actual download (`?download` → `Content-Disposition: attachment`).

### Release note (downstream, not in this PR)
On release: bump README badge + CHANGELOG + features manifest version. The single behavioral default change to call out: **PDF is now accepted by default**.
