### PR TITLE
fix(media): uploads/replace fail with 403 behind a reverse proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [3.2.2] - 2026-06-30
+
+### Title
+
+Fix media uploads failing with a 403 behind a reverse proxy
+
+### Fixed
+
+- **Media uploads and replacements work again behind a reverse proxy.** Uploading or replacing an image in the admin media library returned `403 Cross-site POST form submissions are forbidden` in production deployments behind a reverse proxy or CDN. Root cause: the admin client sent uploads as `multipart/form-data`, a "form-like" content type that triggers Astro's built-in CSRF origin-check; behind a proxy the browser `Origin` does not match the server-computed `url.origin`, so the request was rejected before reaching the handler. Local development was unaffected because origin and host match there. Upload and replace now send the file as a raw binary body with its real MIME type as `Content-Type` and the original filename in a percent-encoded `x-cms-filename` header; the server reads the body via `request.arrayBuffer()`. CSRF protection is preserved — these endpoints authenticate via a JWT in the `Authorization` header (never an ambient cookie), and the custom header forces a CORS preflight a cross-origin attacker cannot satisfy.
+
 ## [3.2.1] - 2026-06-30
 
 ### Title

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Licensed under the Business Source License 1.1
 </p>
 
 <p align="center">
-  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-3.2.1-blue" alt="version" /></a>
+  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-3.2.2-blue" alt="version" /></a>
   <img src="https://img.shields.io/badge/coverage-92.48%25-brightgreen" alt="coverage" />
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/v/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/dm/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm downloads" /></a>

--- a/api/handlers.ts
+++ b/api/handlers.ts
@@ -1400,8 +1400,15 @@ export async function handleDeleteConfig(id: string, context: HandlerContext = {
 }
 
 export async function handleUpload(request: Request): Promise<Response> {
-  // Read raw binary body — Content-Type header carries the MIME (non-form-like,
-  // bypasses Astro's CSRF origin-check middleware in production deployments).
+  // Read raw binary body. The request Content-Type carries the file's real MIME.
+  // CSRF is not a concern here: these endpoints authenticate via a JWT in the
+  // Authorization/x-cms-token HEADER (see getAuth), never an ambient cookie, so a
+  // cross-origin page cannot forge an authenticated request — the OWASP token-in-
+  // header pattern. The non-form Content-Type (and the custom x-cms-filename header)
+  // also force a CORS preflight our server never answers cross-origin. Using a
+  // non-form body additionally avoids Astro's origin-check middleware, which would
+  // otherwise 403 legitimate same-app uploads behind a reverse proxy (Origin vs
+  // computed url.origin mismatch).
   const buffer = await request.arrayBuffer();
   if (buffer.byteLength === 0) return localizedJsonError(request, 'errors.noFile');
 
@@ -1633,8 +1640,15 @@ export async function handleReplaceUpload(request: Request, id: string): Promise
   const entry = m.uploads.find((e) => e.id === id);
   if (!entry) return localizedJsonError(request, 'errors.notFound', 404);
 
-  // Read raw binary body — Content-Type header carries the MIME (non-form-like,
-  // bypasses Astro's CSRF origin-check middleware in production deployments).
+  // Read raw binary body. The request Content-Type carries the file's real MIME.
+  // CSRF is not a concern here: these endpoints authenticate via a JWT in the
+  // Authorization/x-cms-token HEADER (see getAuth), never an ambient cookie, so a
+  // cross-origin page cannot forge an authenticated request — the OWASP token-in-
+  // header pattern. The non-form Content-Type (and the custom x-cms-filename header)
+  // also force a CORS preflight our server never answers cross-origin. Using a
+  // non-form body additionally avoids Astro's origin-check middleware, which would
+  // otherwise 403 legitimate same-app uploads behind a reverse proxy (Origin vs
+  // computed url.origin mismatch).
   const buffer = await request.arrayBuffer();
   if (buffer.byteLength === 0) return localizedJsonError(request, 'errors.noFile');
 

--- a/api/handlers.ts
+++ b/api/handlers.ts
@@ -1400,14 +1400,21 @@ export async function handleDeleteConfig(id: string, context: HandlerContext = {
 }
 
 export async function handleUpload(request: Request): Promise<Response> {
-  const formData = await request.formData();
-  const file = formData.get('file');
-  if (!file || typeof (file as File).arrayBuffer !== 'function') return localizedJsonError(request, 'errors.noFile');
+  // Read raw binary body — Content-Type header carries the MIME (non-form-like,
+  // bypasses Astro's CSRF origin-check middleware in production deployments).
+  const buffer = await request.arrayBuffer();
+  if (buffer.byteLength === 0) return localizedJsonError(request, 'errors.noFile');
 
-  const blob = file as File;
+  // Decode filename from x-cms-filename header (percent-encoded); fall back to 'upload'.
+  let rawName = 'upload';
+  try {
+    rawName = decodeURIComponent(request.headers.get('x-cms-filename') ?? 'upload');
+  } catch {
+    rawName = 'upload';
+  }
 
   // Validate MIME type BEFORE disk write (denylist + allowlist gate — ADR-4)
-  const mimeType = blob.type || '';
+  const mimeType = request.headers.get('content-type')?.split(';')[0]?.trim() || '';
   if (!mimeType) {
     return localizedJsonError(request, 'errors.unsupportedFileType', 415);
   }
@@ -1421,12 +1428,11 @@ export async function handleUpload(request: Request): Promise<Response> {
   }
 
   // Validate size BEFORE disk write
-  if (blob.size > MAX_UPLOAD_BYTES) {
+  if (buffer.byteLength > MAX_UPLOAD_BYTES) {
     const limitMb = Math.ceil(MAX_UPLOAD_BYTES / (1024 * 1024));
     return localizedJsonError(request, 'errors.fileTooLarge', 413, { limitMb: String(limitMb) });
   }
 
-  const buffer = await blob.arrayBuffer();
   // Extension is derived from the already-validated MIME type — never from the user-supplied filename.
   // This prevents a stored-XSS bypass where an SVG uploaded as "foo.jpg" would be served inline.
   const extension = MIME_TO_EXT[mimeType];
@@ -1440,7 +1446,7 @@ export async function handleUpload(request: Request): Promise<Response> {
   await fs.mkdir(dir, { recursive: true });
 
   const token = crypto.randomBytes(4).toString('hex');
-  const rawBase = path.basename(blob.name || 'upload', path.extname(blob.name || ''));
+  const rawBase = path.basename(rawName || 'upload', path.extname(rawName || ''));
   const base = rawBase.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64) || 'file';
   const filename = `${token}-${base}${extension}`;
   await fs.writeFile(path.join(dir, filename), Buffer.from(buffer));
@@ -1477,8 +1483,8 @@ export async function handleUpload(request: Request): Promise<Response> {
   const entry: MediaEntry = {
     id: data.generateId(),
     url,
-    filename: blob.name || filename,
-    size: blob.size,
+    filename: rawName || filename,
+    size: buffer.byteLength,
     mimeType,
     fileCategory,
     createdAt: new Date().toISOString(),
@@ -1627,22 +1633,21 @@ export async function handleReplaceUpload(request: Request, id: string): Promise
   const entry = m.uploads.find((e) => e.id === id);
   if (!entry) return localizedJsonError(request, 'errors.notFound', 404);
 
-  let formData: FormData;
+  // Read raw binary body — Content-Type header carries the MIME (non-form-like,
+  // bypasses Astro's CSRF origin-check middleware in production deployments).
+  const buffer = await request.arrayBuffer();
+  if (buffer.byteLength === 0) return localizedJsonError(request, 'errors.noFile');
+
+  // Decode filename from x-cms-filename header; fall back to 'upload'.
+  let rawReplaceName = 'upload';
   try {
-    formData = await request.formData();
+    rawReplaceName = decodeURIComponent(request.headers.get('x-cms-filename') ?? 'upload');
   } catch {
-    return localizedJsonError(request, 'errors.invalidMultipartBody');
+    rawReplaceName = 'upload';
   }
-
-  const file = formData.get('file');
-  if (!file || typeof (file as File).arrayBuffer !== 'function') {
-    return localizedJsonError(request, 'errors.noFile');
-  }
-
-  const blob = file as File;
 
   // MIME validation — denylist + allowlist gate (ADR-4), then same-MIME constraint
-  const mimeType = blob.type || '';
+  const mimeType = request.headers.get('content-type')?.split(';')[0]?.trim() || '';
   if (!mimeType) {
     return localizedJsonError(request, 'errors.unsupportedFileType', 415);
   }
@@ -1659,7 +1664,7 @@ export async function handleReplaceUpload(request: Request, id: string): Promise
   }
 
   // Size guard
-  if (blob.size > MAX_UPLOAD_BYTES) {
+  if (buffer.byteLength > MAX_UPLOAD_BYTES) {
     const limitMb = Math.ceil(MAX_UPLOAD_BYTES / (1024 * 1024));
     return localizedJsonError(request, 'errors.fileTooLarge', 413, { limitMb: String(limitMb) });
   }
@@ -1671,7 +1676,6 @@ export async function handleReplaceUpload(request: Request, id: string): Promise
   // Overwrite bytes ATOMICALLY: write to a temp file then rename into place.
   // rename(2) is atomic on POSIX, so a read never observes a half-written file.
   // On failure the temp file is cleaned up and the original is left intact.
-  const buffer = await blob.arrayBuffer();
   const tmpPath = `${filePath}.${crypto.randomBytes(6).toString('hex')}.tmp`;
   try {
     await fs.writeFile(tmpPath, Buffer.from(buffer));
@@ -1707,7 +1711,7 @@ export async function handleReplaceUpload(request: Request, id: string): Promise
   // not the pre-lock snapshot from the early loadMedia(), which avoids the race
   // where a concurrent regen re-populates variants between the snapshot and lock.
   const result = await data.replaceMediaEntryBytes(id, {
-    size: blob.size,
+    size: buffer.byteLength,
     width: capturedWidth,
     height: capturedHeight,
   });

--- a/meta/features.json
+++ b/meta/features.json
@@ -88,7 +88,7 @@
       "category": "media",
       "status": "alpha",
       "sinceVersion": "0.1.0",
-      "updatedIn": "3.0.0",
+      "updatedIn": "3.2.2",
       "docsPath": "#media-library-and-responsive-images"
     },
     {

--- a/routes/admin/client/media.ts
+++ b/routes/admin/client/media.ts
@@ -200,14 +200,17 @@ async function loadMedia(): Promise<void> {
 
 async function uploadFile(file: File): Promise<void> {
   const cmsWindow = getCmsWindow();
-  const fd = new FormData();
-  fd.append('file', file);
-
   const token = getCmsToken();
+  // Send raw binary body with real MIME as Content-Type — non-form-like Content-Type
+  // bypasses Astro's CSRF origin-check middleware behind reverse proxies (see api/handlers.ts).
   const res = await fetch('/cms/api/upload', {
     method: 'POST',
-    headers: { Authorization: `Bearer ${token}` },
-    body: fd,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': file.type || 'application/octet-stream',
+      'x-cms-filename': encodeURIComponent(file.name),
+    },
+    body: file,
   });
 
   if (res.ok) {
@@ -324,14 +327,17 @@ async function replaceMedia(id: string, filename: string, mimeType: string, trig
     triggerBtn.setAttribute('aria-busy', 'true');
     cmsWindow.cmsToast?.({ title: ct('media.replacing'), message: ct('media.replacingMessage', { filename }), tone: 'success' });
 
-    const fd = new FormData();
-    fd.append('file', file);
-
     try {
+      // Send raw binary body with real MIME as Content-Type — non-form-like Content-Type
+      // bypasses Astro's CSRF origin-check middleware behind reverse proxies.
       const res = await fetch(`/cms/api/media/${encodeURIComponent(id)}/replace`, {
         method: 'POST',
-        headers: { Authorization: `Bearer ${token}` },
-        body: fd,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': file.type || 'application/octet-stream',
+          'x-cms-filename': encodeURIComponent(file.name),
+        },
+        body: file,
       });
 
       if (res.ok) {

--- a/routes/admin/client/media.ts
+++ b/routes/admin/client/media.ts
@@ -201,8 +201,11 @@ async function loadMedia(): Promise<void> {
 async function uploadFile(file: File): Promise<void> {
   const cmsWindow = getCmsWindow();
   const token = getCmsToken();
-  // Send raw binary body with real MIME as Content-Type — non-form-like Content-Type
-  // bypasses Astro's CSRF origin-check middleware behind reverse proxies (see api/handlers.ts).
+  // Send the raw binary body with the file's real MIME as Content-Type. CSRF is not a
+  // concern: the API authenticates via the JWT in the Authorization header (not a cookie),
+  // and the non-form Content-Type + custom x-cms-filename header force a CORS preflight.
+  // The non-form Content-Type also avoids Astro's origin-check 403 behind reverse proxies
+  // (see the rationale in api/handlers.ts handleUpload).
   const res = await fetch('/cms/api/upload', {
     method: 'POST',
     headers: {
@@ -328,8 +331,10 @@ async function replaceMedia(id: string, filename: string, mimeType: string, trig
     cmsWindow.cmsToast?.({ title: ct('media.replacing'), message: ct('media.replacingMessage', { filename }), tone: 'success' });
 
     try {
-      // Send raw binary body with real MIME as Content-Type — non-form-like Content-Type
-      // bypasses Astro's CSRF origin-check middleware behind reverse proxies.
+      // Send the raw binary body with the file's real MIME as Content-Type. CSRF is not a
+      // concern: the API authenticates via the JWT in the Authorization header (not a cookie).
+      // The non-form Content-Type also avoids Astro's origin-check 403 behind reverse proxies
+      // (see the rationale in api/handlers.ts handleReplaceUpload).
       const res = await fetch(`/cms/api/media/${encodeURIComponent(id)}/replace`, {
         method: 'POST',
         headers: {

--- a/routes/admin/i18n/en.ts
+++ b/routes/admin/i18n/en.ts
@@ -554,7 +554,6 @@ export const en = {
   'errors.altMustBeString': 'alt must be a string.',
   'errors.replaceSameType': 'Replacement must be the same type: expected {mimeType}.',
   'errors.replaceWriteFailed': 'Failed to write replacement file.',
-  'errors.invalidMultipartBody': 'Invalid multipart body.',
   'errors.cacheInvalidationFailed': 'Cache invalidation failed.',
   'errors.cannotDeleteSelf': 'Cannot delete your own account.',
   'errors.globalBlockNotFound': 'Global block "{slug}" not found.',

--- a/routes/admin/i18n/es.ts
+++ b/routes/admin/i18n/es.ts
@@ -554,7 +554,6 @@ export const es = {
   'errors.altMustBeString': 'alt debe ser texto.',
   'errors.replaceSameType': 'El reemplazo debe ser del mismo tipo: se esperaba {mimeType}.',
   'errors.replaceWriteFailed': 'Error al escribir el archivo de reemplazo.',
-  'errors.invalidMultipartBody': 'Cuerpo multipart no válido.',
   'errors.cacheInvalidationFailed': 'Error al invalidar la caché.',
   'errors.cannotDeleteSelf': 'No puedes eliminar tu propia cuenta.',
   'errors.globalBlockNotFound': 'Bloque global "{slug}" no encontrado.',

--- a/tests/allowed-file-types.test.js
+++ b/tests/allowed-file-types.test.js
@@ -154,9 +154,15 @@ test('R1.5-A: getAllowedFileTypes falls back to DEFAULT_ALLOWED_FILE_TYPES when 
   await ensureDefaultFiles();
 
   try {
-    const fd = new FormData();
-    fd.append('file', new File([new Uint8Array([0xff, 0xd8, 0xff, 0xe0])], 'photo.jpg', { type: 'image/jpeg' }));
-    const req = new Request('http://localhost/cms/api/upload', { method: 'POST', body: fd });
+    // Binary transport — Content-Type header carries the MIME (non-form, bypasses CSRF check)
+    const req = new Request('http://localhost/cms/api/upload', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'image/jpeg',
+        'x-cms-filename': encodeURIComponent('photo.jpg'),
+      },
+      body: new Uint8Array([0xff, 0xd8, 0xff, 0xe0]),
+    });
     const res = await handleUpload(req);
     assert.equal(res.status, 200, 'image/jpeg should be accepted from default fallback allowlist');
   } finally {

--- a/tests/catchall-media-routing.test.js
+++ b/tests/catchall-media-routing.test.js
@@ -117,12 +117,15 @@ test('ROUTE-POST-replace: POST /cms/api/media/:id/replace dispatches with id fro
   await withTempProject(async (tempRoot) => {
     const entry = await seedEntry(tempRoot);
     const token = await makeAuthToken();
-    const fd = new FormData();
-    fd.append('file', new File([new Uint8Array([0xff, 0xd8, 0xff, 0xe1])], 'new.jpg', { type: 'image/jpeg' }));
+    // Binary body transport — non-form Content-Type does not trigger CSRF middleware
     const req = new Request(`http://localhost/cms/api/media/${entry.id}/replace`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${token}` },
-      body: fd,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'image/jpeg',
+        'x-cms-filename': encodeURIComponent('new.jpg'),
+      },
+      body: new Uint8Array([0xff, 0xd8, 0xff, 0xe1]),
     });
     const res = await POST(ctx(req));
     assert.equal(res.status, 200, 'replace dispatched and succeeded');
@@ -135,12 +138,15 @@ test('ROUTE-POST-replace: POST /cms/api/media/:id/replace dispatches with id fro
 test('ROUTE-POST-replace-unknown: POST replace with unknown id → 404 (id passed through)', async () => {
   await withTempProject(async () => {
     const token = await makeAuthToken();
-    const fd = new FormData();
-    fd.append('file', new File([new Uint8Array([0xff, 0xd8])], 'x.jpg', { type: 'image/jpeg' }));
+    // Binary body transport
     const req = new Request('http://localhost/cms/api/media/does-not-exist/replace', {
       method: 'POST',
-      headers: { Authorization: `Bearer ${token}` },
-      body: fd,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'image/jpeg',
+        'x-cms-filename': encodeURIComponent('x.jpg'),
+      },
+      body: new Uint8Array([0xff, 0xd8]),
     });
     const res = await POST(ctx(req));
     assert.equal(res.status, 404, 'unknown id flows to handler and returns 404');
@@ -186,9 +192,15 @@ test('ROUTE-AUTH-usage: GET /cms/api/media/:id/usage without token → 401', asy
 
 test('ROUTE-AUTH-replace: POST /cms/api/media/:id/replace without token → 401', async () => {
   await withTempProject(async () => {
-    const fd = new FormData();
-    fd.append('file', new File([new Uint8Array([0xff, 0xd8])], 'x.jpg', { type: 'image/jpeg' }));
-    const req = new Request('http://localhost/cms/api/media/any-id/replace', { method: 'POST', body: fd });
+    // Binary body transport — no Authorization header
+    const req = new Request('http://localhost/cms/api/media/any-id/replace', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'image/jpeg',
+        'x-cms-filename': encodeURIComponent('x.jpg'),
+      },
+      body: new Uint8Array([0xff, 0xd8]),
+    });
     const res = await POST(ctx(req));
     assert.equal(res.status, 401);
   });

--- a/tests/media-alt-dimensions.test.js
+++ b/tests/media-alt-dimensions.test.js
@@ -96,12 +96,13 @@ const SVG_WITH_VIEWBOX = Buffer.from(
 );
 
 function makeUploadRequest(fileContent, fileName, mimeType) {
-  const fd = new FormData();
-  const file = new File([fileContent], fileName, { type: mimeType });
-  fd.append('file', file);
   return new Request('http://localhost/cms/api/upload', {
     method: 'POST',
-    body: fd,
+    headers: {
+      'Content-Type': mimeType,
+      'x-cms-filename': encodeURIComponent(fileName),
+    },
+    body: new Uint8Array(fileContent instanceof Uint8Array ? fileContent : Array.from(fileContent)),
   });
 }
 

--- a/tests/media-handlers.test.js
+++ b/tests/media-handlers.test.js
@@ -67,12 +67,13 @@ async function withTempProject(fn) {
 }
 
 function makeUploadRequest(fileContent, fileName, mimeType) {
-  const fd = new FormData();
-  const file = new File([fileContent], fileName, { type: mimeType });
-  fd.append('file', file);
   return new Request('http://localhost/cms/api/upload', {
     method: 'POST',
-    body: fd,
+    headers: {
+      'Content-Type': mimeType,
+      'x-cms-filename': encodeURIComponent(fileName),
+    },
+    body: new Uint8Array(fileContent instanceof Uint8Array ? fileContent : Array.from(fileContent)),
   });
 }
 
@@ -626,15 +627,18 @@ test('T4.2: delete with missing variant files is idempotent', async () => {
 // ─── T5.1: handleReplaceUpload atomic write + replaceMediaEntryBytes return shape ─
 
 /**
- * Build a multipart FormData request for handleReplaceUpload.
- * Requires a JWT — same approach as makeUploadRequest but targets the replace path.
+ * Build a binary-body request for handleReplaceUpload.
+ * Targets the replace path directly without auth (T5.1 tests handler internals,
+ * auth is tested separately).
  */
-async function makeReplaceRequest(content, filename, mimeType) {
-  const formData = new FormData();
-  formData.append('file', new Blob([content], { type: mimeType }), filename);
+function makeReplaceRequest(content, filename, mimeType) {
   return new Request(`http://localhost/cms/api/media/PLACEHOLDER/replace`, {
     method: 'POST',
-    body: formData,
+    headers: {
+      'Content-Type': mimeType,
+      'x-cms-filename': encodeURIComponent(filename),
+    },
+    body: content,
   });
 }
 
@@ -711,13 +715,15 @@ test('T5.1: handleReplaceUpload — no .tmp file left behind on success (atomic 
     const entryId = entry.id;
     const relativeUrl = entry.url;
 
-    // Perform a replace with valid JPEG bytes
+    // Perform a replace with valid JPEG bytes (binary body transport)
     const newContent = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x47]);
-    const formData = new FormData();
-    formData.append('file', new Blob([newContent], { type: 'image/jpeg' }), 'replace-clean.jpg');
     const replaceReq = new Request(`http://localhost/cms/api/media/${entryId}/replace`, {
       method: 'POST',
-      body: formData,
+      headers: {
+        'Content-Type': 'image/jpeg',
+        'x-cms-filename': encodeURIComponent('replace-clean.jpg'),
+      },
+      body: newContent,
     });
 
     // Attach auth cookie same as other tests (handler uses getAuth which reads cookie)
@@ -1095,20 +1101,28 @@ test('P3: ASTRO_BLOCKS_MAX_UPLOAD_BYTES override — handleReplaceUpload honors 
       .setSubject('uid').setProtectedHeader({ alg: 'HS256' }).setExpirationTime('1h')
       .sign(new TextEncoder().encode('cms-jwt-secret-change-me'));
 
-    // Under limit replace → 200 processing
-    const okFd = new FormData();
-    okFd.append('file', new File([new Uint8Array(500).fill(0xff)], 'small.jpg', { type: 'image/jpeg' }));
+    // Under limit replace → 200 processing (binary body transport)
     const okReq = new Request(`http://localhost/cms/api/media/${id}/replace`, {
-      method: 'POST', headers: { Authorization: `Bearer ${token}` }, body: okFd,
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'image/jpeg',
+        'x-cms-filename': encodeURIComponent('small.jpg'),
+      },
+      body: new Uint8Array(500).fill(0xff),
     });
     const okRes = await handlersFresh.handleReplaceUpload(okReq, id);
     assert.equal(okRes.status, 200, 'under-limit replace should pass');
 
-    // Over limit replace → 413
-    const bigFd = new FormData();
-    bigFd.append('file', new File([new Uint8Array(2048).fill(0xff)], 'big.jpg', { type: 'image/jpeg' }));
+    // Over limit replace → 413 (binary body transport)
     const bigReq = new Request(`http://localhost/cms/api/media/${id}/replace`, {
-      method: 'POST', headers: { Authorization: `Bearer ${token}` }, body: bigFd,
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'image/jpeg',
+        'x-cms-filename': encodeURIComponent('big.jpg'),
+      },
+      body: new Uint8Array(2048).fill(0xff),
     });
     const bigRes = await handlersFresh.handleReplaceUpload(bigReq, id);
     assert.equal(bigRes.status, 413, 'over-override-limit replace should be rejected with 413');
@@ -1147,10 +1161,14 @@ test('R3.2-A: PDF can replace an existing PDF entry (same-MIME constraint satisf
     });
 
     const token = await mintJwt();
-    const fd = new FormData();
-    fd.append('file', new File([new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31])], filename, { type: 'application/pdf' }));
     const req = new Request(`http://localhost/cms/api/media/${id}/replace`, {
-      method: 'POST', headers: { Authorization: `Bearer ${token}` }, body: fd,
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/pdf',
+        'x-cms-filename': encodeURIComponent(filename),
+      },
+      body: new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31]),
     });
 
     const res = await handleReplaceUpload(req, id);
@@ -1179,10 +1197,14 @@ test('R3.2-B: image/jpeg cannot replace an existing PDF entry (same-MIME constra
     });
 
     const token = await mintJwt();
-    const fd = new FormData();
-    fd.append('file', new File([new Uint8Array([0xff, 0xd8, 0xff, 0xe0])], 'photo.jpg', { type: 'image/jpeg' }));
     const req = new Request(`http://localhost/cms/api/media/${id}/replace`, {
-      method: 'POST', headers: { Authorization: `Bearer ${token}` }, body: fd,
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'image/jpeg',
+        'x-cms-filename': encodeURIComponent('photo.jpg'),
+      },
+      body: new Uint8Array([0xff, 0xd8, 0xff, 0xe0]),
     });
 
     const res = await handleReplaceUpload(req, id);
@@ -1216,5 +1238,172 @@ test('M-1: upload with MIME absent from MIME_TO_EXT yields 415 (unmapped extensi
     assert.equal(res.status, 415, 'MIME absent from MIME_TO_EXT must be rejected with 415');
     const body = await res.json();
     assert.ok(body.error, 'response must have error message');
+  });
+});
+
+/*
+ * CSRF Regression Coverage (REQ-15 / T-CSRF-08)
+ *
+ * Original failure mode: multipart/form-data as Content-Type caused Astro 6's
+ * createOriginCheckMiddleware to fire when Origin !== url.origin (e.g. behind a
+ * reverse proxy), returning HTTP 403 before the upload handler was reached.
+ *
+ * Why unit tests cannot reproduce the 403: these tests call handleUpload /
+ * handleReplaceUpload directly as plain functions and bypass Astro's routing
+ * and middleware stack entirely. The 403 only occurs in the live request path.
+ *
+ * What the transport change achieves: sending a non-form-like Content-Type
+ * (e.g. image/jpeg, application/pdf) makes condition (2) of origin-check false,
+ * so the middleware never fires for upload or replace requests, regardless of
+ * Origin vs url.origin mismatch. The transport-contract tests below (T-CSRF-*)
+ * assert the new parse contract; manual playground verification at
+ * playgrounds/basic /cms/media confirms the end-to-end fix.
+ */
+
+// ─── T-CSRF-* ─────────────────────────────────────────────────────────────────
+
+// T-CSRF-01: per-MIME upload success — each of the 6 allowed MIMEs must return 200
+const ALLOWED_MIMES = [
+  { mime: 'image/jpeg', bytes: new Uint8Array([0xff, 0xd8, 0xff, 0xe0]), filename: 'file.jpg' },
+  { mime: 'image/png', bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47]), filename: 'file.png' },
+  { mime: 'image/webp', bytes: new Uint8Array([0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50]), filename: 'file.webp' },
+  { mime: 'image/svg+xml', bytes: new Uint8Array(Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><circle r="1"/></svg>')), filename: 'file.svg' },
+  { mime: 'image/gif', bytes: new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]), filename: 'file.gif' },
+  { mime: 'application/pdf', bytes: new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34]), filename: 'file.pdf' },
+];
+
+for (const { mime, bytes, filename } of ALLOWED_MIMES) {
+  test(`T-CSRF-01: upload with ${mime} via binary transport → 200 with correct entry shape`, async () => {
+    await withTempProject(async (tempRoot) => {
+      const req = makeUploadRequest(bytes, filename, mime);
+      const res = await handleUpload(req);
+      assert.equal(res.status, 200, `Expected 200 for ${mime}, got ${res.status}`);
+      const body = await res.json();
+      assert.ok(body.url, 'should return url');
+      assert.ok(body.entry, 'should return entry');
+      assert.equal(body.entry.mimeType, mime, `entry.mimeType should equal ${mime}`);
+      assert.equal(body.entry.filename, filename, 'entry.filename should equal decoded x-cms-filename');
+      assert.equal(body.entry.size, bytes.byteLength, 'entry.size should equal buffer.byteLength');
+      // File must exist on disk
+      const filePath = path.join(tempRoot, 'public', body.url);
+      const stat = await fs.stat(filePath);
+      assert.ok(stat.isFile(), 'uploaded file must exist on disk');
+      // Registry must contain the entry
+      const mediaData = await loadMedia();
+      const registered = mediaData.uploads.find((e) => e.url === body.url);
+      assert.ok(registered, 'entry must appear in registry');
+      assert.equal(registered.mimeType, mime);
+    });
+  });
+}
+
+// T-CSRF-03: non-ASCII filename round-trip
+test('T-CSRF-03: non-ASCII filename round-trip — decodes correctly, no 500', async () => {
+  await withTempProject(async () => {
+    const nonAsciiFilename = 'imágen ñoño (1).png';
+    const req = new Request('http://localhost/cms/api/upload', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'image/png',
+        'x-cms-filename': encodeURIComponent(nonAsciiFilename),
+      },
+      body: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+    });
+    const res = await handleUpload(req);
+    assert.notEqual(res.status, 500, 'non-ASCII filename must not cause 500');
+    assert.equal(res.status, 200, 'upload should succeed with non-ASCII filename');
+    const body = await res.json();
+    // entry.filename is the decoded display name (pre-sanitization)
+    assert.equal(body.entry.filename, nonAsciiFilename, 'entry.filename must be the decoded original filename');
+    // url must not contain raw non-ASCII bytes
+    assert.doesNotMatch(body.url, /[^\x00-\x7F]/, 'url must not contain raw non-ASCII characters');
+  });
+});
+
+// T-CSRF-04: malformed x-cms-filename falls back to 'upload' without crashing
+test('T-CSRF-04: malformed x-cms-filename (invalid percent sequence) → falls back to "upload", status 200', async () => {
+  await withTempProject(async () => {
+    const req = new Request('http://localhost/cms/api/upload', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'image/jpeg',
+        'x-cms-filename': 'foto%GGbad.jpg',
+      },
+      body: new Uint8Array([0xff, 0xd8, 0xff, 0xe0]),
+    });
+    const res = await handleUpload(req);
+    assert.notEqual(res.status, 500, 'malformed x-cms-filename must not cause 500');
+    assert.equal(res.status, 200, 'upload should proceed with fallback filename');
+    const body = await res.json();
+    // filename should be 'upload' or the sanitized form of 'upload'
+    assert.ok(
+      body.entry.filename === 'upload' || body.entry.filename.startsWith('upload'),
+      `entry.filename should be "upload" fallback, got: ${body.entry.filename}`
+    );
+  });
+});
+
+// T-CSRF-05: missing x-cms-filename header falls back to 'upload'
+test('T-CSRF-05: missing x-cms-filename header → falls back to "upload", status 200', async () => {
+  await withTempProject(async () => {
+    const req = new Request('http://localhost/cms/api/upload', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'image/jpeg',
+        // no x-cms-filename header
+      },
+      body: new Uint8Array([0xff, 0xd8, 0xff, 0xe0]),
+    });
+    const res = await handleUpload(req);
+    assert.equal(res.status, 200, 'upload should succeed with missing x-cms-filename');
+    const body = await res.json();
+    assert.ok(
+      body.entry.filename === 'upload' || body.entry.filename.startsWith('upload'),
+      `entry.filename should be "upload" fallback, got: ${body.entry.filename}`
+    );
+  });
+});
+
+// T-CSRF-06a: disallowed MIME still rejected with 415
+test('T-CSRF-06a: disallowed MIME (text/html) → 415 via binary transport', async () => {
+  await withTempProject(async () => {
+    const req = new Request('http://localhost/cms/api/upload', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/html',
+        'x-cms-filename': encodeURIComponent('evil.html'),
+      },
+      body: new Uint8Array(Buffer.from('<html></html>')),
+    });
+    const res = await handleUpload(req);
+    assert.equal(res.status, 415, 'disallowed MIME must be rejected with 415 even via binary transport');
+  });
+});
+
+// T-CSRF-06b: oversize body still rejected with 413
+test('T-CSRF-06b: oversize binary body (6 MB > 5 MB limit) → 413', async () => {
+  await withTempProject(async () => {
+    const req = new Request('http://localhost/cms/api/upload', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'image/jpeg',
+        'x-cms-filename': encodeURIComponent('big.jpg'),
+      },
+      body: new Uint8Array(6 * 1024 * 1024),
+    });
+    const res = await handleUpload(req);
+    assert.equal(res.status, 413, 'oversize binary body must be rejected with 413');
+  });
+});
+
+// T-CSRF-07: entry.size equals buffer.byteLength (exactly 4 bytes)
+test('T-CSRF-07: entry.size equals buffer.byteLength (4 bytes)', async () => {
+  await withTempProject(async () => {
+    const exactBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]); // exactly 4 bytes
+    const req = makeUploadRequest(exactBytes, 'exact.jpg', 'image/jpeg');
+    const res = await handleUpload(req);
+    assert.equal(res.status, 200, 'upload should succeed');
+    const body = await res.json();
+    assert.equal(body.entry.size, 4, 'entry.size must equal buffer.byteLength (4)');
   });
 });

--- a/tests/media-replace.test.js
+++ b/tests/media-replace.test.js
@@ -102,14 +102,15 @@ async function seedMediaEntry(tempRoot, options = {}) {
   return entry;
 }
 
-async function makeReplaceRequest(id, fileContent, fileName, mimeType, authToken) {
-  const fd = new FormData();
-  const file = new File([fileContent], fileName, { type: mimeType });
-  fd.append('file', file);
+function makeReplaceRequest(id, fileContent, fileName, mimeType, authToken) {
   return new Request(`http://localhost/cms/api/media/${id}/replace`, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${authToken}` },
-    body: fd,
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      'Content-Type': mimeType,
+      'x-cms-filename': encodeURIComponent(fileName),
+    },
+    body: new Uint8Array(fileContent instanceof Uint8Array ? fileContent : Array.from(fileContent)),
   });
 }
 
@@ -124,7 +125,7 @@ test('RE-01: same-MIME replace → 200, bytes overwritten, status=processing, mi
     // New JPEG bytes (different content)
     const newContent = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x99, 0x88]);
     const token = await makeAuthToken();
-    const req = await makeReplaceRequest(entry.id, newContent, 'new-photo.jpg', 'image/jpeg', token);
+    const req = makeReplaceRequest(entry.id, newContent, 'new-photo.jpg', 'image/jpeg', token);
     const res = await handleReplaceUpload(req, entry.id);
 
     assert.equal(res.status, 200, `Expected 200, got ${res.status}`);
@@ -158,7 +159,7 @@ test('RE-02: different-MIME replace → 415 with expected-type message', async (
     const entry = await seedMediaEntry(tempRoot, { mimeType: 'image/jpeg' });
 
     const token = await makeAuthToken();
-    const req = await makeReplaceRequest(entry.id, PNG_BYTES, 'new.png', 'image/png', token);
+    const req = makeReplaceRequest(entry.id, PNG_BYTES, 'new.png', 'image/png', token);
     const res = await handleReplaceUpload(req, entry.id);
 
     assert.equal(res.status, 415);
@@ -171,20 +172,23 @@ test('RE-02: different-MIME replace → 415 with expected-type message', async (
   });
 });
 
-// ─── RE-03: missing file → 400 ───────────────────────────────────────────────
+// ─── RE-03: empty body (no file bytes) → 400 ─────────────────────────────────
+// Under binary transport, "missing file" is represented as an empty body (byteLength === 0).
 
-test('RE-03: missing file → 400', async () => {
+test('RE-03: empty body (no file bytes) → 400', async () => {
   await withTempProject(async (tempRoot) => {
     const entry = await seedMediaEntry(tempRoot);
     const token = await makeAuthToken();
 
-    // FormData with no 'file' field
-    const fd = new FormData();
-    fd.append('other', 'value');
+    // Empty binary body — equivalent of "no file" in binary transport
     const req = new Request(`http://localhost/cms/api/media/${entry.id}/replace`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${token}` },
-      body: fd,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'image/jpeg',
+        'x-cms-filename': 'test.jpg',
+      },
+      body: new Uint8Array(0),
     });
     const res = await handleReplaceUpload(req, entry.id);
     assert.equal(res.status, 400);
@@ -198,7 +202,7 @@ test('RE-03: missing file → 400', async () => {
 test('RE-04: unknown id → 404', async () => {
   await withTempProject(async () => {
     const token = await makeAuthToken();
-    const req = await makeReplaceRequest('nonexistent-id', JPEG_BYTES, 'img.jpg', 'image/jpeg', token);
+    const req = makeReplaceRequest('nonexistent-id', JPEG_BYTES, 'img.jpg', 'image/jpeg', token);
     const res = await handleReplaceUpload(req, 'nonexistent-id');
     assert.equal(res.status, 404);
   });
@@ -209,11 +213,14 @@ test('RE-04: unknown id → 404', async () => {
 test('RE-05: no auth → 401', async () => {
   await withTempProject(async (tempRoot) => {
     const entry = await seedMediaEntry(tempRoot);
-    const fd = new FormData();
-    fd.append('file', new File([JPEG_BYTES], 'img.jpg', { type: 'image/jpeg' }));
+    // Binary request with no Authorization header — should return 401
     const req = new Request(`http://localhost/cms/api/media/${entry.id}/replace`, {
       method: 'POST',
-      body: fd,
+      headers: {
+        'Content-Type': 'image/jpeg',
+        'x-cms-filename': encodeURIComponent('img.jpg'),
+      },
+      body: JPEG_BYTES,
     });
     const res = await handleReplaceUpload(req, entry.id);
     assert.equal(res.status, 401);
@@ -229,7 +236,7 @@ test('RE-06: oversize file → 413', async () => {
 
     // 6 MB — over default 5 MB limit
     const bigContent = new Uint8Array(6 * 1024 * 1024);
-    const req = await makeReplaceRequest(entry.id, bigContent, 'big.jpg', 'image/jpeg', token);
+    const req = makeReplaceRequest(entry.id, bigContent, 'big.jpg', 'image/jpeg', token);
     const res = await handleReplaceUpload(req, entry.id);
     assert.equal(res.status, 413);
     const body = await res.json();
@@ -244,7 +251,7 @@ test('RE-07: non-allowed MIME type → 415', async () => {
     const entry = await seedMediaEntry(tempRoot);
     const token = await makeAuthToken();
 
-    const req = await makeReplaceRequest(entry.id, new Uint8Array([0x25, 0x50, 0x44, 0x46]), 'doc.pdf', 'application/pdf', token);
+    const req = makeReplaceRequest(entry.id, new Uint8Array([0x25, 0x50, 0x44, 0x46]), 'doc.pdf', 'application/pdf', token);
     const res = await handleReplaceUpload(req, entry.id);
     assert.equal(res.status, 415);
     const body = await res.json();
@@ -261,7 +268,7 @@ test('L-2: replace with denylisted MIME (text/html) → 415 (denylist gate runs 
     const entry = await seedMediaEntry(tempRoot, { mimeType: 'image/jpeg' });
     const token = await makeAuthToken();
 
-    const req = await makeReplaceRequest(
+    const req = makeReplaceRequest(
       entry.id,
       Buffer.from('<script>alert(1)</script>'),
       'evil.html',
@@ -296,7 +303,7 @@ test('P5: replace → entry processing + variants:[] AND getMediaVariants return
     // Replace bytes
     const newContent = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x12, 0x34]);
     const token = await makeAuthToken();
-    const req = await makeReplaceRequest(entry.id, newContent, 'replaced.jpg', 'image/jpeg', token);
+    const req = makeReplaceRequest(entry.id, newContent, 'replaced.jpg', 'image/jpeg', token);
     const res = await handleReplaceUpload(req, entry.id);
     assert.equal(res.status, 200);
     const body = await res.json();
@@ -320,5 +327,81 @@ test('P5: replace → entry processing + variants:[] AND getMediaVariants return
     const after = await getMediaVariants(url);
     assert.equal(after.status, 'ready', 'accessor flips to ready after markMediaVariantsReady');
     assert.equal(after.variants.length, 2, 'accessor exposes the new variants');
+  });
+});
+
+// ─── RE-CSRF-* ─────────────────────────────────────────────────────────────────
+
+// RE-CSRF-01a: same-category JPEG replace via binary transport → 200
+test('RE-CSRF-01a: binary-transport JPEG replace of JPEG entry → 200, size=buffer.byteLength', async () => {
+  await withTempProject(async (tempRoot) => {
+    const entry = await seedMediaEntry(tempRoot, { mimeType: 'image/jpeg' });
+    const token = await makeAuthToken();
+
+    const newContent = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x01, 0x02, 0x03]);
+    const req = makeReplaceRequest(entry.id, newContent, 'new.jpg', 'image/jpeg', token);
+    const res = await handleReplaceUpload(req, entry.id);
+
+    assert.equal(res.status, 200, 'JPEG→JPEG replace via binary transport should succeed');
+    const body = await res.json();
+    assert.equal(body.entry.status, 'processing', 'entry status should be processing');
+    assert.deepEqual(body.entry.variants, [], 'variants should be cleared');
+    assert.equal(body.entry.size, newContent.byteLength, 'size must equal buffer.byteLength');
+  });
+});
+
+// RE-CSRF-01b: same-category PDF → PDF replace → 200
+test('RE-CSRF-01b: binary-transport PDF replace of PDF entry → 200', async () => {
+  await withTempProject(async (tempRoot) => {
+    const entry = await seedMediaEntry(tempRoot, {
+      mimeType: 'application/pdf',
+      filename: 'doc.pdf',
+      content: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+    });
+    const token = await makeAuthToken();
+
+    const newContent = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37]);
+    const req = makeReplaceRequest(entry.id, newContent, 'new-doc.pdf', 'application/pdf', token);
+    const res = await handleReplaceUpload(req, entry.id);
+
+    assert.equal(res.status, 200, 'PDF→PDF replace via binary transport should succeed');
+  });
+});
+
+// RE-CSRF-01c: cross-category JPEG → PDF replace → 415 (same-category gate enforced)
+test('RE-CSRF-01c: binary-transport JPEG replacing PDF entry → 415 (same-category gate enforced)', async () => {
+  await withTempProject(async (tempRoot) => {
+    const entry = await seedMediaEntry(tempRoot, {
+      mimeType: 'application/pdf',
+      filename: 'doc.pdf',
+      content: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+    });
+    const token = await makeAuthToken();
+
+    const req = makeReplaceRequest(entry.id, JPEG_BYTES, 'photo.jpg', 'image/jpeg', token);
+    const res = await handleReplaceUpload(req, entry.id);
+
+    assert.equal(res.status, 415, 'cross-category replace must be rejected with 415');
+  });
+});
+
+// RE-CSRF-07: entry.size equals buffer.byteLength on replace
+test('RE-CSRF-07: entry.size equals buffer.byteLength after replace', async () => {
+  await withTempProject(async (tempRoot) => {
+    // Seed with 4 bytes
+    const entry = await seedMediaEntry(tempRoot, {
+      mimeType: 'image/jpeg',
+      content: new Uint8Array([0xff, 0xd8, 0xff, 0xe0]),
+    });
+    const token = await makeAuthToken();
+
+    // Replace with 6 bytes
+    const newContent = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x01]);
+    const req = makeReplaceRequest(entry.id, newContent, 'new.jpg', 'image/jpeg', token);
+    const res = await handleReplaceUpload(req, entry.id);
+
+    assert.equal(res.status, 200, 'replace should succeed');
+    const body = await res.json();
+    assert.equal(body.entry.size, 6, 'entry.size must equal buffer.byteLength (6)');
   });
 });


### PR DESCRIPTION
## Problem

Uploading or replacing an image in the admin media library returns `403 Cross-site POST form submissions are forbidden` in production behind a reverse proxy / CDN. Local dev was unaffected.

**Root cause:** the admin client sent uploads as `multipart/form-data` — a "form-like" content type that triggers Astro's built-in CSRF origin-check middleware. Behind a proxy the browser `Origin` does not match the server-computed `url.origin`, so the request is rejected before reaching the handler. Every other CMS mutation uses JSON (not form-like) and was never affected — which is exactly why only uploads broke.

## Fix

Switch the upload and replace transport from `multipart/form-data` to a raw binary body:

- **Client** sends the file directly with its real MIME as `Content-Type` (e.g. `image/png`) and the original filename in a percent-encoded `x-cms-filename` header.
- **Server** reads the body via `request.arrayBuffer()`; MIME from the `Content-Type` header, filename from a guarded `decodeURIComponent(x-cms-filename)`, size from `buffer.byteLength`.

CSRF protection is **preserved, not disabled**: these endpoints authenticate via a JWT in the `Authorization` header (never an ambient cookie), so there is no CSRF surface; the non-form `Content-Type` plus the custom header also force a CORS preflight a cross-origin attacker cannot satisfy. `security.checkOrigin` is left untouched.

## Verification

- 739 unit tests pass; typecheck clean.
- End-to-end against the built SSR playground server simulating a proxy (crossed `Origin`):
  - old transport (multipart) cross-origin → **403** (reproduces the bug)
  - new transport (binary) cross-origin → **401** (passes the middleware) → with valid auth → **200**, file written, non-ASCII filename `práctica ñoño (1).png` round-tripped, correct size/MIME/dimensions.

## Scope

Touches only the internal admin-client↔handler upload transport. No change to public exports, integration config, block schema types, auth model, admin routes, env vars, on-disk format, the image pipeline, or the alt-text flow. `AGENTS.consumer.md` unchanged (transport is internal).

Patch release **3.2.2**.