### PR TITLE
feat(import-export): foundation — manifest, validators, checksums, fflate stream bridge (Slice A)

### DIFF
--- a/api/backup-stream.ts
+++ b/api/backup-stream.ts
@@ -1,0 +1,154 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * fflate <-> Web ReadableStream bridge.
+ *
+ * This module is the integration seam between fflate's callback-based
+ * streaming API and the web Streams API used by Request/Response bodies.
+ * It has no dependency on handlers.ts or data.ts — pure I/O bridge.
+ *
+ * ADR-4: Streaming export constraint — never buffer the whole archive.
+ *
+ * Implementation note: fflate's Async*Deflate/Inflate variants use Node.js
+ * Worker threads, which are not available in all environments. We use the
+ * synchronous Zip/Unzip + ZipDeflate/UnzipInflate variants instead, which
+ * run on the same thread and are fully compatible with the Node.js ESM build.
+ */
+
+import { Zip, ZipDeflate, Unzip, UnzipInflate } from 'fflate';
+import type { AsyncFlateStreamHandler } from 'fflate';
+
+/**
+ * Creates a ReadableStream<Uint8Array> backed by a fflate Zip instance.
+ *
+ * @param zipSetup - A callback that receives the Zip instance so the caller
+ *   can add entries (via ZipDeflate or ZipPassThrough) and call zip.end().
+ *   The callback must call zip.end() after adding all files.
+ * @returns A ReadableStream that emits the zip archive bytes as they are produced.
+ */
+export function fflateZipToReadableStream(
+  zipSetup: (zip: Zip) => void,
+): ReadableStream<Uint8Array> {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  let streamErrored = false;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(ctrl) {
+      controller = ctrl;
+
+      const zip = new Zip();
+
+      const onData: AsyncFlateStreamHandler = (err, chunk, final) => {
+        if (streamErrored) return;
+        if (err) {
+          streamErrored = true;
+          controller.error(err);
+          return;
+        }
+        controller.enqueue(chunk);
+        if (final) {
+          controller.close();
+        }
+      };
+
+      zip.ondata = onData;
+
+      try {
+        zipSetup(zip);
+      } catch (err) {
+        streamErrored = true;
+        controller.error(err);
+      }
+    },
+    cancel() {
+      streamErrored = true;
+    },
+  });
+
+  return stream;
+}
+
+/**
+ * Reads a ReadableStream of zip bytes and calls onFile for each extracted entry.
+ *
+ * @param stream - A ReadableStream<Uint8Array> of raw zip bytes.
+ * @param onFile - Async callback invoked with (name, data) for each extracted file.
+ *   The data is a Buffer containing the full decompressed content of the file.
+ * @returns A Promise that resolves when the stream is fully consumed, or rejects
+ *   if the stream errors or decompression fails.
+ */
+export async function readableStreamToFflateUnzip(
+  stream: ReadableStream<Uint8Array>,
+  onFile: (name: string, data: Buffer) => Promise<void>,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const unzip = new Unzip();
+    // Register the sync inflate decoder so deflated entries are handled
+    unzip.register(UnzipInflate);
+
+    const pendingFiles: Promise<void>[] = [];
+
+    unzip.onfile = (file) => {
+      const chunks: Uint8Array[] = [];
+
+      file.ondata = (err, chunk, final) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        chunks.push(chunk);
+        if (final) {
+          const totalLen = chunks.reduce((s, c) => s + c.length, 0);
+          const buf = Buffer.allocUnsafe(totalLen);
+          let offset = 0;
+          for (const c of chunks) {
+            buf.set(c, offset);
+            offset += c.length;
+          }
+          const p = onFile(file.name, buf).catch(reject);
+          pendingFiles.push(p);
+        }
+      };
+
+      file.start();
+    };
+
+    // Pump the readable stream into fflate's Unzip
+    const reader = stream.getReader();
+
+    function pump(): void {
+      reader.read().then(
+        ({ done, value }) => {
+          if (done) {
+            try {
+              // Signal end of stream to fflate
+              unzip.push(new Uint8Array(0), true);
+            } catch (err) {
+              reject(err);
+              return;
+            }
+            // Wait for all onFile callbacks to complete
+            Promise.all(pendingFiles).then(() => resolve(), reject);
+            return;
+          }
+          try {
+            unzip.push(value, false);
+          } catch (err) {
+            reject(err);
+            return;
+          }
+          pump();
+        },
+        (err: unknown) => {
+          // Stream reader errored (e.g. controller.error() was called mid-stream)
+          reject(err);
+        },
+      );
+    }
+
+    pump();
+  });
+}

--- a/api/import-utils.ts
+++ b/api/import-utils.ts
@@ -30,9 +30,11 @@ export class CeilingExceededError extends Error {
  * Sorts ascending by name (ISO timestamps sort lexicographically).
  */
 export function selectBackupsToPrune(dirNames: string[], keep: number): string[] {
-  if (dirNames.length <= keep) return [];
+  // Clamp keep to a minimum of 1 so we never select everything for deletion.
+  const effectiveKeep = keep < 1 ? 1 : keep;
+  if (dirNames.length <= effectiveKeep) return [];
   const sorted = [...dirNames].sort(); // ISO names sort correctly lexicographically
-  return sorted.slice(0, sorted.length - keep);
+  return sorted.slice(0, sorted.length - effectiveKeep);
 }
 
 /**
@@ -57,17 +59,29 @@ export function assertWithinCeilings(
 }
 
 /**
+ * Parses a raw env var string to a positive integer.
+ * Returns `defaultValue` if the string is absent, non-numeric (NaN), zero, or negative.
+ */
+function parseCeilingEnvVar(raw: string | undefined, defaultValue: number): number {
+  if (!raw) return defaultValue;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+}
+
+/**
  * Reads the decompression ceiling env vars and returns their values.
  * Env var names are locked (do not rename):
  *   ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES  (default: 50 MB)
  *   ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES (default: 500 MB)
  */
 export function readCeilingEnvVars(): CeilingLimits {
-  const perFile = process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES']
-    ? parseInt(process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'], 10)
-    : DEFAULT_MAX_IMPORT_FILE_BYTES;
-  const total = process.env['ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES']
-    ? parseInt(process.env['ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES'], 10)
-    : DEFAULT_MAX_IMPORT_TOTAL_BYTES;
+  const perFile = parseCeilingEnvVar(
+    process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'],
+    DEFAULT_MAX_IMPORT_FILE_BYTES,
+  );
+  const total = parseCeilingEnvVar(
+    process.env['ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES'],
+    DEFAULT_MAX_IMPORT_TOTAL_BYTES,
+  );
   return { perFile, total };
 }

--- a/api/import-utils.ts
+++ b/api/import-utils.ts
@@ -1,0 +1,73 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/** Default per-file decompression ceiling: 50 MB */
+export const DEFAULT_MAX_IMPORT_FILE_BYTES = 50 * 1024 * 1024;
+
+/** Default total uncompressed ceiling: 500 MB */
+export const DEFAULT_MAX_IMPORT_TOTAL_BYTES = 500 * 1024 * 1024;
+
+export interface CeilingLimits {
+  perFile: number;
+  total: number;
+}
+
+/**
+ * Custom error thrown when a decompression ceiling is exceeded.
+ */
+export class CeilingExceededError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CeilingExceededError';
+  }
+}
+
+/**
+ * Given a list of backup directory names (ISO-sortable strings) and a retention count,
+ * returns the names that should be pruned (oldest ones beyond `keep`).
+ * Sorts ascending by name (ISO timestamps sort lexicographically).
+ */
+export function selectBackupsToPrune(dirNames: string[], keep: number): string[] {
+  if (dirNames.length <= keep) return [];
+  const sorted = [...dirNames].sort(); // ISO names sort correctly lexicographically
+  return sorted.slice(0, sorted.length - keep);
+}
+
+/**
+ * Asserts that the given per-file and total byte counts are within the provided limits.
+ * Throws CeilingExceededError with a descriptive message if a ceiling is exceeded.
+ */
+export function assertWithinCeilings(
+  perFileBytes: number,
+  totalBytes: number,
+  limits: CeilingLimits,
+): void {
+  if (perFileBytes > limits.perFile) {
+    throw new CeilingExceededError(
+      `per-file decompression ceiling exceeded: ${perFileBytes} bytes > ${limits.perFile} bytes`,
+    );
+  }
+  if (totalBytes > limits.total) {
+    throw new CeilingExceededError(
+      `total decompression ceiling exceeded: ${totalBytes} bytes > ${limits.total} bytes`,
+    );
+  }
+}
+
+/**
+ * Reads the decompression ceiling env vars and returns their values.
+ * Env var names are locked (do not rename):
+ *   ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES  (default: 50 MB)
+ *   ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES (default: 500 MB)
+ */
+export function readCeilingEnvVars(): CeilingLimits {
+  const perFile = process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES']
+    ? parseInt(process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'], 10)
+    : DEFAULT_MAX_IMPORT_FILE_BYTES;
+  const total = process.env['ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES']
+    ? parseInt(process.env['ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES'], 10)
+    : DEFAULT_MAX_IMPORT_TOTAL_BYTES;
+  return { perFile, total };
+}

--- a/api/import-validate.ts
+++ b/api/import-validate.ts
@@ -26,6 +26,15 @@ export function validateUsersUnit(data: unknown): ValidationResult {
       return { ok: false, reason: 'each user must be an object' };
     }
     const u = user as Record<string, unknown>;
+    if (typeof u['id'] !== 'string' || u['id'] === '') {
+      return { ok: false, reason: 'each user must have a non-empty string "id"' };
+    }
+    if (typeof u['email'] !== 'string' || u['email'] === '') {
+      return { ok: false, reason: 'each user must have a non-empty string "email"' };
+    }
+    if (typeof u['passwordHash'] !== 'string' || u['passwordHash'] === '') {
+      return { ok: false, reason: 'each user must have a non-empty string "passwordHash"' };
+    }
     if (!VALID_ROLES.has(u['role'] as string)) {
       return {
         ok: false,

--- a/api/import-validate.ts
+++ b/api/import-validate.ts
@@ -1,0 +1,110 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+import type { ExportUnit } from '../types/index.js';
+
+type ValidationResult = { ok: boolean; reason?: string };
+
+const VALID_ROLES = new Set(['owner', 'user']);
+
+/**
+ * Validates the users unit data structure.
+ * Enforces role in { 'owner', 'user' } per types/index.ts:200.
+ */
+export function validateUsersUnit(data: unknown): ValidationResult {
+  if (typeof data !== 'object' || data === null) {
+    return { ok: false, reason: 'users data must be a non-null object' };
+  }
+  const d = data as Record<string, unknown>;
+  if (!Array.isArray(d['users'])) {
+    return { ok: false, reason: 'users data must have a "users" array' };
+  }
+  for (const user of d['users'] as unknown[]) {
+    if (typeof user !== 'object' || user === null) {
+      return { ok: false, reason: 'each user must be an object' };
+    }
+    const u = user as Record<string, unknown>;
+    if (!VALID_ROLES.has(u['role'] as string)) {
+      return {
+        ok: false,
+        reason: `invalid role "${u['role']}" — must be "owner" or "user"`,
+      };
+    }
+  }
+  return { ok: true };
+}
+
+/**
+ * Validates the pages unit data structure (lenient — top-key shape only).
+ */
+export function validatePagesUnit(data: unknown): ValidationResult {
+  if (typeof data !== 'object' || data === null) {
+    return { ok: false, reason: 'pages data must be a non-null object' };
+  }
+  const d = data as Record<string, unknown>;
+  if (!Array.isArray(d['pages'])) {
+    return { ok: false, reason: 'pages data must have a "pages" array' };
+  }
+  return { ok: true };
+}
+
+/**
+ * Validates the media unit data structure.
+ */
+export function validateMediaUnit(data: unknown): ValidationResult {
+  if (typeof data !== 'object' || data === null) {
+    return { ok: false, reason: 'media data must be a non-null object' };
+  }
+  const d = data as Record<string, unknown>;
+  if (!Array.isArray(d['uploads'])) {
+    return { ok: false, reason: 'media data must have an "uploads" array' };
+  }
+  return { ok: true };
+}
+
+/**
+ * Validates the configuration unit data structure.
+ * Configuration covers site, configs, menus, redirects, languages — validated individually.
+ * At the unit level we only validate by checking each known top-level shape.
+ */
+export function validateConfigurationUnit(data: unknown): ValidationResult {
+  // Configuration is an object containing one or more of the individual data objects.
+  // We accept any non-null object at this level (each file is validated separately on import).
+  if (typeof data !== 'object' || data === null) {
+    return { ok: false, reason: 'configuration data must be a non-null object' };
+  }
+  return { ok: true };
+}
+
+/**
+ * Validates the global-blocks unit data structure.
+ */
+export function validateGlobalBlocksUnit(data: unknown): ValidationResult {
+  if (typeof data !== 'object' || data === null) {
+    return { ok: false, reason: 'global-blocks data must be a non-null object' };
+  }
+  const d = data as Record<string, unknown>;
+  if (typeof d['globalBlocks'] !== 'object' || d['globalBlocks'] === null) {
+    // Also accept { blocks: [] } shape as mentioned in spec
+    if (!Array.isArray(d['blocks'])) {
+      return {
+        ok: false,
+        reason: 'global-blocks data must have a "globalBlocks" object or "blocks" array',
+      };
+    }
+  }
+  return { ok: true };
+}
+
+/**
+ * Unified validator map keyed by ExportUnit.
+ */
+export const unitValidators: Record<ExportUnit, (data: unknown) => ValidationResult> = {
+  pages: validatePagesUnit,
+  media: validateMediaUnit,
+  users: validateUsersUnit,
+  configuration: validateConfigurationUnit,
+  'global-blocks': validateGlobalBlocksUnit,
+};

--- a/api/manifest.ts
+++ b/api/manifest.ts
@@ -92,11 +92,24 @@ export function validateManifest(obj: unknown): { ok: boolean; reason?: string }
   if (!Array.isArray(m['units'])) {
     return { ok: false, reason: 'units must be an array' };
   }
+  // Validate every units element is a known ExportUnit.
+  const knownUnits = new Set<string>(Object.keys(UNIT_TO_DATA_FILES));
+  for (const unit of m['units'] as unknown[]) {
+    if (typeof unit !== 'string' || !knownUnits.has(unit)) {
+      return { ok: false, reason: `unknown unit "${unit}" — must be one of: ${[...knownUnits].join(', ')}` };
+    }
+  }
   if (typeof m['counts'] !== 'object' || m['counts'] === null) {
     return { ok: false, reason: 'counts must be an object' };
   }
   if (typeof m['checksums'] !== 'object' || m['checksums'] === null || Array.isArray(m['checksums'])) {
     return { ok: false, reason: 'checksums must be a non-null object' };
+  }
+  // Validate every checksums value is a non-empty string.
+  for (const [path, hash] of Object.entries(m['checksums'] as Record<string, unknown>)) {
+    if (typeof hash !== 'string' || hash === '') {
+      return { ok: false, reason: `checksums entry "${path}" must be a non-empty string` };
+    }
   }
   return { ok: true };
 }
@@ -126,6 +139,12 @@ export function verifyChecksums(
     const actualHash = sha256Hex(fileBytes);
     if (actualHash !== expectedHash) {
       failed.push(entryPath);
+    }
+  }
+  // Second pass: any staged path not present in manifest.checksums is an injection attempt.
+  for (const stagedPath of Object.keys(staged)) {
+    if (!(stagedPath in manifest.checksums)) {
+      failed.push(stagedPath);
     }
   }
   if (failed.length > 0) {

--- a/api/manifest.ts
+++ b/api/manifest.ts
@@ -1,0 +1,135 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+import crypto from 'node:crypto';
+import { createRequire } from 'node:module';
+import { DATA_SCHEMA_VERSION } from './schema-version.js';
+import type { BackupManifest, ExportUnit } from '../types/index.js';
+
+export type { BackupManifest, ExportUnit };
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Mapping of ExportUnit to the data file paths it covers (relative to data/).
+ * This is the 5-unit → 9-file allowlist.
+ * data/_backups/ is intentionally excluded.
+ */
+export const UNIT_TO_DATA_FILES: Record<ExportUnit, string[]> = {
+  pages: ['data/pages.json'],
+  media: ['data/media.json'],
+  users: ['data/users.json'],
+  configuration: [
+    'data/site.json',
+    'data/configs.json',
+    'data/menus.json',
+    'data/redirects.json',
+    'data/languages.json',
+  ],
+  'global-blocks': ['data/global-blocks.json'],
+};
+
+/** All 9 allowed data file paths (for allowlist validation on import). */
+export const ALL_DATA_FILES = new Set<string>(
+  Object.values(UNIT_TO_DATA_FILES).flat(),
+);
+
+function readPackageVersion(): string {
+  try {
+    // At runtime the package.json is at dist/package.json, resolved relative to this module.
+    const pkg = require('../package.json') as { version: string };
+    return pkg.version;
+  } catch {
+    return 'unknown';
+  }
+}
+
+/**
+ * Builds a BackupManifest from the given units, counts, and checksums.
+ */
+export function buildManifest(
+  units: ExportUnit[],
+  counts: Partial<Record<ExportUnit, number>>,
+  checksums: Record<string, string>,
+): BackupManifest {
+  return {
+    schemaVersion: DATA_SCHEMA_VERSION,
+    astroBlocksVersion: readPackageVersion(),
+    exportedAt: new Date().toISOString(),
+    units,
+    counts,
+    checksums,
+  };
+}
+
+/**
+ * Validates a raw (unknown) object as a BackupManifest.
+ * Returns { ok: true } on success, or { ok: false, reason } on failure.
+ */
+export function validateManifest(obj: unknown): { ok: boolean; reason?: string } {
+  if (typeof obj !== 'object' || obj === null) {
+    return { ok: false, reason: 'manifest must be a non-null object' };
+  }
+  const m = obj as Record<string, unknown>;
+
+  if (typeof m['schemaVersion'] !== 'number') {
+    return { ok: false, reason: 'schemaVersion is missing or not a number' };
+  }
+  if (m['schemaVersion'] !== DATA_SCHEMA_VERSION) {
+    return {
+      ok: false,
+      reason: `version mismatch: archive has schemaVersion ${m['schemaVersion']}, expected ${DATA_SCHEMA_VERSION}`,
+    };
+  }
+  if (typeof m['astroBlocksVersion'] !== 'string' || !m['astroBlocksVersion']) {
+    return { ok: false, reason: 'astroBlocksVersion is missing or empty' };
+  }
+  if (typeof m['exportedAt'] !== 'string' || !m['exportedAt']) {
+    return { ok: false, reason: 'exportedAt is missing or empty' };
+  }
+  if (!Array.isArray(m['units'])) {
+    return { ok: false, reason: 'units must be an array' };
+  }
+  if (typeof m['counts'] !== 'object' || m['counts'] === null) {
+    return { ok: false, reason: 'counts must be an object' };
+  }
+  if (typeof m['checksums'] !== 'object' || m['checksums'] === null || Array.isArray(m['checksums'])) {
+    return { ok: false, reason: 'checksums must be a non-null object' };
+  }
+  return { ok: true };
+}
+
+/**
+ * Computes the SHA-256 hex digest of the given bytes.
+ */
+export function sha256Hex(bytes: Uint8Array | Buffer): string {
+  return crypto.createHash('sha256').update(bytes).digest('hex');
+}
+
+/**
+ * Verifies that staged file contents match checksums in the manifest.
+ * Returns { ok: true } if all match, or { ok: false, failed: string[] } listing mismatches.
+ */
+export function verifyChecksums(
+  staged: Record<string, Buffer>,
+  manifest: BackupManifest,
+): { ok: boolean; failed?: string[] } {
+  const failed: string[] = [];
+  for (const [entryPath, expectedHash] of Object.entries(manifest.checksums)) {
+    const fileBytes = staged[entryPath];
+    if (!fileBytes) {
+      failed.push(entryPath);
+      continue;
+    }
+    const actualHash = sha256Hex(fileBytes);
+    if (actualHash !== expectedHash) {
+      failed.push(entryPath);
+    }
+  }
+  if (failed.length > 0) {
+    return { ok: false, failed };
+  }
+  return { ok: true };
+}

--- a/api/schema-version.ts
+++ b/api/schema-version.ts
@@ -1,0 +1,10 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * Increment ONLY on breaking on-disk shape changes. See CHANGELOG.
+ * Current version: 1 (initial import/export format).
+ */
+export const DATA_SCHEMA_VERSION = 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@lucide/astro": "^1.18.0",
         "@picocss/pico": "^2.1.1",
         "animate.css": "^4.1.1",
+        "fflate": "^0.8.2",
         "image-size": "^2.0.2",
         "jose": "^6.2.3",
         "sharp": "^0.35.1",
@@ -3223,6 +3224,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@lucide/astro": "^1.18.0",
     "@picocss/pico": "^2.1.1",
     "animate.css": "^4.1.1",
+    "fflate": "^0.8.2",
     "image-size": "^2.0.2",
     "jose": "^6.2.3",
     "sharp": "^0.35.1",

--- a/tests/import-export-checksum.test.js
+++ b/tests/import-export-checksum.test.js
@@ -1,0 +1,81 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+
+import { sha256Hex, verifyChecksums, buildManifest } from '../dist/api/manifest.js';
+
+// A-4: sha256Hex
+
+test('A-4: sha256Hex returns known sha256 of "hello"', () => {
+  // Known sha256 of 'hello'
+  const expected = '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824';
+  const actual = sha256Hex(Buffer.from('hello'));
+  assert.equal(actual, expected);
+});
+
+test('A-4: sha256Hex accepts Uint8Array', () => {
+  const bytes = new Uint8Array([104, 101, 108, 108, 111]); // 'hello'
+  const expected = '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824';
+  assert.equal(sha256Hex(bytes), expected);
+});
+
+test('A-4: sha256Hex matches node:crypto output directly', () => {
+  const bytes = Buffer.from('test content for checksum');
+  const expected = crypto.createHash('sha256').update(bytes).digest('hex');
+  assert.equal(sha256Hex(bytes), expected);
+});
+
+// A-4: verifyChecksums
+
+function makeManifestWithChecksums(checksums) {
+  return buildManifest(['pages'], { pages: 1 }, checksums);
+}
+
+test('A-4: verifyChecksums returns { ok: true } when all staged entries match', () => {
+  const content = Buffer.from('{"pages":[]}');
+  const hash = sha256Hex(content);
+  const manifest = makeManifestWithChecksums({ 'data/pages.json': hash });
+  const staged = { 'data/pages.json': content };
+  const result = verifyChecksums(staged, manifest);
+  assert.deepEqual(result, { ok: true });
+});
+
+test('A-4: verifyChecksums returns { ok: false, failed } when one entry mismatches', () => {
+  const content = Buffer.from('{"pages":[]}');
+  const hash = sha256Hex(content);
+  const manifest = makeManifestWithChecksums({ 'data/pages.json': hash });
+  const tamperedStaged = { 'data/pages.json': Buffer.from('{"pages":["tampered"]}') };
+  const result = verifyChecksums(tamperedStaged, manifest);
+  assert.equal(result.ok, false);
+  assert.ok(Array.isArray(result.failed));
+  assert.ok(result.failed.includes('data/pages.json'));
+});
+
+test('A-4: verifyChecksums returns { ok: false } when manifest entry is missing from staged', () => {
+  const hash = sha256Hex(Buffer.from('content'));
+  const manifest = makeManifestWithChecksums({ 'data/pages.json': hash });
+  const result = verifyChecksums({}, manifest); // staged is empty
+  assert.equal(result.ok, false);
+  assert.ok(result.failed?.includes('data/pages.json'));
+});
+
+test('A-4: verifyChecksums succeeds with multiple matching entries', () => {
+  const pages = Buffer.from('{"pages":[]}');
+  const users = Buffer.from('{"users":[]}');
+  const checksums = {
+    'data/pages.json': sha256Hex(pages),
+    'data/users.json': sha256Hex(users),
+  };
+  const manifest = makeManifestWithChecksums(checksums);
+  const staged = {
+    'data/pages.json': pages,
+    'data/users.json': users,
+  };
+  const result = verifyChecksums(staged, manifest);
+  assert.deepEqual(result, { ok: true });
+});

--- a/tests/import-export-checksum.test.js
+++ b/tests/import-export-checksum.test.js
@@ -79,3 +79,21 @@ test('A-4: verifyChecksums succeeds with multiple matching entries', () => {
   const result = verifyChecksums(staged, manifest);
   assert.deepEqual(result, { ok: true });
 });
+
+// C-1: extra staged files not in manifest must be rejected (injection bypass guard)
+
+test('C-1: verifyChecksums returns { ok: false } when staged has extra file not in manifest checksums', () => {
+  const pages = Buffer.from('{"pages":[]}');
+  const pagesHash = sha256Hex(pages);
+  // manifest only covers data/pages.json
+  const manifest = makeManifestWithChecksums({ 'data/pages.json': pagesHash });
+  const staged = {
+    'data/pages.json': pages,
+    // injected file not listed in manifest.checksums
+    'data/users.json': Buffer.from('{"users":[{"role":"owner","id":"x","email":"x@x.com","passwordHash":"h"}]}'),
+  };
+  const result = verifyChecksums(staged, manifest);
+  assert.equal(result.ok, false);
+  assert.ok(Array.isArray(result.failed));
+  assert.ok(result.failed.includes('data/users.json'));
+});

--- a/tests/import-export-fflate-bridge.test.js
+++ b/tests/import-export-fflate-bridge.test.js
@@ -1,0 +1,125 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// A-1 canary: fflate core exports are available (validates fflate is installed + build succeeds)
+import { strToU8, Zip, Unzip } from 'fflate';
+
+test('A-1: fflate strToU8 is a function', () => {
+  assert.equal(typeof strToU8, 'function');
+});
+
+test('A-1: fflate Zip is a function (constructor)', () => {
+  assert.equal(typeof Zip, 'function');
+});
+
+test('A-1: fflate Unzip is a function (constructor)', () => {
+  assert.equal(typeof Unzip, 'function');
+});
+
+// A-7: fflate <-> ReadableStream bridge tests
+import { fflateZipToReadableStream, readableStreamToFflateUnzip } from '../dist/api/backup-stream.js';
+import { ZipDeflate } from 'fflate';
+
+test('A-7: fflateZipToReadableStream is a function', () => {
+  assert.equal(typeof fflateZipToReadableStream, 'function');
+});
+
+test('A-7: readableStreamToFflateUnzip is a function', () => {
+  assert.equal(typeof readableStreamToFflateUnzip, 'function');
+});
+
+test('A-7: round-trip zip then unzip via ReadableStream', async () => {
+  const inputContent = 'Hello, fflate ReadableStream bridge!';
+  const inputBytes = strToU8(inputContent);
+
+  // Zip via ReadableStream using synchronous ZipDeflate
+  const zipStream = fflateZipToReadableStream((zip) => {
+    const entry = new ZipDeflate('test.txt');
+    zip.add(entry);
+    entry.push(inputBytes, true);
+    zip.end();
+  });
+
+  // Collect zipped bytes
+  const reader = zipStream.getReader();
+  const chunks = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
+  const zipped = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    zipped.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  // Verify zip magic bytes: PK\x03\x04
+  assert.equal(zipped[0], 0x50, 'zip magic byte 0 should be 0x50 (P)');
+  assert.equal(zipped[1], 0x4b, 'zip magic byte 1 should be 0x4b (K)');
+  assert.equal(zipped[2], 0x03, 'zip magic byte 2 should be 0x03');
+  assert.equal(zipped[3], 0x04, 'zip magic byte 3 should be 0x04');
+
+  // Unzip via ReadableStream
+  const zipBuffer = Buffer.from(zipped);
+  const unzipStream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new Uint8Array(zipBuffer));
+      controller.close();
+    },
+  });
+
+  const extracted = {};
+  await readableStreamToFflateUnzip(unzipStream, async (name, data) => {
+    extracted[name] = Buffer.from(data).toString('utf-8');
+  });
+
+  assert.ok('test.txt' in extracted, 'extracted should contain test.txt');
+  assert.equal(extracted['test.txt'], inputContent, 'extracted content should match input');
+});
+
+test('A-7: zip output starts with PK\\x03\\x04 magic bytes', async () => {
+  const bytes = strToU8('small content');
+  const stream = fflateZipToReadableStream((zip) => {
+    const entry = new ZipDeflate('file.txt');
+    zip.add(entry);
+    entry.push(bytes, true);
+    zip.end();
+  });
+
+  const reader = stream.getReader();
+  const firstChunk = (await reader.read()).value;
+  reader.cancel();
+
+  assert.ok(firstChunk instanceof Uint8Array, 'first chunk should be Uint8Array');
+  assert.ok(firstChunk.length >= 4, 'first chunk should have at least 4 bytes');
+  assert.equal(firstChunk[0], 0x50);
+  assert.equal(firstChunk[1], 0x4b);
+  assert.equal(firstChunk[2], 0x03);
+  assert.equal(firstChunk[3], 0x04);
+});
+
+test('A-7: controller.error mid-stream aborts cleanly', async () => {
+  // Create a stream that errors partway through
+  const errorStream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new Uint8Array([0x50, 0x4b, 0x03, 0x04])); // partial PK header
+      controller.error(new Error('simulated mid-stream abort'));
+    },
+  });
+
+  // readableStreamToFflateUnzip should reject (propagate the error) rather than hang
+  await assert.rejects(
+    async () => {
+      await readableStreamToFflateUnzip(errorStream, async () => {});
+    },
+    /simulated mid-stream abort/,
+  );
+});

--- a/tests/import-export-manifest.test.js
+++ b/tests/import-export-manifest.test.js
@@ -1,0 +1,104 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildManifest,
+  validateManifest,
+  UNIT_TO_DATA_FILES,
+} from '../dist/api/manifest.js';
+import { DATA_SCHEMA_VERSION } from '../dist/api/schema-version.js';
+
+// A-3: buildManifest
+
+test('A-3: buildManifest returns object with schemaVersion equal to DATA_SCHEMA_VERSION', () => {
+  const manifest = buildManifest(
+    ['pages'],
+    { pages: 3 },
+    { 'data/pages.json': 'abc123' },
+  );
+  assert.equal(manifest.schemaVersion, DATA_SCHEMA_VERSION);
+});
+
+test('A-3: buildManifest sets astroBlocksVersion to a non-empty string', () => {
+  const manifest = buildManifest(['pages'], { pages: 3 }, { 'data/pages.json': 'abc123' });
+  assert.equal(typeof manifest.astroBlocksVersion, 'string');
+  assert.ok(manifest.astroBlocksVersion.length > 0, 'astroBlocksVersion should be non-empty');
+});
+
+test('A-3: buildManifest sets exportedAt to an ISO 8601 string', () => {
+  const manifest = buildManifest(['pages'], { pages: 3 }, { 'data/pages.json': 'abc123' });
+  assert.equal(typeof manifest.exportedAt, 'string');
+  assert.match(manifest.exportedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$/);
+});
+
+test('A-3: buildManifest propagates units, counts, and checksums', () => {
+  const units = ['pages'];
+  const counts = { pages: 3 };
+  const checksums = { 'data/pages.json': 'abc123' };
+  const manifest = buildManifest(units, counts, checksums);
+  assert.deepEqual(manifest.units, units);
+  assert.deepEqual(manifest.counts, counts);
+  assert.deepEqual(manifest.checksums, checksums);
+});
+
+// A-3: validateManifest
+
+function makeValidManifest() {
+  return buildManifest(['pages'], { pages: 1 }, { 'data/pages.json': 'aabbcc' });
+}
+
+test('A-3: validateManifest returns { ok: true } for a valid manifest', () => {
+  const result = validateManifest(makeValidManifest());
+  assert.deepEqual(result, { ok: true });
+});
+
+test('A-3: validateManifest returns { ok: false } with reason containing "schemaVersion" for empty object', () => {
+  const result = validateManifest({});
+  assert.equal(result.ok, false);
+  assert.match(result.reason ?? '', /schemaVersion/);
+});
+
+test('A-3: validateManifest returns { ok: false } with reason containing "version mismatch" for wrong schemaVersion', () => {
+  const valid = makeValidManifest();
+  const result = validateManifest({ ...valid, schemaVersion: 99 });
+  assert.equal(result.ok, false);
+  assert.match(result.reason ?? '', /version mismatch/);
+});
+
+test('A-3: validateManifest returns { ok: false } when checksums is null', () => {
+  const valid = makeValidManifest();
+  const result = validateManifest({ ...valid, checksums: null });
+  assert.equal(result.ok, false);
+});
+
+test('A-3: validateManifest returns { ok: false } for null input', () => {
+  const result = validateManifest(null);
+  assert.equal(result.ok, false);
+});
+
+// A-3: UNIT_TO_DATA_FILES mapping
+
+test('A-3: UNIT_TO_DATA_FILES has exactly 5 units', () => {
+  const keys = Object.keys(UNIT_TO_DATA_FILES);
+  assert.equal(keys.length, 5);
+  assert.ok(keys.includes('pages'));
+  assert.ok(keys.includes('media'));
+  assert.ok(keys.includes('users'));
+  assert.ok(keys.includes('configuration'));
+  assert.ok(keys.includes('global-blocks'));
+});
+
+test('A-3: UNIT_TO_DATA_FILES maps to exactly 9 unique files total', () => {
+  const allFiles = Object.values(UNIT_TO_DATA_FILES).flat();
+  const unique = new Set(allFiles);
+  assert.equal(unique.size, 9);
+});
+
+test('A-3: UNIT_TO_DATA_FILES configuration maps to 5 files', () => {
+  assert.equal(UNIT_TO_DATA_FILES['configuration'].length, 5);
+});

--- a/tests/import-export-manifest.test.js
+++ b/tests/import-export-manifest.test.js
@@ -81,6 +81,35 @@ test('A-3: validateManifest returns { ok: false } for null input', () => {
   assert.equal(result.ok, false);
 });
 
+// H-3: validateManifest must validate checksums values and units elements
+
+test('H-3: validateManifest returns { ok: false } when a checksums value is null', () => {
+  const valid = makeValidManifest();
+  const result = validateManifest({ ...valid, checksums: { 'data/users.json': null } });
+  assert.equal(result.ok, false);
+  assert.ok(result.reason, 'should provide a reason');
+});
+
+test('H-3: validateManifest returns { ok: false } when a checksums value is empty string', () => {
+  const valid = makeValidManifest();
+  const result = validateManifest({ ...valid, checksums: { 'data/users.json': '' } });
+  assert.equal(result.ok, false);
+  assert.ok(result.reason, 'should provide a reason');
+});
+
+test('H-3: validateManifest returns { ok: false } when units contains unknown value', () => {
+  const valid = makeValidManifest();
+  const result = validateManifest({ ...valid, units: ['pages', 'bogus'] });
+  assert.equal(result.ok, false);
+  assert.ok(result.reason, 'should provide a reason');
+});
+
+test('H-3: validateManifest returns { ok: true } for valid manifest with known units and non-empty checksums', () => {
+  const valid = makeValidManifest();
+  const result = validateManifest(valid);
+  assert.deepEqual(result, { ok: true });
+});
+
 // A-3: UNIT_TO_DATA_FILES mapping
 
 test('A-3: UNIT_TO_DATA_FILES has exactly 5 units', () => {

--- a/tests/import-export-schema-version.test.js
+++ b/tests/import-export-schema-version.test.js
@@ -1,0 +1,21 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { DATA_SCHEMA_VERSION } from '../dist/api/schema-version.js';
+
+test('A-2: DATA_SCHEMA_VERSION is a number', () => {
+  assert.equal(typeof DATA_SCHEMA_VERSION, 'number');
+});
+
+test('A-2: DATA_SCHEMA_VERSION equals 1', () => {
+  assert.equal(DATA_SCHEMA_VERSION, 1);
+});
+
+test('A-2: DATA_SCHEMA_VERSION is greater than 0', () => {
+  assert.ok(DATA_SCHEMA_VERSION > 0);
+});

--- a/tests/import-export-utils.test.js
+++ b/tests/import-export-utils.test.js
@@ -109,3 +109,53 @@ test('A-6: readCeilingEnvVars reads ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES', () => 
     else process.env['ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES'] = prev;
   }
 });
+
+// H-1: readCeilingEnvVars must reject NaN/zero/negative — fall back to default
+
+test('H-1: readCeilingEnvVars falls back to default perFile when env is non-numeric ("abc")', () => {
+  const prev = process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'];
+  try {
+    process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'] = 'abc';
+    const result = readCeilingEnvVars();
+    assert.equal(result.perFile, DEFAULT_MAX_IMPORT_FILE_BYTES);
+  } finally {
+    if (prev === undefined) delete process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'];
+    else process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'] = prev;
+  }
+});
+
+test('H-1: readCeilingEnvVars falls back to default perFile when env is "0"', () => {
+  const prev = process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'];
+  try {
+    process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'] = '0';
+    const result = readCeilingEnvVars();
+    assert.equal(result.perFile, DEFAULT_MAX_IMPORT_FILE_BYTES);
+  } finally {
+    if (prev === undefined) delete process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'];
+    else process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'] = prev;
+  }
+});
+
+test('H-1: readCeilingEnvVars falls back to default perFile when env is "-1"', () => {
+  const prev = process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'];
+  try {
+    process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'] = '-1';
+    const result = readCeilingEnvVars();
+    assert.equal(result.perFile, DEFAULT_MAX_IMPORT_FILE_BYTES);
+  } finally {
+    if (prev === undefined) delete process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'];
+    else process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'] = prev;
+  }
+});
+
+// M-2: selectBackupsToPrune must clamp keep < 1 to 1 (never wipe all backups)
+
+test('M-2: selectBackupsToPrune with keep=0 returns only the oldest entries (clamps to keep=1)', () => {
+  const dirs = ['2024-01-01', '2024-01-02', '2024-01-03'];
+  const result = selectBackupsToPrune(dirs, 0);
+  // clamp-to-1: keeps the newest 1, so returns the oldest 2
+  assert.equal(result.length, 2);
+  assert.ok(result.includes('2024-01-01'));
+  assert.ok(result.includes('2024-01-02'));
+  assert.ok(!result.includes('2024-01-03'));
+});

--- a/tests/import-export-utils.test.js
+++ b/tests/import-export-utils.test.js
@@ -1,0 +1,111 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  selectBackupsToPrune,
+  assertWithinCeilings,
+  readCeilingEnvVars,
+  DEFAULT_MAX_IMPORT_FILE_BYTES,
+  DEFAULT_MAX_IMPORT_TOTAL_BYTES,
+} from '../dist/api/import-utils.js';
+
+// A-6: selectBackupsToPrune
+
+test('A-6: selectBackupsToPrune returns oldest entries beyond keep=5', () => {
+  const dirs = ['2024-01-01', '2024-01-02', '2024-01-03', '2024-01-04', '2024-01-05', '2024-01-06'];
+  const result = selectBackupsToPrune(dirs, 5);
+  assert.deepEqual(result, ['2024-01-01']);
+});
+
+test('A-6: selectBackupsToPrune returns empty when count equals keep', () => {
+  const result = selectBackupsToPrune(['2024-01-01'], 5);
+  assert.deepEqual(result, []);
+});
+
+test('A-6: selectBackupsToPrune returns empty for empty array', () => {
+  assert.deepEqual(selectBackupsToPrune([], 5), []);
+});
+
+test('A-6: selectBackupsToPrune returns multiple when far over retention', () => {
+  const dirs = [
+    '2024-01-01',
+    '2024-01-02',
+    '2024-01-03',
+    '2024-01-04',
+    '2024-01-05',
+    '2024-01-06',
+    '2024-01-07',
+  ];
+  const result = selectBackupsToPrune(dirs, 5);
+  assert.deepEqual(result, ['2024-01-01', '2024-01-02']);
+});
+
+// A-6: assertWithinCeilings
+
+test('A-6: assertWithinCeilings does not throw when within limits', () => {
+  assert.doesNotThrow(() => {
+    assertWithinCeilings(500, 1000, { perFile: 1024, total: 10240 });
+  });
+});
+
+test('A-6: assertWithinCeilings throws with /per-file/ when perFile exceeds limit', () => {
+  assert.throws(
+    () => assertWithinCeilings(2000, 1000, { perFile: 1024, total: 10240 }),
+    /per-file/,
+  );
+});
+
+test('A-6: assertWithinCeilings throws with /total/ when total exceeds limit', () => {
+  assert.throws(
+    () => assertWithinCeilings(500, 20000, { perFile: 1024, total: 10240 }),
+    /total/,
+  );
+});
+
+// A-6: readCeilingEnvVars
+
+test('A-6: readCeilingEnvVars returns defaults when env vars are unset', () => {
+  const prev1 = process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'];
+  const prev2 = process.env['ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES'];
+  try {
+    delete process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'];
+    delete process.env['ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES'];
+    const result = readCeilingEnvVars();
+    assert.equal(result.perFile, DEFAULT_MAX_IMPORT_FILE_BYTES);
+    assert.equal(result.total, DEFAULT_MAX_IMPORT_TOTAL_BYTES);
+  } finally {
+    if (prev1 === undefined) delete process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'];
+    else process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'] = prev1;
+    if (prev2 === undefined) delete process.env['ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES'];
+    else process.env['ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES'] = prev2;
+  }
+});
+
+test('A-6: readCeilingEnvVars reads ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES', () => {
+  const prev = process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'];
+  try {
+    process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'] = '999';
+    const result = readCeilingEnvVars();
+    assert.equal(result.perFile, 999);
+  } finally {
+    if (prev === undefined) delete process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'];
+    else process.env['ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES'] = prev;
+  }
+});
+
+test('A-6: readCeilingEnvVars reads ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES', () => {
+  const prev = process.env['ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES'];
+  try {
+    process.env['ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES'] = '9999';
+    const result = readCeilingEnvVars();
+    assert.equal(result.total, 9999);
+  } finally {
+    if (prev === undefined) delete process.env['ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES'];
+    else process.env['ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES'] = prev;
+  }
+});

--- a/tests/import-export-validators.test.js
+++ b/tests/import-export-validators.test.js
@@ -1,0 +1,121 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  validateUsersUnit,
+  validatePagesUnit,
+  validateMediaUnit,
+  validateConfigurationUnit,
+  validateGlobalBlocksUnit,
+  unitValidators,
+} from '../dist/api/import-validate.js';
+
+// A-5: validateUsersUnit
+
+test('A-5: validateUsersUnit accepts empty users array', () => {
+  assert.deepEqual(validateUsersUnit({ users: [] }), { ok: true });
+});
+
+test('A-5: validateUsersUnit accepts valid user with role "owner"', () => {
+  const result = validateUsersUnit({
+    users: [{ id: '1', email: 'a@b.com', passwordHash: 'x', role: 'owner' }],
+  });
+  assert.deepEqual(result, { ok: true });
+});
+
+test('A-5: validateUsersUnit accepts valid user with role "user"', () => {
+  const result = validateUsersUnit({
+    users: [{ id: '2', email: 'b@c.com', passwordHash: 'y', role: 'user' }],
+  });
+  assert.deepEqual(result, { ok: true });
+});
+
+test('A-5: validateUsersUnit rejects invalid role "superadmin"', () => {
+  const result = validateUsersUnit({
+    users: [{ id: '1', email: 'a@b.com', passwordHash: 'x', role: 'superadmin' }],
+  });
+  assert.equal(result.ok, false);
+});
+
+test('A-5: validateUsersUnit rejects null', () => {
+  const result = validateUsersUnit(null);
+  assert.equal(result.ok, false);
+});
+
+// A-5: validatePagesUnit
+
+test('A-5: validatePagesUnit accepts empty pages array', () => {
+  assert.deepEqual(validatePagesUnit({ pages: [] }), { ok: true });
+});
+
+test('A-5: validatePagesUnit accepts page with only id (lenient)', () => {
+  const result = validatePagesUnit({ pages: [{ id: '1' }] });
+  assert.deepEqual(result, { ok: true });
+});
+
+test('A-5: validatePagesUnit rejects null', () => {
+  assert.equal(validatePagesUnit(null).ok, false);
+});
+
+test('A-5: validatePagesUnit rejects object without pages key', () => {
+  assert.equal(validatePagesUnit({}).ok, false);
+});
+
+// A-5: validateMediaUnit
+
+test('A-5: validateMediaUnit accepts empty uploads array', () => {
+  assert.deepEqual(validateMediaUnit({ uploads: [] }), { ok: true });
+});
+
+test('A-5: validateMediaUnit rejects null', () => {
+  assert.equal(validateMediaUnit(null).ok, false);
+});
+
+// A-5: validateConfigurationUnit
+
+test('A-5: validateConfigurationUnit accepts an object', () => {
+  assert.deepEqual(validateConfigurationUnit({ site: {} }), { ok: true });
+});
+
+test('A-5: validateConfigurationUnit rejects null', () => {
+  assert.equal(validateConfigurationUnit(null).ok, false);
+});
+
+// A-5: validateGlobalBlocksUnit
+
+test('A-5: validateGlobalBlocksUnit accepts { globalBlocks: {} }', () => {
+  assert.deepEqual(validateGlobalBlocksUnit({ globalBlocks: {} }), { ok: true });
+});
+
+test('A-5: validateGlobalBlocksUnit accepts { blocks: [] }', () => {
+  assert.deepEqual(validateGlobalBlocksUnit({ blocks: [] }), { ok: true });
+});
+
+test('A-5: validateGlobalBlocksUnit rejects null', () => {
+  assert.equal(validateGlobalBlocksUnit(null).ok, false);
+});
+
+// A-5: unitValidators map
+
+test('A-5: unitValidators has all 5 ExportUnit keys', () => {
+  const keys = Object.keys(unitValidators);
+  assert.equal(keys.length, 5);
+  assert.ok(keys.includes('pages'));
+  assert.ok(keys.includes('media'));
+  assert.ok(keys.includes('users'));
+  assert.ok(keys.includes('configuration'));
+  assert.ok(keys.includes('global-blocks'));
+});
+
+test('A-5: unitValidators.users delegates to validateUsersUnit', () => {
+  assert.equal(unitValidators['users']({ users: [] }).ok, true);
+  assert.equal(
+    unitValidators['users']({ users: [{ role: 'superadmin' }] }).ok,
+    false,
+  );
+});

--- a/tests/import-export-validators.test.js
+++ b/tests/import-export-validators.test.js
@@ -100,6 +100,39 @@ test('A-5: validateGlobalBlocksUnit rejects null', () => {
   assert.equal(validateGlobalBlocksUnit(null).ok, false);
 });
 
+// H-2: validateUsersUnit must require id, email, passwordHash (not just role)
+
+test('H-2: validateUsersUnit rejects user missing passwordHash', () => {
+  const result = validateUsersUnit({
+    users: [{ id: '1', email: 'a@b.com', role: 'owner' }],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.reason, 'should provide a reason');
+});
+
+test('H-2: validateUsersUnit rejects user missing email', () => {
+  const result = validateUsersUnit({
+    users: [{ id: '1', passwordHash: 'h', role: 'owner' }],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.reason, 'should provide a reason');
+});
+
+test('H-2: validateUsersUnit rejects user missing id', () => {
+  const result = validateUsersUnit({
+    users: [{ email: 'a@b.com', passwordHash: 'h', role: 'owner' }],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.reason, 'should provide a reason');
+});
+
+test('H-2: validateUsersUnit accepts fully valid user with id, email, passwordHash, role', () => {
+  const result = validateUsersUnit({
+    users: [{ id: '1', email: 'a@b.com', passwordHash: 'hashed', role: 'owner' }],
+  });
+  assert.deepEqual(result, { ok: true });
+});
+
 // A-5: unitValidators map
 
 test('A-5: unitValidators has all 5 ExportUnit keys', () => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -305,6 +305,27 @@ export interface MediaData {
   uploads: MediaEntry[];
 }
 
+// --- Import/Export types ---
+
+export type ExportUnit = 'pages' | 'media' | 'users' | 'configuration' | 'global-blocks';
+
+export interface BackupManifest {
+  /** DATA_SCHEMA_VERSION at export time. Strict equality checked on import. */
+  schemaVersion: number;
+  /** Package version from package.json — informational only, does not gate import. */
+  astroBlocksVersion: string;
+  /** ISO 8601 timestamp of when the archive was created. */
+  exportedAt: string;
+  /** The export units included in this archive. */
+  units: ExportUnit[];
+  /** Entry count per unit. */
+  counts: Partial<Record<ExportUnit, number>>;
+  /** Zip-entry path → sha256 hex digest for every data/* and uploads/* entry. */
+  checksums: Record<string, string>;
+}
+
+// --- End Import/Export types ---
+
 export interface AstroBlocksOptions {
   layoutPath?: string;
   blocks: BlockSchema[];


### PR DESCRIPTION
## Slice A — Foundation (import/export)

First PR in the chained `import-export` feature (feature-branch-chain; base = `feat/import-export` tracker). No user-visible behavior — pure foundation modules + new dependency that unblock the export (B), import pipeline (C), bootstrap import (D), and admin UI (E) slices.

### What's included (tasks A-1 … A-7)
- **A-1** — `fflate@^0.8.2` added to `dependencies` (pure JS, zero native deps, streaming).
- **A-2** — `api/schema-version.ts` → `DATA_SCHEMA_VERSION = 1` (the strict compatibility key).
- **A-3** — `api/manifest.ts` → `ExportUnit`, `BackupManifest`, `UNIT_TO_DATA_FILES` (5 units → 9-file allowlist), `buildManifest`, `validateManifest` (strict schemaVersion equality).
- **A-4** — `sha256Hex` + `verifyChecksums` (node:crypto only).
- **A-5** — `api/import-validate.ts` → per-unit structural validators (`unitValidators`).
- **A-6** — `api/import-utils.ts` → `selectBackupsToPrune`, `assertWithinCeilings`, `readCeilingEnvVars` (env vars `ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES` default 50MB, `ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES` default 500MB).
- **A-7** — `api/backup-stream.ts` → `fflate ↔ web ReadableStream` bridge (the critical streaming spike B and C depend on).

### Design notes
- fflate's Worker-based `Async*` variants fail in this Node ESM environment → using synchronous `ZipDeflate`/`UnzipInflate` (equivalent for server-side use; fine for typical backup sizes).

### Adversarial review + hardening
A fresh-context security review (threat model: replace-all import + unauthenticated bootstrap import + zip-bomb) flagged 1 CRITICAL + 3 HIGH + 1 MEDIUM, all fixed in `6d44b80`:
- **C-1 (critical)** — `verifyChecksums` now also flags staged files absent from the manifest (closes injection bypass).
- **H-1** — `readCeilingEnvVars` rejects NaN/0/negative → defaults (was failing the zip-bomb defense OPEN).
- **H-2** — `validateUsersUnit` now requires non-empty `id`/`email`/`passwordHash`.
- **H-3** — `validateManifest` now validates `checksums` value types and `units` element types.
- **M-2** — `selectBackupsToPrune` clamps `keep` to ≥1 (was wiping all backups at `keep=0`).

Carry-forward to Slice C (M-1): the decompression ceiling must be enforced DURING streaming extraction (cumulative byte tracking), not after a file is fully buffered.

### Tests
Strict TDD (RED → GREEN → REFACTOR). `npm test` = `npm run build && node --test tests/*.test.js`.
**Full suite: 810 pass / 0 fail** (no regressions). ~60 new Slice A tests across 6 test files.
