### PR TITLE
feat(import-export): export endpoint — GET /cms/api/export (Slice B)

### DIFF
--- a/api/backup.ts
+++ b/api/backup.ts
@@ -56,10 +56,17 @@ async function* walkDir(
   }
   for (const name of names) {
     const absPath = path.join(dir, name);
-    let stat: Awaited<ReturnType<typeof fs.stat>>;
+    let stat: Awaited<ReturnType<typeof fs.lstat>>;
     try {
-      stat = await fs.stat(absPath);
+      // Use lstat (not stat) so we inspect the symlink itself, not its target.
+      // Symlinks are skipped entirely to prevent path-traversal leaks via
+      // crafted uploads pointing outside the project root.
+      stat = await fs.lstat(absPath);
     } catch {
+      continue;
+    }
+    if (stat.isSymbolicLink()) {
+      // Skip symlinks — do not follow, do not include
       continue;
     }
     if (stat.isDirectory()) {
@@ -102,16 +109,25 @@ export async function buildExportStream(
     throw new Error('units must be a non-empty array');
   }
 
+  // Defense-in-depth: deduplicate units so callers cannot produce duplicate zip entries.
+  const dedupedUnits = [...new Set(units)];
+
   // Resolve the project root (allows injection for tests)
   const root = projectRoot ?? (process.env.ASTRO_BLOCKS_PROJECT_ROOT || process.cwd());
 
+  // SOURCE BUFFERING NOTE (v1 tradeoff): source file bytes are read into memory
+  // before the zip stream opens. The zip OUTPUT is streamed to the client;
+  // SOURCE buffering is a known v1 tradeoff acceptable for typical CMS backup sizes.
+  // True source streaming (pipe each file directly into the zip deflate entry) is a
+  // future optimization.
+  //
   // Collect all data file entries synchronously before starting the stream.
   // We need the bytes to compute checksums before building the manifest.
   const dataEntries: Array<{ entryName: string; bytes: Uint8Array }> = [];
   const uploadsEntries: Array<{ entryName: string; bytes: Uint8Array }> = [];
   const counts: Partial<Record<ExportUnit, number>> = {};
 
-  for (const unit of units) {
+  for (const unit of dedupedUnits) {
     const dataFiles = UNIT_TO_DATA_FILES[unit];
     let unitCount = 0;
 
@@ -164,7 +180,7 @@ export async function buildExportStream(
   }
 
   // Build the manifest (written last into the zip)
-  const manifest = buildManifest(units, counts, checksums);
+  const manifest = buildManifest(dedupedUnits, counts, checksums);
   const manifestBytes = strToBytes(JSON.stringify(manifest, null, 2));
 
   // Create the streaming zip

--- a/api/backup.ts
+++ b/api/backup.ts
@@ -1,0 +1,186 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * api/backup.ts — Export service for streaming zip archives.
+ *
+ * Implements ADR-4: buildExportStream enumerates only the 9-file allowlist
+ * (UNIT_TO_DATA_FILES) and, for the media unit, also includes the
+ * public/uploads tree as `uploads/...` entries.
+ *
+ * Checksums (sha256) are computed for every entry; manifest.json is written
+ * LAST so its checksums map is complete.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { ZipDeflate } from 'fflate';
+import { fflateZipToReadableStream } from './backup-stream.js';
+import { UNIT_TO_DATA_FILES, buildManifest, sha256Hex } from './manifest.js';
+import type { ExportUnit } from './manifest.js';
+import { getDataPath, getUploadsDir } from '../utils/paths.js';
+
+/** Converts a string to Uint8Array (UTF-8). */
+function strToBytes(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+/**
+ * Read a raw file from disk and return its contents as a Buffer.
+ * Returns null when the file does not exist (data not yet initialised).
+ */
+async function readRawFile(filePath: string): Promise<Buffer | null> {
+  try {
+    return await fs.readFile(filePath);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Recursively walk a directory and yield { relPath, absPath } for every file.
+ * relPath is relative to the base directory.
+ */
+async function* walkDir(
+  dir: string,
+  base: string = dir,
+): AsyncGenerator<{ relPath: string; absPath: string }> {
+  let names: string[];
+  try {
+    names = await fs.readdir(dir);
+  } catch {
+    // Directory does not exist — skip silently
+    return;
+  }
+  for (const name of names) {
+    const absPath = path.join(dir, name);
+    let stat: Awaited<ReturnType<typeof fs.stat>>;
+    try {
+      stat = await fs.stat(absPath);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      yield* walkDir(absPath, base);
+    } else if (stat.isFile()) {
+      const relPath = path.relative(base, absPath);
+      yield { relPath, absPath };
+    }
+  }
+}
+
+/**
+ * Add a single entry to an fflate Zip synchronously.
+ * Returns the sha256 hex digest of the raw bytes written.
+ */
+function addZipEntry(
+  zip: InstanceType<typeof import('fflate').Zip>,
+  entryName: string,
+  bytes: Uint8Array,
+): string {
+  const entry = new ZipDeflate(entryName);
+  zip.add(entry);
+  entry.push(bytes, true);
+  return sha256Hex(bytes);
+}
+
+/**
+ * Build a streaming zip export for the given units.
+ *
+ * @param units   - Non-empty array of ExportUnit keys to include.
+ * @param projectRoot - Project root directory (defaults to ASTRO_BLOCKS_PROJECT_ROOT / cwd).
+ * @returns A ReadableStream<Uint8Array> of the zip archive bytes.
+ * @throws Error when units is empty.
+ */
+export async function buildExportStream(
+  units: ExportUnit[],
+  projectRoot?: string,
+): Promise<ReadableStream<Uint8Array>> {
+  if (!units || units.length === 0) {
+    throw new Error('units must be a non-empty array');
+  }
+
+  // Resolve the project root (allows injection for tests)
+  const root = projectRoot ?? (process.env.ASTRO_BLOCKS_PROJECT_ROOT || process.cwd());
+
+  // Collect all data file entries synchronously before starting the stream.
+  // We need the bytes to compute checksums before building the manifest.
+  const dataEntries: Array<{ entryName: string; bytes: Uint8Array }> = [];
+  const uploadsEntries: Array<{ entryName: string; bytes: Uint8Array }> = [];
+  const counts: Partial<Record<ExportUnit, number>> = {};
+
+  for (const unit of units) {
+    const dataFiles = UNIT_TO_DATA_FILES[unit];
+    let unitCount = 0;
+
+    for (const dataFile of dataFiles) {
+      // dataFile is like "data/pages.json" — resolve to absolute path
+      const filename = path.basename(dataFile); // e.g. "pages.json"
+      const absPath = path.join(root, 'data', filename);
+      const buf = await readRawFile(absPath);
+      if (buf) {
+        dataEntries.push({ entryName: dataFile, bytes: new Uint8Array(buf) });
+        // Count records for the manifest
+        try {
+          const parsed = JSON.parse(buf.toString('utf-8')) as Record<string, unknown>;
+          // Each data file has a primary array — find the first array value
+          for (const val of Object.values(parsed)) {
+            if (Array.isArray(val)) {
+              unitCount += val.length;
+              break;
+            }
+          }
+        } catch {
+          // Not parseable JSON — count = 0, still include the file
+        }
+      }
+    }
+
+    counts[unit] = unitCount;
+
+    // Media unit: also walk public/uploads tree
+    if (unit === 'media') {
+      const uploadsDir = path.join(root, 'public', 'uploads');
+      for await (const { relPath, absPath } of walkDir(uploadsDir)) {
+        const buf = await readRawFile(absPath);
+        if (buf) {
+          // relPath is relative to uploadsDir; zip entry path is uploads/<relPath>
+          const entryName = 'uploads/' + relPath.replace(/\\/g, '/');
+          uploadsEntries.push({ entryName, bytes: new Uint8Array(buf) });
+        }
+      }
+    }
+  }
+
+  // Compute checksums for all data + uploads entries
+  const checksums: Record<string, string> = {};
+  for (const { entryName, bytes } of dataEntries) {
+    checksums[entryName] = sha256Hex(bytes);
+  }
+  for (const { entryName, bytes } of uploadsEntries) {
+    checksums[entryName] = sha256Hex(bytes);
+  }
+
+  // Build the manifest (written last into the zip)
+  const manifest = buildManifest(units, counts, checksums);
+  const manifestBytes = strToBytes(JSON.stringify(manifest, null, 2));
+
+  // Create the streaming zip
+  const stream = fflateZipToReadableStream((zip) => {
+    // Write data entries
+    for (const { entryName, bytes } of dataEntries) {
+      addZipEntry(zip, entryName, bytes);
+    }
+    // Write uploads entries
+    for (const { entryName, bytes } of uploadsEntries) {
+      addZipEntry(zip, entryName, bytes);
+    }
+    // Write manifest.json LAST
+    addZipEntry(zip, 'manifest.json', manifestBytes);
+    zip.end();
+  });
+
+  return stream;
+}

--- a/api/handlers.ts
+++ b/api/handlers.ts
@@ -1963,10 +1963,14 @@ export async function handleExport(request: Request, authUser?: AuthUser | null)
   // Parse ?units=pages,media,... from the query string
   const url = new URL(request.url);
   const unitsParam = url.searchParams.get('units') ?? '';
-  const rawUnits = unitsParam
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
+  const rawUnits = [
+    ...new Set(
+      unitsParam
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean),
+    ),
+  ];
 
   if (rawUnits.length === 0) {
     return localizedJsonError(request, 'errors.invalidBody', 400);

--- a/api/handlers.ts
+++ b/api/handlers.ts
@@ -55,6 +55,9 @@ import type {
   User,
 } from '../types/index.js';
 import * as data from './data.js';
+import { buildExportStream } from './backup.js';
+import { UNIT_TO_DATA_FILES } from './manifest.js';
+import type { ExportUnit } from './manifest.js';
 import { resolveUiLocale } from '../routes/admin/i18n/resolve.js';
 import { catalogs } from '../routes/admin/i18n/catalogs.js';
 import { t as translateFn } from '../routes/admin/i18n/t.js';
@@ -1936,5 +1939,65 @@ export async function handleInvalidateCache(request: Request, context: HandlerCo
     return localizedJsonError(request, 'errors.cacheInvalidationFailed', 500, undefined, {
       detail: error instanceof Error ? error.message : String(error),
     });
+  }
+}
+
+/**
+ * GET /cms/api/export?units=pages,media,...
+ *
+ * Owner-only streaming zip export of selected CMS units (ADR-4).
+ * Returns the zip archive as a ReadableStream with Content-Type application/zip.
+ */
+export async function handleExport(request: Request, authUser?: AuthUser | null): Promise<Response> {
+  // Auth gate: must be authenticated
+  if (!authUser) {
+    return request
+      ? localizedJsonError(request, 'errors.unauthorized', 401)
+      : jsonError('Unauthorized', 401);
+  }
+
+  // Owner-only gate
+  const forbidden = requireOwner(authUser, request);
+  if (forbidden) return forbidden;
+
+  // Parse ?units=pages,media,... from the query string
+  const url = new URL(request.url);
+  const unitsParam = url.searchParams.get('units') ?? '';
+  const rawUnits = unitsParam
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (rawUnits.length === 0) {
+    return localizedJsonError(request, 'errors.invalidBody', 400);
+  }
+
+  // Validate each unit against the known allowlist
+  const knownUnits = new Set<string>(Object.keys(UNIT_TO_DATA_FILES));
+  for (const unit of rawUnits) {
+    if (!knownUnits.has(unit)) {
+      return localizedJsonError(request, 'errors.invalidBody', 400);
+    }
+  }
+
+  const units = rawUnits as ExportUnit[];
+
+  try {
+    const stream = await buildExportStream(units);
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+    const filename = `astro-blocks-export-${timestamp}.zip`;
+
+    return new Response(stream as unknown as BodyInit, {
+      status: 200,
+      headers: {
+        'content-type': 'application/zip',
+        'content-disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (error) {
+    return jsonError(
+      error instanceof Error ? error.message : 'Export failed',
+      500,
+    );
   }
 }

--- a/routes/api/catchall.ts
+++ b/routes/api/catchall.ts
@@ -48,6 +48,8 @@ export async function GET({ request }: APIContext): Promise<Response> {
   const authResult = await ensureAuth(request);
   if ('status' in authResult) return new Response(JSON.stringify(authResult.body), { status: 401 });
 
+  if (seg[0] === 'export' && seg.length === 1) return handlers.handleExport(request, authResult.user);
+
   if (seg[0] === 'pages' && seg.length === 1) return handlers.handleGetPages(request);
   if (seg[0] === 'site' && seg.length === 1) return handlers.handleGetSite();
   if (seg[0] === 'menus' && seg.length === 1) return handlers.handleGetMenus(request);

--- a/tests/import-export-build-export-stream.test.js
+++ b/tests/import-export-build-export-stream.test.js
@@ -250,3 +250,80 @@ test('B-1: buildExportStream rejects when units array is empty', async () => {
     );
   });
 });
+
+// H-1: deduplicate units — calling with ['pages','pages'] must produce exactly one data/pages.json entry
+
+test('H-1: buildExportStream with duplicate units produces exactly one data/pages.json entry', async () => {
+  await withTempProject(async (tempRoot) => {
+    const stream = await buildExportStream(['pages', 'pages'], tempRoot);
+    const buf = await collectStream(stream);
+    const entries = await extractZip(buf);
+
+    const pagesKeys = Object.keys(entries).filter((n) => n === 'data/pages.json');
+    assert.equal(
+      pagesKeys.length,
+      1,
+      `zip must contain exactly one data/pages.json entry, got ${pagesKeys.length}`,
+    );
+  });
+});
+
+test('H-1: buildExportStream manifest.units has no duplicate when called with duplicate units', async () => {
+  await withTempProject(async (tempRoot) => {
+    const stream = await buildExportStream(['pages', 'pages'], tempRoot);
+    const buf = await collectStream(stream);
+    const entries = await extractZip(buf);
+    const manifest = JSON.parse(entries['manifest.json'].toString('utf-8'));
+
+    const unique = [...new Set(manifest.units)];
+    assert.deepEqual(
+      manifest.units,
+      unique,
+      `manifest.units must not contain duplicates, got ${JSON.stringify(manifest.units)}`,
+    );
+  });
+});
+
+// I-1: walkDir must not follow symlinks — symlink inside uploads pointing outside must be skipped
+
+test('I-1: buildExportStream media unit does not include content of a symlink pointing outside uploads', async () => {
+  await withTempProject(async (tempRoot) => {
+    // Create a secret file outside the project root
+    const secretContent = Buffer.from('TOP SECRET CONTENT');
+    const secretPath = path.join(os.tmpdir(), `astro-blocks-secret-${Date.now()}.txt`);
+    await fs.writeFile(secretPath, secretContent);
+
+    const uploadsDir = path.join(tempRoot, 'public', 'uploads');
+    await fs.mkdir(uploadsDir, { recursive: true });
+
+    let symlinkCreated = false;
+    try {
+      await fs.symlink(secretPath, path.join(uploadsDir, 'secret-link.txt'));
+      symlinkCreated = true;
+    } catch {
+      // Symlinks not available on this platform — skip symlink assertion
+    }
+
+    try {
+      const stream = await buildExportStream(['media'], tempRoot);
+      const buf = await collectStream(stream);
+      const entries = await extractZip(buf);
+
+      if (symlinkCreated) {
+        // The symlink entry must not appear in the zip
+        const symlinkEntries = Object.entries(entries).filter(([name, bytes]) => {
+          if (!name.startsWith('uploads/')) return false;
+          // Check if content matches the secret
+          return Buffer.from(bytes).equals(secretContent);
+        });
+        assert.equal(
+          symlinkEntries.length,
+          0,
+          `zip must not include content from a symlink pointing outside uploads, found ${symlinkEntries.map(([n]) => n).join(', ')}`,
+        );
+      }
+    } finally {
+      await fs.rm(secretPath, { force: true });
+    }
+  });
+});

--- a/tests/import-export-build-export-stream.test.js
+++ b/tests/import-export-build-export-stream.test.js
@@ -1,0 +1,252 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * B-1: buildExportStream tests.
+ * Verifies the streaming zip export for selected units.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { ensureDefaultFiles } from '../dist/api/data.js';
+import { buildExportStream } from '../dist/api/backup.js';
+import { readableStreamToFflateUnzip } from '../dist/api/backup-stream.js';
+import { sha256Hex } from '../dist/api/manifest.js';
+
+async function withTempProject(fn) {
+  const previousRoot = process.env.ASTRO_BLOCKS_PROJECT_ROOT;
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'astro-blocks-export-'));
+
+  process.env.ASTRO_BLOCKS_PROJECT_ROOT = tempRoot;
+  await ensureDefaultFiles();
+
+  try {
+    await fn(tempRoot);
+  } finally {
+    if (previousRoot === undefined) {
+      delete process.env.ASTRO_BLOCKS_PROJECT_ROOT;
+    } else {
+      process.env.ASTRO_BLOCKS_PROJECT_ROOT = previousRoot;
+    }
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Collect all bytes from a ReadableStream<Uint8Array> into a Buffer.
+ */
+async function collectStream(stream) {
+  const reader = stream.getReader();
+  const chunks = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const totalLen = chunks.reduce((s, c) => s + c.length, 0);
+  const buf = Buffer.allocUnsafe(totalLen);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buf.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return buf;
+}
+
+/**
+ * Extract all entries from a zip Buffer.
+ * Returns a Record<name, Buffer>.
+ */
+async function extractZip(zipBuf) {
+  const entries = {};
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new Uint8Array(zipBuf));
+      controller.close();
+    },
+  });
+  await readableStreamToFflateUnzip(stream, async (name, data) => {
+    entries[name] = data;
+  });
+  return entries;
+}
+
+// B-1: zip starts with PK magic bytes
+
+test('B-1: buildExportStream produces a ReadableStream whose bytes start with PK\\x03\\x04', async () => {
+  await withTempProject(async (tempRoot) => {
+    const stream = await buildExportStream(['pages'], tempRoot);
+    const buf = await collectStream(stream);
+
+    assert.ok(buf.length >= 4, 'zip must have at least 4 bytes');
+    assert.equal(buf[0], 0x50, 'byte 0 must be P');
+    assert.equal(buf[1], 0x4b, 'byte 1 must be K');
+    assert.equal(buf[2], 0x03, 'byte 2 must be 0x03');
+    assert.equal(buf[3], 0x04, 'byte 3 must be 0x04');
+  });
+});
+
+// B-1: manifest.json is present as last entry and parseable
+
+test('B-1: zip contains manifest.json and it is parseable JSON', async () => {
+  await withTempProject(async (tempRoot) => {
+    const stream = await buildExportStream(['pages'], tempRoot);
+    const buf = await collectStream(stream);
+    const entries = await extractZip(buf);
+
+    assert.ok('manifest.json' in entries, 'zip must contain manifest.json');
+    const manifest = JSON.parse(entries['manifest.json'].toString('utf-8'));
+    assert.ok(typeof manifest.schemaVersion === 'number', 'manifest.schemaVersion must be a number');
+    assert.ok(typeof manifest.astroBlocksVersion === 'string', 'manifest.astroBlocksVersion must be a string');
+    assert.ok(typeof manifest.exportedAt === 'string', 'manifest.exportedAt must be a string');
+    assert.deepEqual(manifest.units, ['pages']);
+    assert.ok(typeof manifest.checksums === 'object' && manifest.checksums !== null, 'manifest.checksums must be object');
+  });
+});
+
+// B-1: selected files present, unselected absent
+
+test('B-1: pages unit — data/pages.json present, data/users.json absent', async () => {
+  await withTempProject(async (tempRoot) => {
+    const stream = await buildExportStream(['pages'], tempRoot);
+    const buf = await collectStream(stream);
+    const entries = await extractZip(buf);
+
+    assert.ok('data/pages.json' in entries, 'data/pages.json must be in zip');
+    assert.ok(!('data/users.json' in entries), 'data/users.json must NOT be in zip');
+    assert.ok(!('data/site.json' in entries), 'data/site.json must NOT be in zip');
+    assert.ok(!('data/global-blocks.json' in entries), 'data/global-blocks.json must NOT be in zip');
+  });
+});
+
+test('B-1: configuration unit — all 5 config files present, pages absent', async () => {
+  await withTempProject(async (tempRoot) => {
+    const stream = await buildExportStream(['configuration'], tempRoot);
+    const buf = await collectStream(stream);
+    const entries = await extractZip(buf);
+
+    assert.ok('data/site.json' in entries, 'data/site.json must be in zip');
+    assert.ok('data/configs.json' in entries, 'data/configs.json must be in zip');
+    assert.ok('data/menus.json' in entries, 'data/menus.json must be in zip');
+    assert.ok('data/redirects.json' in entries, 'data/redirects.json must be in zip');
+    assert.ok('data/languages.json' in entries, 'data/languages.json must be in zip');
+    assert.ok(!('data/pages.json' in entries), 'data/pages.json must NOT be in zip for configuration only');
+  });
+});
+
+test('B-1: users unit — data/users.json present, other files absent', async () => {
+  await withTempProject(async (tempRoot) => {
+    const stream = await buildExportStream(['users'], tempRoot);
+    const buf = await collectStream(stream);
+    const entries = await extractZip(buf);
+
+    assert.ok('data/users.json' in entries, 'data/users.json must be in zip');
+    assert.ok(!('data/pages.json' in entries), 'data/pages.json must NOT be in zip');
+    assert.ok(!('data/site.json' in entries), 'data/site.json must NOT be in zip');
+  });
+});
+
+// B-1: checksum matches entry bytes
+
+test('B-1: manifest.checksums contains sha256 for each data entry that matches the actual bytes', async () => {
+  await withTempProject(async (tempRoot) => {
+    const stream = await buildExportStream(['pages', 'users'], tempRoot);
+    const buf = await collectStream(stream);
+    const entries = await extractZip(buf);
+    const manifest = JSON.parse(entries['manifest.json'].toString('utf-8'));
+
+    // Every data/* entry in the zip should have a matching checksum in manifest
+    for (const [entryName, entryBuf] of Object.entries(entries)) {
+      if (entryName === 'manifest.json') continue;
+      const expectedChecksum = manifest.checksums[entryName];
+      assert.ok(expectedChecksum, `manifest.checksums must contain entry for ${entryName}`);
+      const actualChecksum = sha256Hex(entryBuf);
+      assert.equal(actualChecksum, expectedChecksum, `checksum mismatch for ${entryName}`);
+    }
+  });
+});
+
+// B-1: data/_backups/ is never included
+
+test('B-1: zip never includes entries under data/_backups/', async () => {
+  await withTempProject(async (tempRoot) => {
+    // Create a fake backup dir to make sure it is not included
+    const backupsDir = path.join(tempRoot, 'data', '_backups', '2026-01-01T00:00:00.000Z');
+    await fs.mkdir(backupsDir, { recursive: true });
+    await fs.writeFile(path.join(backupsDir, 'pages.json'), '{"pages":[]}');
+
+    const stream = await buildExportStream(['pages'], tempRoot);
+    const buf = await collectStream(stream);
+    const entries = await extractZip(buf);
+
+    for (const name of Object.keys(entries)) {
+      assert.ok(!name.startsWith('data/_backups'), `entry "${name}" must not be under data/_backups/`);
+    }
+  });
+});
+
+// B-1: media unit includes uploads/ entries
+
+test('B-1: media unit includes uploads/ entries when uploads directory has files', async () => {
+  await withTempProject(async (tempRoot) => {
+    // Create a sample upload file
+    const uploadsDir = path.join(tempRoot, 'public', 'uploads', '2026', '06');
+    await fs.mkdir(uploadsDir, { recursive: true });
+    const sampleFile = path.join(uploadsDir, 'ab12-photo.jpg');
+    await fs.writeFile(sampleFile, Buffer.from([0xff, 0xd8, 0xff])); // minimal JPEG magic
+
+    const stream = await buildExportStream(['media'], tempRoot);
+    const buf = await collectStream(stream);
+    const entries = await extractZip(buf);
+
+    // media.json must be present
+    assert.ok('data/media.json' in entries, 'data/media.json must be in zip for media unit');
+
+    // uploads/ entries should be present
+    const uploadEntries = Object.keys(entries).filter((n) => n.startsWith('uploads/'));
+    assert.ok(uploadEntries.length > 0, 'zip must include uploads/ entries when files exist');
+    assert.ok(
+      uploadEntries.some((n) => n.includes('ab12-photo.jpg')),
+      'uploads/2026/06/ab12-photo.jpg must be included',
+    );
+  });
+});
+
+test('B-1: media unit — uploads entries checksums match actual bytes', async () => {
+  await withTempProject(async (tempRoot) => {
+    const uploadsDir = path.join(tempRoot, 'public', 'uploads', '2026', '06');
+    await fs.mkdir(uploadsDir, { recursive: true });
+    const sampleBytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+    await fs.writeFile(path.join(uploadsDir, 'cd34-img.jpg'), sampleBytes);
+
+    const stream = await buildExportStream(['media'], tempRoot);
+    const buf = await collectStream(stream);
+    const entries = await extractZip(buf);
+    const manifest = JSON.parse(entries['manifest.json'].toString('utf-8'));
+
+    const uploadEntries = Object.keys(entries).filter((n) => n.startsWith('uploads/'));
+    for (const entryName of uploadEntries) {
+      const expectedHash = manifest.checksums[entryName];
+      assert.ok(expectedHash, `manifest.checksums must contain entry for ${entryName}`);
+      const actualHash = sha256Hex(entries[entryName]);
+      assert.equal(actualHash, expectedHash, `checksum mismatch for upload entry ${entryName}`);
+    }
+  });
+});
+
+// B-1: empty units array rejects
+
+test('B-1: buildExportStream rejects when units array is empty', async () => {
+  await withTempProject(async (tempRoot) => {
+    await assert.rejects(
+      async () => buildExportStream([], tempRoot),
+      /units/i,
+    );
+  });
+});

--- a/tests/import-export-handlers.test.js
+++ b/tests/import-export-handlers.test.js
@@ -166,3 +166,51 @@ test('B-2: handleExport returns 403 when authUser role is not owner', async () =
     assert.equal(res.status, 403, `expected 403 for non-owner, got ${res.status}`);
   });
 });
+
+// H-1: deduplicate units — duplicate query param must not produce duplicate zip entries
+
+import { readableStreamToFflateUnzip } from '../dist/api/backup-stream.js';
+
+test('H-1: handleExport with ?units=pages,pages returns 200 and zip has exactly one data/pages.json entry', async () => {
+  await withTempProject(async () => {
+    const req = new Request('http://localhost/cms/api/export?units=pages,pages', {
+      method: 'GET',
+    });
+    const res = await handleExport(req, OWNER_USER);
+    assert.equal(res.status, 200, `expected 200 for duplicate units, got ${res.status}`);
+
+    // Consume and parse the zip
+    const reader = res.body.getReader();
+    const chunks = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    const totalLen = chunks.reduce((s, c) => s + c.length, 0);
+    const zipBuf = Buffer.allocUnsafe(totalLen);
+    let offset = 0;
+    for (const chunk of chunks) {
+      zipBuf.set(chunk, offset);
+      offset += chunk.length;
+    }
+
+    const entryNames = [];
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(zipBuf));
+        controller.close();
+      },
+    });
+    await readableStreamToFflateUnzip(stream, async (name) => {
+      entryNames.push(name);
+    });
+
+    const pagesEntries = entryNames.filter((n) => n === 'data/pages.json');
+    assert.equal(
+      pagesEntries.length,
+      1,
+      `zip must contain exactly one data/pages.json entry, got ${pagesEntries.length}`,
+    );
+  });
+});

--- a/tests/import-export-handlers.test.js
+++ b/tests/import-export-handlers.test.js
@@ -1,0 +1,168 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * B-2: handleExport handler tests.
+ * Verifies auth gates, query parsing, and response shape.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { ensureDefaultFiles } from '../dist/api/data.js';
+import { handleExport } from '../dist/api/handlers.js';
+
+async function withTempProject(fn) {
+  const previousRoot = process.env.ASTRO_BLOCKS_PROJECT_ROOT;
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'astro-blocks-export-handler-'));
+
+  process.env.ASTRO_BLOCKS_PROJECT_ROOT = tempRoot;
+  await ensureDefaultFiles();
+
+  try {
+    await fn(tempRoot);
+  } finally {
+    if (previousRoot === undefined) {
+      delete process.env.ASTRO_BLOCKS_PROJECT_ROOT;
+    } else {
+      process.env.ASTRO_BLOCKS_PROJECT_ROOT = previousRoot;
+    }
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+/** Minimal owner AuthUser for tests. */
+const OWNER_USER = { id: 'user-1', email: 'owner@example.com', role: 'owner' };
+/** Minimal non-owner AuthUser for tests. */
+const REGULAR_USER = { id: 'user-2', email: 'user@example.com', role: 'user' };
+
+// B-2: 200 + correct headers on valid request
+
+test('B-2: handleExport returns 200 with Content-Type application/zip for valid owner + units', async () => {
+  await withTempProject(async () => {
+    const req = new Request('http://localhost/cms/api/export?units=pages', {
+      method: 'GET',
+    });
+    const res = await handleExport(req, OWNER_USER);
+
+    assert.equal(res.status, 200, `expected 200, got ${res.status}`);
+    const ct = res.headers.get('content-type') ?? '';
+    assert.ok(ct.includes('application/zip'), `Content-Type must include application/zip, got "${ct}"`);
+  });
+});
+
+test('B-2: handleExport response has Content-Disposition attachment header with .zip filename', async () => {
+  await withTempProject(async () => {
+    const req = new Request('http://localhost/cms/api/export?units=pages', {
+      method: 'GET',
+    });
+    const res = await handleExport(req, OWNER_USER);
+
+    const cd = res.headers.get('content-disposition') ?? '';
+    assert.ok(cd.includes('attachment'), `Content-Disposition must include "attachment", got "${cd}"`);
+    assert.ok(cd.includes('.zip'), `Content-Disposition filename must end with .zip, got "${cd}"`);
+  });
+});
+
+test('B-2: handleExport response body streams valid zip bytes (PK magic)', async () => {
+  await withTempProject(async () => {
+    const req = new Request('http://localhost/cms/api/export?units=pages', {
+      method: 'GET',
+    });
+    const res = await handleExport(req, OWNER_USER);
+
+    // Consume the first chunk of the body
+    const reader = res.body.getReader();
+    const { value } = await reader.read();
+    reader.cancel();
+
+    assert.ok(value instanceof Uint8Array, 'body must stream Uint8Array chunks');
+    assert.equal(value[0], 0x50, 'PK byte 0');
+    assert.equal(value[1], 0x4b, 'PK byte 1');
+  });
+});
+
+// B-2: multiple units in query string
+
+test('B-2: handleExport accepts multiple units via comma-separated ?units param', async () => {
+  await withTempProject(async () => {
+    const req = new Request('http://localhost/cms/api/export?units=pages,users', {
+      method: 'GET',
+    });
+    const res = await handleExport(req, OWNER_USER);
+    assert.equal(res.status, 200, `expected 200 for multiple units, got ${res.status}`);
+  });
+});
+
+// B-2: 400 on empty units
+
+test('B-2: handleExport returns 400 when ?units param is empty string', async () => {
+  await withTempProject(async () => {
+    const req = new Request('http://localhost/cms/api/export?units=', {
+      method: 'GET',
+    });
+    const res = await handleExport(req, OWNER_USER);
+    assert.equal(res.status, 400, `expected 400 for empty units, got ${res.status}`);
+  });
+});
+
+test('B-2: handleExport returns 400 when ?units param is absent', async () => {
+  await withTempProject(async () => {
+    const req = new Request('http://localhost/cms/api/export', {
+      method: 'GET',
+    });
+    const res = await handleExport(req, OWNER_USER);
+    assert.equal(res.status, 400, `expected 400 for missing units, got ${res.status}`);
+  });
+});
+
+// B-2: 400 on invalid unit name
+
+test('B-2: handleExport returns 400 when ?units contains an unknown unit name', async () => {
+  await withTempProject(async () => {
+    const req = new Request('http://localhost/cms/api/export?units=pages,bogus-unit', {
+      method: 'GET',
+    });
+    const res = await handleExport(req, OWNER_USER);
+    assert.equal(res.status, 400, `expected 400 for invalid unit, got ${res.status}`);
+  });
+});
+
+// B-2: 401 when authUser is null
+
+test('B-2: handleExport returns 401 when authUser is null', async () => {
+  await withTempProject(async () => {
+    const req = new Request('http://localhost/cms/api/export?units=pages', {
+      method: 'GET',
+    });
+    const res = await handleExport(req, null);
+    assert.equal(res.status, 401, `expected 401 for no auth, got ${res.status}`);
+  });
+});
+
+test('B-2: handleExport returns 401 when authUser is undefined', async () => {
+  await withTempProject(async () => {
+    const req = new Request('http://localhost/cms/api/export?units=pages', {
+      method: 'GET',
+    });
+    const res = await handleExport(req, undefined);
+    assert.equal(res.status, 401, `expected 401 for undefined auth, got ${res.status}`);
+  });
+});
+
+// B-2: 403 when non-owner
+
+test('B-2: handleExport returns 403 when authUser role is not owner', async () => {
+  await withTempProject(async () => {
+    const req = new Request('http://localhost/cms/api/export?units=pages', {
+      method: 'GET',
+    });
+    const res = await handleExport(req, REGULAR_USER);
+    assert.equal(res.status, 403, `expected 403 for non-owner, got ${res.status}`);
+  });
+});


### PR DESCRIPTION
## Slice B — Export endpoint (import/export)

Second PR in the chained `import-export` feature. **Base = `feat/import-export-pr1-foundation`** (chained on PR #21). Builds the owner-only export on top of the Slice A foundation.

### What's included (tasks B-1, B-2)
- **B-1** — `api/backup.ts` → `buildExportStream(units, projectRoot): ReadableStream`. Streams a zip via the Slice A fflate bridge: enumerates ONLY the 9-file allowlist (`UNIT_TO_DATA_FILES`, never `data/_backups/`), includes the `public/uploads` tree as `uploads/...` entries for the `media` unit, computes sha256 per entry, writes `manifest.json` last.
- **B-2** — `handleExport(request, authUser)` in `api/handlers.ts` + GET branch in `routes/api/catchall.ts` (after `ensureAuth`). Owner-only via `requireOwner()`; parses/validates `?units=`; returns 200 `application/zip` with `Content-Disposition`. 400 on empty/invalid units, 401 no auth, 403 non-owner.

### Adversarial review + fixes (commit e7912ff)
A fresh-context review flagged 1 HIGH + 1 security-posture issue, both fixed:
- **H-1 (high)** — duplicate units (`?units=pages,pages`) produced duplicate zip entries (malformed archive). Now deduplicated in both `handleExport` and `buildExportStream`.
- **I-1** — `walkDir` followed symlinks (`fs.stat`) → could leak external bytes into the export. Now uses `fs.lstat` and skips symlinks entirely.
- **N-3 (documented, not a bug)** — source file bytes are read into memory before the zip stream opens (the zip OUTPUT is streamed; SOURCE buffering is a known v1 tradeoff acceptable for typical backup sizes). Inline comment added.

Cleared by review: auth gating, query-input validation, allowlist (no `data/_backups`), checksum/manifest correctness, stream safety, header-injection safety.

### Tests
Strict TDD. **Full suite: 834 pass / 0 fail** (no regressions). +24 Slice B tests (20 initial + 4 review-fix).
