### PR TITLE
feat(import-export): bootstrap import + login-screen seed UI (Slices D+F)

### DIFF
--- a/api/backup.ts
+++ b/api/backup.ts
@@ -702,12 +702,26 @@ export interface ImportPipelineOptions {
   ceilings: CeilingLimits;
   selectedUnits?: ExportUnit[];
   context: { cache?: unknown };
+  /**
+   * When true the pipeline re-checks users.length === 0 INSIDE the lock
+   * (after lock acquisition, before extraction) to close the TOCTOU window
+   * between the outer gate in handleBootstrapImport and the pipeline start.
+   *
+   * Residual narrow window: if handleLogin's saveUsers completes DURING
+   * extractToStaging (i.e. after this re-check but before applyImport),
+   * the pipeline will still apply the import on a no-longer-empty instance.
+   * Fully eliminating this residual would require wrapping handleLogin's
+   * saveUsers in the same _importLock, which is a larger cross-cutting
+   * refactor deferred to a future hardening pass. The in-lock re-check
+   * covers the concurrent-bootstrap-POST race fully.
+   */
+  bootstrapMode?: boolean;
 }
 
 export interface ImportPipelineResult {
   ok: boolean;
   usersReplaced?: boolean;
-  errorCode?: 'empty' | 'corrupt' | 'ceiling' | 'validation' | 'apply-failed';
+  errorCode?: 'empty' | 'corrupt' | 'ceiling' | 'validation' | 'apply-failed' | 'bootstrap-users-exist';
   reason?: string;
 }
 
@@ -744,6 +758,18 @@ async function _runImportPipelineCore(
   opts: ImportPipelineOptions,
 ): Promise<ImportPipelineResult> {
   const { projectRoot, ceilings, context } = opts;
+
+  // B1 — in-lock bootstrap re-check (TOCTOU hardening).
+  // This runs AFTER the lock is acquired, closing the race window between
+  // the outer gate in handleBootstrapImport and this pipeline execution.
+  // Two concurrent bootstrap POSTs cannot both pass: the second one will
+  // observe users written by the first inside this serialized check.
+  if (opts.bootstrapMode) {
+    const currentUsers = await data.loadUsers();
+    if (currentUsers.users.length !== 0) {
+      return { ok: false, errorCode: 'bootstrap-users-exist', reason: 'instance already has users (in-lock check)' };
+    }
+  }
 
   if (!body || body.length === 0) {
     return { ok: false, errorCode: 'empty', reason: 'request body is empty' };

--- a/api/handlers.ts
+++ b/api/handlers.ts
@@ -2110,3 +2110,104 @@ export async function handleImport(
 
   return Response.json({ success: true, usersReplaced: result.usersReplaced ?? false });
 }
+
+/**
+ * POST /cms/api/import/bootstrap
+ *
+ * Unauthenticated import endpoint for seeding a fresh instance (ADR-6).
+ * SECURITY-CRITICAL: this surface is public — the zero-user gate is the ONLY
+ * protection. The gate MUST be checked before any request-body access.
+ *
+ * Flow:
+ *   1. Load users — check length BEFORE reading the request body.
+ *   2. If users.length !== 0 → 403 IMMEDIATELY (body never read).
+ *   3. If users.length === 0 → run the shared runImportPipeline (same validation,
+ *      ceilings, checksum, path guards, backup, atomic apply as the authed import).
+ *
+ * Status codes:
+ *   200 {success:true, usersReplaced}   — pipeline succeeded
+ *   400                                  — empty or corrupt zip
+ *   403                                  — instance already has users
+ *   413                                  — decompression ceiling exceeded
+ *   422                                  — schemaVersion mismatch / checksum / structural
+ */
+export async function handleBootstrapImport(
+  request: Request,
+  context: HandlerContext = {},
+): Promise<Response> {
+  // GATE: load users FIRST — before reading/consuming any request body.
+  // If any user exists, refuse immediately without touching the body.
+  const usersData = await data.loadUsers();
+  if (usersData.users.length !== 0) {
+    return jsonError('Forbidden: instance already has users', 403);
+  }
+
+  // Read ceiling limits so we can reject oversized payloads early.
+  const ceilings = readCeilingEnvVars();
+
+  // Compressed body size check via Content-Length (may be absent or spoofed).
+  const contentLength = request.headers.get('content-length');
+  if (contentLength !== null) {
+    const clBytes = parseInt(contentLength, 10);
+    if (Number.isFinite(clBytes) && clBytes > ceilings.compressed) {
+      return jsonError(
+        `Compressed body too large: Content-Length ${clBytes} exceeds limit ${ceilings.compressed}`,
+        413,
+      );
+    }
+  }
+
+  // Read the request body for fflate processing.
+  let bodyBuffer: Buffer;
+  try {
+    const ab = await request.arrayBuffer();
+    bodyBuffer = Buffer.from(ab);
+  } catch {
+    return localizedJsonError(request, 'errors.invalidBody', 400);
+  }
+
+  // Post-buffer compressed size check (catches absent/spoofed Content-Length).
+  if (bodyBuffer.length > ceilings.compressed) {
+    return jsonError(
+      `Compressed body too large: ${bodyBuffer.length} bytes exceeds limit ${ceilings.compressed}`,
+      413,
+    );
+  }
+
+  if (bodyBuffer.length === 0) {
+    return localizedJsonError(request, 'errors.invalidBody', 400);
+  }
+
+  const projectRoot = process.env.ASTRO_BLOCKS_PROJECT_ROOT || process.cwd();
+
+  // Run the shared import pipeline — same validation, ceilings, path guards,
+  // backup snapshot, and atomic apply as the authenticated import (C-5/ADR-5).
+  let result: Awaited<ReturnType<typeof runImportPipeline>>;
+  try {
+    result = await runImportPipeline(bodyBuffer, {
+      projectRoot,
+      ceilings,
+      context,
+    });
+  } catch (err) {
+    return jsonError(`Bootstrap import failed unexpectedly: ${(err as Error).message}`, 500);
+  }
+
+  if (!result.ok) {
+    switch (result.errorCode) {
+      case 'empty':
+      case 'corrupt':
+        return localizedJsonError(request, 'errors.invalidBody', 400);
+      case 'ceiling':
+        return jsonError(result.reason ?? 'Decompression ceiling exceeded', 413);
+      case 'validation':
+        return jsonError(result.reason ?? 'Validation failed', 422);
+      case 'apply-failed':
+        return jsonError(result.reason ?? 'Bootstrap import apply failed (rollback attempted)', 500);
+      default:
+        return jsonError(result.reason ?? 'Bootstrap import failed', 500);
+    }
+  }
+
+  return Response.json({ success: true, usersReplaced: result.usersReplaced ?? false });
+}

--- a/api/handlers.ts
+++ b/api/handlers.ts
@@ -2089,7 +2089,9 @@ export async function handleImport(
       context,
     });
   } catch (err) {
-    return jsonError(`Import failed unexpectedly: ${(err as Error).message}`, 500);
+    // Log the real error server-side; never expose raw message or paths to callers.
+    console.error('[handleImport] unexpected error:', err);
+    return jsonError('Import failed.', 500);
   }
 
   if (!result.ok) {
@@ -2104,7 +2106,7 @@ export async function handleImport(
       case 'apply-failed':
         return jsonError(result.reason ?? 'Import apply failed (rollback attempted)', 500);
       default:
-        return jsonError(result.reason ?? 'Import failed', 500);
+        return jsonError('Import failed.', 500);
     }
   }
 
@@ -2182,15 +2184,20 @@ export async function handleBootstrapImport(
 
   // Run the shared import pipeline — same validation, ceilings, path guards,
   // backup snapshot, and atomic apply as the authenticated import (C-5/ADR-5).
+  // bootstrapMode:true enables the in-lock re-check inside _runImportPipelineCore
+  // to close the TOCTOU race between the outer gate above and pipeline start.
   let result: Awaited<ReturnType<typeof runImportPipeline>>;
   try {
     result = await runImportPipeline(bodyBuffer, {
       projectRoot,
       ceilings,
       context,
+      bootstrapMode: true,
     });
   } catch (err) {
-    return jsonError(`Bootstrap import failed unexpectedly: ${(err as Error).message}`, 500);
+    // Log the real error server-side; never expose raw message to anonymous callers.
+    console.error('[handleBootstrapImport] unexpected error:', err);
+    return jsonError('Bootstrap import failed.', 500);
   }
 
   if (!result.ok) {
@@ -2204,8 +2211,10 @@ export async function handleBootstrapImport(
         return jsonError(result.reason ?? 'Validation failed', 422);
       case 'apply-failed':
         return jsonError(result.reason ?? 'Bootstrap import apply failed (rollback attempted)', 500);
+      case 'bootstrap-users-exist':
+        return jsonError('Forbidden: instance already has users', 403);
       default:
-        return jsonError(result.reason ?? 'Bootstrap import failed', 500);
+        return jsonError('Bootstrap import failed.', 500);
     }
   }
 

--- a/routes/admin/i18n/en.ts
+++ b/routes/admin/i18n/en.ts
@@ -27,6 +27,9 @@ export const en = {
   'bootstrap.importTitle': 'Import a backup to seed this instance',
   'bootstrap.importHint': 'Select a .zip backup file exported from another AstroBlocks instance.',
   'bootstrap.importButton': 'Import backup',
+  'bootstrap.importingStatus': 'Importing backup…',
+  'bootstrap.importError': 'Import failed: HTTP {status}',
+  'bootstrap.networkError': 'Network error. Please try again.',
 
   // ─── Navigation ───────────────────────────────────────────────────────────
   'nav.dashboard': 'Dashboard',

--- a/routes/admin/i18n/en.ts
+++ b/routes/admin/i18n/en.ts
@@ -23,6 +23,11 @@ export const en = {
   'auth.loginError': 'Sign-in error.',
   'auth.sessionLabel': 'Panel session',
 
+  // ─── Bootstrap import (login screen — hasUsers===false only) ──────────────
+  'bootstrap.importTitle': 'Import a backup to seed this instance',
+  'bootstrap.importHint': 'Select a .zip backup file exported from another AstroBlocks instance.',
+  'bootstrap.importButton': 'Import backup',
+
   // ─── Navigation ───────────────────────────────────────────────────────────
   'nav.dashboard': 'Dashboard',
   'nav.content': 'Content',

--- a/routes/admin/i18n/es.ts
+++ b/routes/admin/i18n/es.ts
@@ -25,8 +25,11 @@ export const es = {
 
   // ─── Bootstrap import (pantalla de inicio de sesión — solo cuando hasUsers===false) ─
   'bootstrap.importTitle': 'Importar un respaldo para inicializar esta instancia',
-  'bootstrap.importHint': 'Selecciona un archivo .zip exportado desde otra instancia de AstroBlocks.',
+  'bootstrap.importHint': 'Seleccionar un archivo .zip exportado desde otra instancia de AstroBlocks.',
   'bootstrap.importButton': 'Importar respaldo',
+  'bootstrap.importingStatus': 'Importando el respaldo…',
+  'bootstrap.importError': 'Error al importar: HTTP {status}',
+  'bootstrap.networkError': 'Error de red. Intentar de nuevo.',
 
   // ─── Navigation ───────────────────────────────────────────────────────────
   'nav.dashboard': 'Dashboard',

--- a/routes/admin/i18n/es.ts
+++ b/routes/admin/i18n/es.ts
@@ -23,6 +23,11 @@ export const es = {
   'auth.loginError': 'Error al iniciar sesión.',
   'auth.sessionLabel': 'Sesión del panel',
 
+  // ─── Bootstrap import (pantalla de inicio de sesión — solo cuando hasUsers===false) ─
+  'bootstrap.importTitle': 'Importar un respaldo para inicializar esta instancia',
+  'bootstrap.importHint': 'Selecciona un archivo .zip exportado desde otra instancia de AstroBlocks.',
+  'bootstrap.importButton': 'Importar respaldo',
+
   // ─── Navigation ───────────────────────────────────────────────────────────
   'nav.dashboard': 'Dashboard',
   'nav.content': 'Contenido',

--- a/routes/admin/layout.astro
+++ b/routes/admin/layout.astro
@@ -74,7 +74,7 @@ const t = createT(uiLocale);
               </button>
             </form>
             <!-- Bootstrap import section — only shown when hasUsers === false -->
-            <div id="cms-bootstrap-import" class="cms-hidden" aria-label={t('bootstrap.importTitle')}>
+            <div id="cms-bootstrap-import" class="cms-hidden">
               <hr class="cms-divider" aria-hidden="true" />
               <p class="cms-muted cms-bootstrap-import-title">{t('bootstrap.importTitle')}</p>
               <p class="cms-muted cms-bootstrap-import-hint">{t('bootstrap.importHint')}</p>
@@ -84,7 +84,6 @@ const t = createT(uiLocale);
                 id="cms-bootstrap-file"
                 accept=".zip"
                 class="cms-bootstrap-file-input"
-                aria-label={t('bootstrap.importButton')}
               />
               <button type="button" id="cms-bootstrap-btn" class="cms-btn cms-btn-secondary">
                 {t('bootstrap.importButton')}
@@ -93,14 +92,12 @@ const t = createT(uiLocale);
                 id="cms-bootstrap-status"
                 class="cms-muted cms-hidden"
                 role="status"
-                aria-live="polite"
                 aria-atomic="true"
               ></div>
               <div
                 id="cms-bootstrap-error"
                 class="cms-muted cms-hidden"
                 role="alert"
-                aria-live="assertive"
                 aria-atomic="true"
               ></div>
             </div>
@@ -278,6 +275,9 @@ const t = createT(uiLocale);
       _bootstrapImportTitle: t('bootstrap.importTitle'),
       _bootstrapImportHint: t('bootstrap.importHint'),
       _bootstrapImportButton: t('bootstrap.importButton'),
+      _bootstrapImportingStatus: t('bootstrap.importingStatus'),
+      _bootstrapImportError: t('bootstrap.importError'),
+      _bootstrapNetworkError: t('bootstrap.networkError'),
     }}>
       window.__cmsAuthI18n = {
         loading: _authLoading,
@@ -292,6 +292,9 @@ const t = createT(uiLocale);
         bootstrapImportTitle: _bootstrapImportTitle,
         bootstrapImportHint: _bootstrapImportHint,
         bootstrapImportButton: _bootstrapImportButton,
+        bootstrapImportingStatus: _bootstrapImportingStatus,
+        bootstrapImportError: _bootstrapImportError,
+        bootstrapNetworkError: _bootstrapNetworkError,
       };
     </script>
     <script>
@@ -418,17 +421,21 @@ const t = createT(uiLocale);
         // Bootstrap import handler — POSTs the selected .zip as a raw body to
         // /cms/api/import/bootstrap. On success redirects to /cms. On error
         // shows a message in the aria-live error region (text, not color-only).
+        // No explicit confirm dialog is needed: the instance is in zero-user
+        // state (nothing to overwrite) and mismatched zips fail with 422.
         if (bootstrapBtn && bootstrapFileInput) {
           bootstrapBtn.addEventListener('click', async function() {
             const file = bootstrapFileInput.files?.[0];
             if (!file) return;
-            if (bootstrapStatus) {
-              bootstrapStatus.textContent = '';
-              bootstrapStatus.classList.add('cms-hidden');
-            }
             if (bootstrapError) {
               bootstrapError.textContent = '';
               bootstrapError.classList.add('cms-hidden');
+            }
+            // F1: populate aria-live status region before fetch so screen readers
+            // announce the in-progress state.
+            if (bootstrapStatus) {
+              bootstrapStatus.textContent = _i18n.bootstrapImportingStatus || 'Importing backup…';
+              bootstrapStatus.classList.remove('cms-hidden');
             }
             bootstrapBtn.setAttribute('disabled', 'true');
             try {
@@ -441,7 +448,9 @@ const t = createT(uiLocale);
                 location.href = '/cms';
               } else {
                 const errData = await res.json().catch(() => ({}));
-                const msg = errData?.error || ('Import failed: HTTP ' + res.status);
+                // F2: use i18n key for HTTP error; fall back to raw error text or generic.
+                const importErrorTpl = _i18n.bootstrapImportError || 'Import failed: HTTP {status}';
+                const msg = errData?.error || importErrorTpl.replace('{status}', String(res.status));
                 if (bootstrapError) {
                   bootstrapError.textContent = msg;
                   bootstrapError.classList.remove('cms-hidden');
@@ -449,11 +458,17 @@ const t = createT(uiLocale);
               }
             } catch (err) {
               if (bootstrapError) {
-                bootstrapError.textContent = 'Network error. Please try again.';
+                // F2: use i18n key for network error.
+                bootstrapError.textContent = _i18n.bootstrapNetworkError || 'Network error. Please try again.';
                 bootstrapError.classList.remove('cms-hidden');
               }
             } finally {
               bootstrapBtn.removeAttribute('disabled');
+              // F1: clear and hide the status region after request completes.
+              if (bootstrapStatus) {
+                bootstrapStatus.textContent = '';
+                bootstrapStatus.classList.add('cms-hidden');
+              }
             }
           });
         }

--- a/routes/admin/layout.astro
+++ b/routes/admin/layout.astro
@@ -73,6 +73,37 @@ const t = createT(uiLocale);
                 <span id="cms-submit-label">{t('auth.enterLabel')}</span>
               </button>
             </form>
+            <!-- Bootstrap import section — only shown when hasUsers === false -->
+            <div id="cms-bootstrap-import" class="cms-hidden" aria-label={t('bootstrap.importTitle')}>
+              <hr class="cms-divider" aria-hidden="true" />
+              <p class="cms-muted cms-bootstrap-import-title">{t('bootstrap.importTitle')}</p>
+              <p class="cms-muted cms-bootstrap-import-hint">{t('bootstrap.importHint')}</p>
+              <label for="cms-bootstrap-file" class="cms-sr-only">{t('bootstrap.importButton')}</label>
+              <input
+                type="file"
+                id="cms-bootstrap-file"
+                accept=".zip"
+                class="cms-bootstrap-file-input"
+                aria-label={t('bootstrap.importButton')}
+              />
+              <button type="button" id="cms-bootstrap-btn" class="cms-btn cms-btn-secondary">
+                {t('bootstrap.importButton')}
+              </button>
+              <div
+                id="cms-bootstrap-status"
+                class="cms-muted cms-hidden"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+              ></div>
+              <div
+                id="cms-bootstrap-error"
+                class="cms-muted cms-hidden"
+                role="alert"
+                aria-live="assertive"
+                aria-atomic="true"
+              ></div>
+            </div>
           </div>
           <p id="cms-login-error" class="cms-muted cms-hidden" role="alert"></p>
         </div>
@@ -244,6 +275,9 @@ const t = createT(uiLocale);
       _authLoginError: t('auth.loginError'),
       _authSessionLabel: t('auth.sessionLabel'),
       _authRoleOwner: t('users.roleOwner'),
+      _bootstrapImportTitle: t('bootstrap.importTitle'),
+      _bootstrapImportHint: t('bootstrap.importHint'),
+      _bootstrapImportButton: t('bootstrap.importButton'),
     }}>
       window.__cmsAuthI18n = {
         loading: _authLoading,
@@ -255,6 +289,9 @@ const t = createT(uiLocale);
         loginError: _authLoginError,
         sessionLabel: _authSessionLabel,
         roleOwner: _authRoleOwner,
+        bootstrapImportTitle: _bootstrapImportTitle,
+        bootstrapImportHint: _bootstrapImportHint,
+        bootstrapImportButton: _bootstrapImportButton,
       };
     </script>
     <script>
@@ -272,6 +309,11 @@ const t = createT(uiLocale);
         const passwordInput = document.getElementById('cms-password-input');
         const loginError = document.getElementById('cms-login-error');
         const profileEmail = document.getElementById('cms-profile-email');
+        const bootstrapSection = document.getElementById('cms-bootstrap-import');
+        const bootstrapFileInput = document.getElementById('cms-bootstrap-file') as HTMLInputElement | null;
+        const bootstrapBtn = document.getElementById('cms-bootstrap-btn');
+        const bootstrapStatus = document.getElementById('cms-bootstrap-status');
+        const bootstrapError = document.getElementById('cms-bootstrap-error');
         const _i18n = (window as unknown as { __cmsAuthI18n?: Record<string, string> }).__cmsAuthI18n || {};
         function setProfileEmail(user: { email?: string; role?: string } | null) {
           if (!profileEmail) return;
@@ -312,6 +354,8 @@ const t = createT(uiLocale);
           if (submitLabel) submitLabel.textContent = hasUsers ? (_i18n.enterLabel || 'Sign in') : (_i18n.createAccountLabel || 'Create account');
           if (authLoading) authLoading.classList.add('cms-hidden');
           if (authForms) authForms.classList.remove('cms-hidden');
+          // Show bootstrap import section only on a fresh instance (no users yet).
+          if (bootstrapSection) bootstrapSection.classList.toggle('cms-hidden', hasUsers);
         }
         try {
           const token = sessionStorage.getItem('cms-token');
@@ -369,6 +413,48 @@ const t = createT(uiLocale);
               if (data.user) sessionStorage.setItem('cms-user', JSON.stringify(data.user));
             } catch (_) {}
             location.reload();
+          });
+        }
+        // Bootstrap import handler — POSTs the selected .zip as a raw body to
+        // /cms/api/import/bootstrap. On success redirects to /cms. On error
+        // shows a message in the aria-live error region (text, not color-only).
+        if (bootstrapBtn && bootstrapFileInput) {
+          bootstrapBtn.addEventListener('click', async function() {
+            const file = bootstrapFileInput.files?.[0];
+            if (!file) return;
+            if (bootstrapStatus) {
+              bootstrapStatus.textContent = '';
+              bootstrapStatus.classList.add('cms-hidden');
+            }
+            if (bootstrapError) {
+              bootstrapError.textContent = '';
+              bootstrapError.classList.add('cms-hidden');
+            }
+            bootstrapBtn.setAttribute('disabled', 'true');
+            try {
+              const res = await fetch('/cms/api/import/bootstrap', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/zip' },
+                body: file,
+              });
+              if (res.ok) {
+                location.href = '/cms';
+              } else {
+                const errData = await res.json().catch(() => ({}));
+                const msg = errData?.error || ('Import failed: HTTP ' + res.status);
+                if (bootstrapError) {
+                  bootstrapError.textContent = msg;
+                  bootstrapError.classList.remove('cms-hidden');
+                }
+              }
+            } catch (err) {
+              if (bootstrapError) {
+                bootstrapError.textContent = 'Network error. Please try again.';
+                bootstrapError.classList.remove('cms-hidden');
+              }
+            } finally {
+              bootstrapBtn.removeAttribute('disabled');
+            }
           });
         }
       })();

--- a/routes/api/catchall.ts
+++ b/routes/api/catchall.ts
@@ -77,6 +77,12 @@ export async function POST({ request, cache }: APIContext): Promise<Response> {
 
   if (seg[0] === 'auth' && seg[1] === 'login' && seg.length === 2) return handlers.handleLogin(request);
 
+  // Bootstrap import — public, unauthenticated. MUST be before ensureAuth (ADR-6).
+  // Zero-user gate inside the handler is the sole protection.
+  if (seg[0] === 'import' && seg[1] === 'bootstrap' && seg.length === 2) {
+    return handlers.handleBootstrapImport(request, { cache });
+  }
+
   const authResult = await ensureAuth(request);
   if ('status' in authResult) return new Response(JSON.stringify(authResult.body), { status: 401 });
 

--- a/tests/import-export-bootstrap.test.js
+++ b/tests/import-export-bootstrap.test.js
@@ -102,6 +102,36 @@ function makeRequest(body, extraHeaders = {}) {
 }
 
 // ---------------------------------------------------------------------------
+// Helpers for ceiling-exceeded test (B5)
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the current count of entries in data/_backups (0 if directory absent).
+ */
+async function countBackups(projectRoot) {
+  const backupsDir = path.join(projectRoot, 'data', '_backups');
+  try {
+    return (await fs.readdir(backupsDir)).length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Return the current count of entries in the OS temp dir whose name starts
+ * with 'astro-import-'. Used to detect staging dirs that were NOT cleaned up.
+ */
+async function countStagingDirs() {
+  const tmpDir = os.tmpdir();
+  try {
+    const entries = await fs.readdir(tmpDir);
+    return entries.filter((e) => e.startsWith('astro-import-')).length;
+  } catch {
+    return 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // D-1: Zero-user gate — allow when empty
 // ---------------------------------------------------------------------------
 
@@ -312,6 +342,237 @@ test('D-1: empty users + ceiling exceeded → 413, no files written', async () =
         delete process.env.ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES;
       } else {
         process.env.ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES = originalTotalCeiling;
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B1: Concurrency — two concurrent bootstrap POSTs on a zero-user instance
+// ---------------------------------------------------------------------------
+
+test('B1: concurrent bootstrap POSTs — exactly one succeeds, second gets bootstrap-users-exist', async () => {
+  await withTempProject(async (tempRoot) => {
+    // Seed the instance with a user in users.json so that both zips contain a
+    // users unit. When the first pipeline applies, it writes users to disk.
+    // The second pipeline's in-lock re-check then observes users.length !== 0
+    // and returns bootstrap-users-exist.
+    await saveUsers({
+      users: [
+        {
+          id: 'import-user-1',
+          email: 'imported@example.com',
+          passwordHash: 'hash',
+          role: 'owner',
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    // Build zips that include the 'users' unit BEFORE clearing users.json,
+    // so both archives carry a non-empty users array.
+    const zip1 = await buildZipBody(['users'], tempRoot);
+    const zip2 = await buildZipBody(['users'], tempRoot);
+
+    // Now clear users.json to simulate a fresh instance so the outer gate (and
+    // the initial in-lock re-check for the FIRST pipeline) sees 0 users.
+    await saveUsers({ users: [] });
+
+    const { readCeilingEnvVars } = await import('../dist/api/import-utils.js');
+
+    const makeOpts = () => ({
+      projectRoot: tempRoot,
+      ceilings: readCeilingEnvVars(),
+      context: {},
+      bootstrapMode: true,
+    });
+
+    // Fire both pipelines concurrently via runImportPipeline (same code path
+    // that handleBootstrapImport calls after the outer gate).
+    const [r1, r2] = await Promise.all([
+      runImportPipeline(zip1, makeOpts()),
+      runImportPipeline(zip2, makeOpts()),
+    ]);
+
+    const successes = [r1, r2].filter((r) => r.ok).length;
+    const usersExist = [r1, r2].filter((r) => r.errorCode === 'bootstrap-users-exist').length;
+
+    assert.equal(successes, 1, `expected exactly 1 success, got: r1=${JSON.stringify(r1)}, r2=${JSON.stringify(r2)}`);
+    assert.equal(usersExist, 1, `expected exactly 1 bootstrap-users-exist, got: r1=${JSON.stringify(r1)}, r2=${JSON.stringify(r2)}`);
+
+    // Final users.json must be internally consistent (one archive's users, not a merge).
+    const finalUsers = await loadUsers();
+    assert.equal(finalUsers.users.length, 1, `expected exactly 1 user after import, got ${finalUsers.users.length}`);
+    assert.equal(typeof finalUsers.users[0].id, 'string', 'users.json must remain internally consistent');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B1: In-lock re-check unit — users appear between outer gate and lock
+// ---------------------------------------------------------------------------
+
+test('B1: in-lock re-check — users seeded before pipeline acquires lock → bootstrap-users-exist', async () => {
+  await withTempProject(async (tempRoot) => {
+    // The instance starts empty. We seed a user FIRST to simulate users appearing
+    // between the outer handleBootstrapImport gate and pipeline execution.
+    await saveUsers({
+      users: [
+        {
+          id: 'seeded-user',
+          email: 'owner@example.com',
+          passwordHash: 'hash',
+          role: 'owner',
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const zipBody = await buildZipBody(['pages'], tempRoot);
+    const { readCeilingEnvVars } = await import('../dist/api/import-utils.js');
+
+    // Call runImportPipeline with bootstrapMode:true directly.
+    // Users exist → in-lock re-check must abort immediately.
+    const result = await runImportPipeline(zipBody, {
+      projectRoot: tempRoot,
+      ceilings: readCeilingEnvVars(),
+      context: {},
+      bootstrapMode: true,
+    });
+
+    assert.equal(result.ok, false, 'pipeline must not succeed when users exist at lock time');
+    assert.equal(result.errorCode, 'bootstrap-users-exist', `expected bootstrap-users-exist, got ${result.errorCode}`);
+
+    // Assert no backup was created (pipeline aborted before backup step).
+    assert.equal(await countBackups(tempRoot), 0, 'no backup must be created when in-lock re-check aborts');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B2: Generic 500 — handler must NOT expose raw error messages to anonymous callers
+// ---------------------------------------------------------------------------
+
+test('B2: unexpected throw → 500 with generic message, no path/err text leaked', async () => {
+  await withTempProject(async () => {
+    // Create a request whose arrayBuffer() throws an error containing a filesystem path.
+    // handleBootstrapImport must return a generic 500 body, not expose the error.
+    const sensitiveMessage = '/secret/path/to/internal/data.js was not found';
+    const poisonedRequest = new Request('http://localhost/cms/api/import/bootstrap', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/zip', 'Content-Length': '1' },
+      body: 'x', // minimal body so outer gate passes
+    });
+
+    // Patch arrayBuffer on this specific request instance to throw with sensitive message.
+    const origArrayBuffer = poisonedRequest.arrayBuffer.bind(poisonedRequest);
+    let called = false;
+    Object.defineProperty(poisonedRequest, 'arrayBuffer', {
+      value: async () => {
+        called = true;
+        throw new Error(sensitiveMessage);
+      },
+      writable: false,
+    });
+
+    const res = await handleBootstrapImport(poisonedRequest, { cache: null });
+
+    // Status must be 400 (arrayBuffer throws → treated as invalid body) or 500.
+    // Either way the body must NOT contain the sensitive path.
+    const body = await res.json().catch(() => ({}));
+    const bodyStr = JSON.stringify(body);
+    assert.equal(bodyStr.includes('/secret/path'), false, `response must not leak internal paths: ${bodyStr}`);
+    assert.equal(bodyStr.includes('was not found'), false, `response must not leak raw error text: ${bodyStr}`);
+    assert.equal(called, true, 'arrayBuffer must have been called (outer gate passes, body is read)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B3: Strengthened body-not-consumed test — spy on arrayBuffer
+// ---------------------------------------------------------------------------
+
+test('B3: non-empty users → 403 without calling arrayBuffer (body truly not consumed)', async () => {
+  await withTempProject(async (tempRoot) => {
+    await saveUsers({
+      users: [
+        {
+          id: 'user-b3',
+          email: 'owner@example.com',
+          passwordHash: 'hash',
+          role: 'owner',
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const zipBody = await buildZipBody(['pages'], tempRoot);
+    const req = new Request('http://localhost/cms/api/import/bootstrap', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/zip' },
+      body: zipBody,
+    });
+
+    // Spy on arrayBuffer — it must NOT be called when 403 fires.
+    let arrayBufferCalled = false;
+    Object.defineProperty(req, 'arrayBuffer', {
+      value: async () => {
+        arrayBufferCalled = true;
+        return zipBody.buffer ?? zipBody;
+      },
+      writable: false,
+    });
+
+    const res = await handleBootstrapImport(req, { cache: null });
+
+    assert.equal(res.status, 403, `expected 403, got ${res.status}`);
+    assert.equal(arrayBufferCalled, false, 'arrayBuffer must NOT be called when gate returns 403');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B5: Content-Length preflight — oversized compressed body → 413, no side effects
+// ---------------------------------------------------------------------------
+
+test('B5: Content-Length exceeds compressed ceiling → 413 with no staging/backup side effects', async () => {
+  await withTempProject(async (tempRoot) => {
+    const stagingsBefore = await countStagingDirs();
+    const backupsBefore = await countBackups(tempRoot);
+
+    // Use a valid zip body but set Content-Length to a value exceeding the default
+    // compressed ceiling. The handler must reject at the Content-Length preflight
+    // (before arrayBuffer / before pipeline).
+    const zipBody = await buildZipBody(['pages'], tempRoot);
+
+    // The default ASTRO_BLOCKS_MAX_IMPORT_COMPRESSED_BYTES is 500MB; use a tiny
+    // ceiling via env var override to ensure a realistic preflight rejection.
+    const originalCompressed = process.env.ASTRO_BLOCKS_MAX_IMPORT_COMPRESSED_BYTES;
+    process.env.ASTRO_BLOCKS_MAX_IMPORT_COMPRESSED_BYTES = '10'; // 10 bytes ceiling
+
+    try {
+      const req = new Request('http://localhost/cms/api/import/bootstrap', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/zip',
+          // Spoof a large Content-Length — must exceed the 10-byte ceiling.
+          'Content-Length': String(zipBody.length),
+        },
+        body: zipBody,
+      });
+
+      const res = await handleBootstrapImport(req, { cache: null });
+
+      assert.equal(res.status, 413, `expected 413 for oversized Content-Length, got ${res.status}`);
+
+      // No staging directories must have been created.
+      const stagingsAfter = await countStagingDirs();
+      assert.equal(stagingsAfter, stagingsBefore, 'no staging dirs must be created on Content-Length preflight rejection');
+
+      // No backups must have been created.
+      const backupsAfter = await countBackups(tempRoot);
+      assert.equal(backupsAfter, backupsBefore, 'no backups must be created on Content-Length preflight rejection');
+    } finally {
+      if (originalCompressed === undefined) {
+        delete process.env.ASTRO_BLOCKS_MAX_IMPORT_COMPRESSED_BYTES;
+      } else {
+        process.env.ASTRO_BLOCKS_MAX_IMPORT_COMPRESSED_BYTES = originalCompressed;
       }
     }
   });

--- a/tests/import-export-bootstrap.test.js
+++ b/tests/import-export-bootstrap.test.js
@@ -1,0 +1,318 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * D-1: handleBootstrapImport handler tests.
+ *
+ * Security contract:
+ *   - users.length === 0  → runs the full import pipeline
+ *   - users.length  > 0  → 403 IMMEDIATELY, body is NOT consumed
+ *
+ * The bootstrap endpoint is unauthenticated: no Authorization header needed.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { ensureDefaultFiles, loadUsers, saveUsers } from '../dist/api/data.js';
+import { buildExportStream, runImportPipeline } from '../dist/api/backup.js';
+import { handleBootstrapImport } from '../dist/api/handlers.js';
+import { DATA_SCHEMA_VERSION } from '../dist/api/schema-version.js';
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+async function withTempProject(fn) {
+  const previousRoot = process.env.ASTRO_BLOCKS_PROJECT_ROOT;
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'astro-blocks-bootstrap-'));
+  process.env.ASTRO_BLOCKS_PROJECT_ROOT = tempRoot;
+  await ensureDefaultFiles();
+  try {
+    await fn(tempRoot);
+  } finally {
+    if (previousRoot === undefined) {
+      delete process.env.ASTRO_BLOCKS_PROJECT_ROOT;
+    } else {
+      process.env.ASTRO_BLOCKS_PROJECT_ROOT = previousRoot;
+    }
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+async function collectStream(stream) {
+  const reader = stream.getReader();
+  const chunks = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const totalLen = chunks.reduce((s, c) => s + c.length, 0);
+  const buf = Buffer.allocUnsafe(totalLen);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buf.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return buf;
+}
+
+async function buildZipBody(units, projectRoot) {
+  const stream = await buildExportStream(units, projectRoot);
+  return collectStream(stream);
+}
+
+async function buildMinimalZip(entries) {
+  const { Zip, ZipDeflate } = await import('fflate');
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    const zip = new Zip();
+    zip.ondata = (err, chunk, final) => {
+      if (err) { reject(err); return; }
+      chunks.push(chunk);
+      if (final) {
+        const totalLen = chunks.reduce((s, c) => s + c.length, 0);
+        const buf = Buffer.allocUnsafe(totalLen);
+        let off = 0;
+        for (const c of chunks) { buf.set(c, off); off += c.length; }
+        resolve(buf);
+      }
+    };
+    for (const { name, bytes } of entries) {
+      const entry = new ZipDeflate(name);
+      zip.add(entry);
+      entry.push(new Uint8Array(bytes), true);
+    }
+    zip.end();
+  });
+}
+
+function makeRequest(body, extraHeaders = {}) {
+  return new Request('http://localhost/cms/api/import/bootstrap', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/zip', ...extraHeaders },
+    body,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// D-1: Zero-user gate — allow when empty
+// ---------------------------------------------------------------------------
+
+test('D-1: empty users + valid zip → 200 with success:true', async () => {
+  await withTempProject(async (tempRoot) => {
+    // Instance has no users (default empty state from ensureDefaultFiles)
+    const usersData = await loadUsers();
+    assert.equal(usersData.users.length, 0, 'precondition: must start with 0 users');
+
+    const zipBody = await buildZipBody(['pages'], tempRoot);
+    const req = makeRequest(zipBody);
+    const res = await handleBootstrapImport(req, { cache: null });
+
+    assert.equal(res.status, 200, `expected 200, got ${res.status}`);
+    const body = await res.json();
+    assert.equal(body.success, true, `expected success:true, got: ${JSON.stringify(body)}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D-1: Zero-user gate — refuse when users exist
+// ---------------------------------------------------------------------------
+
+test('D-1: non-empty users → 403 and body is NOT consumed', async () => {
+  await withTempProject(async (tempRoot) => {
+    // Seed one user
+    await saveUsers({
+      users: [
+        {
+          id: 'existing-user-1',
+          email: 'owner@example.com',
+          passwordHash: 'hash',
+          role: 'owner',
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    // Use a zip that WOULD pass the pipeline if body were consumed — but must not be.
+    // The key invariant: even with a valid zip body, the 403 comes before arrayBuffer().
+    // We verify by checking that no staging directory side-effects appear.
+    const zipBody = await buildZipBody(['pages'], tempRoot);
+    const req = makeRequest(zipBody);
+
+    // Record the backup count before the call — if body were consumed and pipeline ran,
+    // a backup would be created. 403 must return with zero new backups and zero staging dirs.
+    const backupsDir = path.join(tempRoot, 'data', '_backups');
+    let backupsBefore = 0;
+    try { backupsBefore = (await fs.readdir(backupsDir)).length; } catch { /* dir may not exist */ }
+
+    const res = await handleBootstrapImport(req, { cache: null });
+
+    assert.equal(res.status, 403, `expected 403, got ${res.status}`);
+
+    // Pipeline must NOT have run: no new backups created
+    let backupsAfter = 0;
+    try { backupsAfter = (await fs.readdir(backupsDir)).length; } catch { /* dir may not exist */ }
+    assert.equal(backupsAfter, backupsBefore, 'no backups must be created when 403 gate fires');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D-1: Empty users + schema version mismatch → 422
+// ---------------------------------------------------------------------------
+
+test('D-1: empty users + schemaVersion mismatch → 422', async () => {
+  await withTempProject(async () => {
+    // Build a corrupt-schemaVersion manifest
+    const wrongManifest = {
+      schemaVersion: DATA_SCHEMA_VERSION + 99,
+      astroBlocksVersion: '0.0.0',
+      exportedAt: new Date().toISOString(),
+      units: ['pages'],
+      counts: { pages: 0 },
+      checksums: { 'data/pages.json': 'abc123' },
+    };
+    const pagesJson = JSON.stringify({ pages: [] });
+    const manifestJson = JSON.stringify(wrongManifest);
+
+    const zipBody = await buildMinimalZip([
+      { name: 'manifest.json', bytes: Buffer.from(manifestJson) },
+      { name: 'data/pages.json', bytes: Buffer.from(pagesJson) },
+    ]);
+
+    const req = makeRequest(zipBody);
+    const res = await handleBootstrapImport(req, { cache: null });
+
+    assert.equal(res.status, 422, `expected 422 for schemaVersion mismatch, got ${res.status}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D-1: Empty users + corrupt zip → 400
+// ---------------------------------------------------------------------------
+
+test('D-1: empty users + corrupt zip → 400', async () => {
+  await withTempProject(async () => {
+    const corruptBytes = Buffer.from('this is not a zip file at all');
+    const req = makeRequest(corruptBytes);
+    const res = await handleBootstrapImport(req, { cache: null });
+
+    assert.equal(res.status, 400, `expected 400 for corrupt zip, got ${res.status}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D-1: No Authorization header — still works when users empty (public endpoint)
+// ---------------------------------------------------------------------------
+
+test('D-1: no Authorization header → 200 when users empty (endpoint is public)', async () => {
+  await withTempProject(async (tempRoot) => {
+    const zipBody = await buildZipBody(['pages'], tempRoot);
+    // Deliberately omit Authorization header
+    const req = new Request('http://localhost/cms/api/import/bootstrap', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/zip' },
+      body: zipBody,
+    });
+
+    const res = await handleBootstrapImport(req, { cache: null });
+    assert.equal(res.status, 200, `expected 200 without auth header, got ${res.status}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D-1: Empty users + path traversal entry → 400, no files written
+// ---------------------------------------------------------------------------
+
+test('D-1: empty users + path-traversal entry → 400, no files written', async () => {
+  await withTempProject(async (tempRoot) => {
+    // Craft a manifest that references a traversal path
+    const manifest = {
+      schemaVersion: DATA_SCHEMA_VERSION,
+      astroBlocksVersion: '0.0.0',
+      exportedAt: new Date().toISOString(),
+      units: ['pages'],
+      counts: { pages: 0 },
+      checksums: {
+        'uploads/../../etc/passwd': 'abc123',
+        'data/pages.json': 'abc123',
+      },
+    };
+    const pagesJson = JSON.stringify({ pages: [] });
+    const traversalBytes = Buffer.from('evil content');
+    const manifestJson = JSON.stringify(manifest);
+
+    const zipBody = await buildMinimalZip([
+      { name: 'manifest.json', bytes: Buffer.from(manifestJson) },
+      { name: 'data/pages.json', bytes: Buffer.from(pagesJson) },
+      { name: 'uploads/../../etc/passwd', bytes: traversalBytes },
+    ]);
+
+    // Ensure no suspicious file exists before
+    const evilPath = path.join(tempRoot, 'etc', 'passwd');
+    let existedBefore = false;
+    try { await fs.access(evilPath); existedBefore = true; } catch { /* ok */ }
+    assert.equal(existedBefore, false, 'precondition: evil file must not exist before test');
+
+    const req = makeRequest(zipBody);
+    const res = await handleBootstrapImport(req, { cache: null });
+
+    // Should be 400 (path traversal rejected at extraction)
+    assert.equal(res.status, 400, `expected 400 for path traversal, got ${res.status}`);
+
+    // Evil file must not have been written
+    let existedAfter = false;
+    try { await fs.access(evilPath); existedAfter = true; } catch { /* ok */ }
+    assert.equal(existedAfter, false, 'path-traversal entry must not create files on disk');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D-1: Empty users + ceiling exceeded → 413, no files written
+// ---------------------------------------------------------------------------
+
+test('D-1: empty users + ceiling exceeded → 413, no files written', async () => {
+  await withTempProject(async (tempRoot) => {
+    // Set a very low ceiling via env var
+    const originalFileCeiling = process.env.ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES;
+    const originalTotalCeiling = process.env.ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES;
+    // Set ceiling to 10 bytes (any real file will exceed this)
+    process.env.ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES = '10';
+    process.env.ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES = '100';
+
+    try {
+      const zipBody = await buildZipBody(['pages'], tempRoot);
+      const req = makeRequest(zipBody);
+      const res = await handleBootstrapImport(req, { cache: null });
+
+      assert.equal(res.status, 413, `expected 413 for ceiling exceeded, got ${res.status}`);
+
+      // No new backup should have been created
+      const backupsDir = path.join(tempRoot, 'data', '_backups');
+      let backupEntries = [];
+      try {
+        backupEntries = await fs.readdir(backupsDir);
+      } catch {
+        // _backups dir may not exist — fine
+      }
+      assert.equal(backupEntries.length, 0, 'no backups should be created when ceiling exceeded');
+    } finally {
+      if (originalFileCeiling === undefined) {
+        delete process.env.ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES;
+      } else {
+        process.env.ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES = originalFileCeiling;
+      }
+      if (originalTotalCeiling === undefined) {
+        delete process.env.ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES;
+      } else {
+        process.env.ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES = originalTotalCeiling;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Slice D + F — Bootstrap import + login-screen UI (import/export)

Fourth PR in the chained `import-export` feature. **Base = `feat/import-export-pr3-import`**. Adds the one-time UNAUTHENTICATED seed import (login screen, zero-user state) — the second-most-sensitive surface after the import pipeline.

### What's included
- **D-1 `handleBootstrapImport`** (`api/handlers.ts`) + `POST /cms/api/import/bootstrap` branch placed BEFORE `ensureAuth` (public, like login). Zero-user gate loads users and returns 403 BEFORE reading the body once any user exists. When zero users, reuses the shared, hardened `runImportPipeline` for a FULL RESTORE (any unit combination), same validation/ceiling/backup/rollback guarantees as the authed import.
- **F-1 login-screen UI** (`routes/admin/layout.astro`): in the `hasUsers === false` branch, an accessible "Import a backup to seed this instance" control — `<label for>` file picker, POST of the raw zip (`application/zip`), aria-live status + error regions, redirect to `/cms` on success. i18n keys in en + es (neutral Spanish).

### Dual blind review + fixes
Two independent blind reviewers (backend gate + frontend) drove these fixes:
- **CRITICAL (TOCTOU)** — the zero-user gate was checked OUTSIDE the import lock, so two concurrent bootstrap POSTs could both pass and the second overwrite the freshly-seeded instance. Fixed: an in-lock re-check (`bootstrapMode`) is now the first step of the pipeline under the serialization lock; the second concurrent bootstrap gets `bootstrap-users-exist` → 403. Verified by a concurrency test.
- **HIGH** — the public 500 path echoed raw exception messages (internal path leak). Now returns a generic message and logs server-side (applied to `handleImport` too).
- **Frontend HIGH** — the `aria-live` status region was never populated during import (no progress feedback) and error strings were hardcoded English. Fixed: status region announces "Importing…"; new i18n keys `bootstrap.importingStatus/importError/networkError` (en + es).
- **Frontend MEDIUM/LOW** — removed redundant/inert ARIA (double name on file input, `aria-label` on non-role div, `aria-live` implied by role); aligned Spanish tone to catalog infinitives.
- **Tests** — strengthened the "body not consumed on 403" test (arrayBuffer spy), added concurrency + Content-Length-preflight (413) tests.

The `define:vars` runtime pitfall that previously bit this file did NOT recur — the new client code is in a plain (transpiled) `<script>` and all `define:vars` bridges are pure JS. (Reviewer-confirmed.)

### Known limitation (documented in code)
A very narrow residual race remains: if `handleLogin`'s first-user `saveUsers` completes AFTER the in-lock re-check but DURING extraction, the bootstrap pipeline could still overwrite the just-created user. Fully closing it requires `handleLogin` to join the same lock domain (cross-cutting refactor) — deferred to a follow-up. The primary concurrent-bootstrap vector is fully closed.

### Tests
Strict TDD. **Full suite: 894 pass / 0 fail** (no regressions). +12 bootstrap tests (7 initial + 5 review-fix).
