### PR TITLE
fix: admin upload, cache invalidation, and global-block editing regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [3.3.1] - 2026-07-02
+
+### Title
+
+Fix admin upload, cache invalidation, and global-block editing
+
+### Fixed
+
+- **Block editor uploads**: uploading an image or file from a block (or the SEO image field) failed because those pickers sent `multipart/form-data`, which the upload endpoint does not parse. All uploads now use the same raw-binary protocol as the media library, unified in a single shared helper.
+- **Cache invalidation**: the "Invalidate cache" action returned a `403` behind reverse proxies. The bodyless POST now sends a non-form `Content-Type`, so Astro's origin-check middleware no longer rejects it.
+- **Global-block editing**: opening or editing a global block returned a `404` on deployed sites (rendering was unaffected). The admin API previously resolved block declarations from the gitignored `.astro-blocks/runtime.mjs` build artifact at request time; the registry is now baked into the bundle at build, so it is always available.
+
+### Added
+
+- End-to-end coverage (Playwright) for block image/file uploads, cache invalidation, and global-block resolution — each guarding the exact regression it fixes.
+
 ## [3.3.0] - 2026-07-01
 
 ### Title

--- a/e2e/admin-flow.spec.ts
+++ b/e2e/admin-flow.spec.ts
@@ -15,6 +15,14 @@ import { test, expect } from './fixtures/coverage';
 const TEST_EMAIL = 'owner@example.com';
 const TEST_PASSWORD = 'password123';
 
+// Smallest valid 1×1 PNG — enough for the upload allowlist + imageSize probe.
+const PNG_1x1 = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  'base64',
+);
+// Minimal PDF byte stream — the server gates on the application/pdf MIME, not structure.
+const PDF_MIN = Buffer.from('%PDF-1.4\n1 0 obj<</Type/Catalog>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF', 'utf-8');
+
 // Helper: log in through the CMS login screen.
 // Waits for the authenticated panel (#admin-content) to become visible.
 async function login(page: import('@playwright/test').Page): Promise<void> {
@@ -29,6 +37,62 @@ async function login(page: import('@playwright/test').Page): Promise<void> {
 
   // After successful login the page reloads and #admin-content becomes visible
   await page.locator('#admin-content').waitFor({ state: 'visible', timeout: 20_000 });
+}
+
+// Helper: open the new-page modal, fill title/slug, add the named block, and return
+// the modal locator. The freshly added block auto-expands (openBlockIndex = last), so
+// its field controls are immediately reachable inside .cms-block-item-body.
+async function openNewPageWithBlock(
+  page: import('@playwright/test').Page,
+  blockName: string,
+): Promise<import('@playwright/test').Locator> {
+  await page.goto('/cms/pages');
+  await page.locator('#admin-content').waitFor({ state: 'visible', timeout: 20_000 });
+  await page.locator('#cms-page-new-btn').waitFor({ state: 'visible', timeout: 15_000 });
+  await page.locator('#cms-page-new-btn').click();
+
+  const modal = page.locator('#page-detail-modal');
+  await modal.waitFor({ state: 'visible', timeout: 10_000 });
+
+  const uniqueSuffix = Date.now();
+  await page.locator('#page-detail-title').fill(`E2E Upload ${uniqueSuffix}`);
+  await page.locator('#page-detail-slug').fill(`/e2e-upload-${uniqueSuffix}`);
+
+  await page.locator('#page-detail-blocks-add').click();
+  const blockSelectModal = page.locator('#page-detail-block-select-modal');
+  await blockSelectModal.waitFor({ state: 'visible', timeout: 10_000 });
+  await blockSelectModal.getByText(blockName, { exact: true }).click();
+  await blockSelectModal.waitFor({ state: 'hidden', timeout: 10_000 });
+
+  await expect(page.locator('#page-detail-blocks-list .cms-block-item')).toHaveCount(1, {
+    timeout: 10_000,
+  });
+
+  return modal;
+}
+
+// Helper: upload a file through the already-open media picker and return the upload
+// response. The picker binds its file-input change listener only AFTER the media list
+// finishes loading (openPickerDialog awaits pickerLoadPage, then binds), so a single
+// setInputFiles can race ahead of the listener and leave the upload button disabled.
+// Re-applying the file re-fires change until the button enables — deterministic.
+async function uploadThroughPicker(
+  page: import('@playwright/test').Page,
+  fileSpec: { name: string; mimeType: string; buffer: Buffer },
+): Promise<import('@playwright/test').Response> {
+  const fileInput = page.locator('#cms-picker-file-input');
+  const uploadBtn = page.locator('#cms-picker-upload-btn');
+
+  await expect(async () => {
+    await fileInput.setInputFiles(fileSpec);
+    await expect(uploadBtn).toBeEnabled({ timeout: 1_000 });
+  }).toPass({ timeout: 15_000 });
+
+  const uploadResponse = page.waitForResponse(
+    (r) => r.url().includes('/cms/api/upload') && r.request().method() === 'POST',
+  );
+  await uploadBtn.click();
+  return uploadResponse;
 }
 
 test.describe('Admin panel', () => {
@@ -123,5 +187,114 @@ test.describe('Admin panel', () => {
     await expect(
       page.locator('#cms-pages-tbody').getByText(uniqueTitle)
     ).toBeVisible({ timeout: 10_000 });
+  });
+
+  // Regression: the block editor's image/file pickers must upload through the same
+  // raw-binary protocol as the media grid. They previously sent multipart/form-data,
+  // which the server rejected (handleUpload reads request.arrayBuffer(), never parses
+  // multipart) — surfacing as an "unauthorized" upload. These tests drive the real
+  // picker UI and assert the POST /cms/api/upload the browser sends is accepted (200).
+
+  test('Test C: uploading an image from a block succeeds (not 401)', async ({ page }) => {
+    await login(page);
+    // "Media Showcase" exposes image fields (heroImage, galleryImage1/2)
+    await openNewPageWithBlock(page, 'Media Showcase');
+
+    // The auto-expanded block body holds the image field's "Choose image" button
+    const blockBody = page.locator('#page-detail-blocks-list .cms-block-item-body').first();
+    const chooseImage = blockBody.locator('.cms-image-field-choose').first();
+    await chooseImage.waitFor({ state: 'visible', timeout: 10_000 });
+    await chooseImage.click();
+
+    // The singleton media picker dialog opens
+    const picker = page.locator('#cms-media-picker');
+    await picker.waitFor({ state: 'visible', timeout: 10_000 });
+
+    // Select an in-memory PNG and upload it. The exact regression guard: the request
+    // the browser sends must be accepted (200), not 401/403.
+    const response = await uploadThroughPicker(page, {
+      name: 'e2e-hero.png',
+      mimeType: 'image/png',
+      buffer: PNG_1x1,
+    });
+    expect(response.status()).toBe(200);
+
+    // On success the picker closes and the image field flips to its selected state
+    await picker.waitFor({ state: 'hidden', timeout: 10_000 });
+    await expect(blockBody.locator('.cms-image-field--has-value').first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(blockBody.locator('[data-choose-label]').first()).toHaveText('Replace', {
+      timeout: 10_000,
+    });
+  });
+
+  test('Test D: uploading a file (PDF) from a block succeeds (not 401)', async ({ page }) => {
+    await login(page);
+    // "Download Button" exposes a file field (accept: application/pdf)
+    await openNewPageWithBlock(page, 'Download Button');
+
+    const blockBody = page.locator('#page-detail-blocks-list .cms-block-item-body').first();
+    const chooseFile = blockBody.locator('.cms-file-field-choose').first();
+    await chooseFile.waitFor({ state: 'visible', timeout: 10_000 });
+    await chooseFile.click();
+
+    const picker = page.locator('#cms-media-picker');
+    await picker.waitFor({ state: 'visible', timeout: 10_000 });
+
+    const response = await uploadThroughPicker(page, {
+      name: 'e2e-doc.pdf',
+      mimeType: 'application/pdf',
+      buffer: PDF_MIN,
+    });
+    expect(response.status()).toBe(200);
+
+    await picker.waitFor({ state: 'hidden', timeout: 10_000 });
+    await expect(blockBody.locator('[data-file-choose-label]').first()).toHaveText('Replace', {
+      timeout: 10_000,
+    });
+  });
+
+  // Regression: the bodyless "Invalidate cache" POST previously carried no Content-Type,
+  // tripping Astro's origin-check middleware (403) behind a proxy. It now sends
+  // application/json like every other admin call. Assert the POST is accepted.
+  test('Test E: cache invalidation POST is accepted (not 403)', async ({ page }) => {
+    await login(page);
+    await page.goto('/cms/cache');
+    await page.locator('#admin-content').waitFor({ state: 'visible', timeout: 20_000 });
+
+    const invalidateBtn = page.locator('#cache-invalidate-btn');
+    await invalidateBtn.waitFor({ state: 'visible', timeout: 15_000 });
+
+    const invalidateResponse = page.waitForResponse(
+      (r) => r.url().includes('/cms/api/cache/invalidate') && r.request().method() === 'POST',
+    );
+    await invalidateBtn.click();
+
+    const response = await invalidateResponse;
+    expect(response.status()).toBe(200);
+  });
+
+  // Regression: opening/editing a global block must resolve the block declaration from
+  // the registry. The API previously read .astro-blocks/runtime.mjs from disk at request
+  // time — a gitignored build artifact that is absent in deployed/data-dir-rooted setups
+  // (as here: ASTRO_BLOCKS_PROJECT_ROOT points at .e2e-data, which has no .astro-blocks),
+  // so every global-block GET/PUT 404'd even though rendering worked via the bundled alias.
+  test('Test F: opening a global block resolves its declaration (not 404)', async ({ page }) => {
+    await login(page);
+    await page.goto('/cms/global-blocks');
+    await page.locator('#admin-content').waitFor({ state: 'visible', timeout: 20_000 });
+
+    // Call the exact endpoint the editor uses, with the real session token, from the page
+    // context. "header-cta" is declared in the playground's globalBlocks config.
+    const status = await page.evaluate(async () => {
+      const token = (window as unknown as { getCmsToken?: () => string }).getCmsToken?.() ?? '';
+      const res = await fetch('/cms/api/global-blocks/header-cta', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      return res.status;
+    });
+
+    expect(status).toBe(200);
   });
 });

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from 'node:url';
 import type { AstroIntegration } from 'astro';
 import { buildSchemaMap, resolveBlockEntries } from '../utils/blocks.js';
 import { COMPONENT_PATH_KEY } from '../contract/index.js';
-import type { AstroBlocksOptions, GlobalBlockDeclaration, PrimitivePropDef } from '../types/index.js';
+import type { AstroBlocksOptions, GlobalBlockDeclaration, GlobalBlockRuntimeEntry, PrimitivePropDef } from '../types/index.js';
 import { DEFAULT_ALLOWED_FILE_TYPES } from '../utils/file-types.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -83,7 +83,7 @@ export function validateGlobalBlocks(declarations: GlobalBlockDeclaration[]): vo
   }
 }
 
-export async function generateRuntime(projectRoot: string, options: AstroBlocksOptions): Promise<void> {
+export async function generateRuntime(projectRoot: string, options: AstroBlocksOptions): Promise<GlobalBlockRuntimeEntry[]> {
   const layoutPath = options.layoutPath || './src/layouts/Layout.astro';
   const astroBlocksDir = path.join(projectRoot, '.astro-blocks');
 
@@ -158,6 +158,13 @@ export async function generateRuntime(projectRoot: string, options: AstroBlocksO
   await fs.mkdir(astroBlocksDir, { recursive: true });
   await fs.writeFile(path.join(astroBlocksDir, 'runtime.mjs'), runtimeLines.join('\n'), 'utf-8');
   await fs.writeFile(path.join(astroBlocksDir, 'schema-map.mjs'), schemaMapLines.join('\n'), 'utf-8');
+
+  // Return the registry so the caller can bake it into the bundle (vite.define). The
+  // precompiled API route (catchall.js) cannot import the 'astro-blocks-runtime' alias
+  // like the .astro render paths do, and reading .astro-blocks/runtime.mjs from disk at
+  // request time is unreliable in deployment (gitignored build artifact). Baking is the
+  // robust source of truth for the admin global-block API.
+  return registryEntries;
 }
 
 function resolveOptions(options: AstroBlocksOptions): ResolvedPluginOptions {
@@ -269,7 +276,7 @@ export default function astroBlocks(options: AstroBlocksOptions): AstroIntegrati
           resolvedOptions.i18n.routingStrategy = 'path-prefix';
         }
 
-        await generateRuntime(projectRoot, resolvedOptions);
+        const globalBlocksRegistry = await generateRuntime(projectRoot, resolvedOptions);
 
         const resolveCms = (file: string): string => path.join(cmsDir, 'routes', file);
         const vite = config.vite || {};
@@ -307,6 +314,12 @@ export default function astroBlocks(options: AstroBlocksOptions): AstroIntegrati
         vite.define['import.meta.env.ASTRO_BLOCKS_CACHE_SWR'] = JSON.stringify(resolvedOptions.cache.swr);
         vite.define['import.meta.env.ASTRO_BLOCKS_ROUTING_STRATEGY'] = JSON.stringify(resolvedOptions.i18n.routingStrategy);
         vite.define['import.meta.env.ASTRO_BLOCKS_ALLOWED_FILE_TYPES'] = JSON.stringify(resolvedOptions.allowedFileTypes);
+        // Bake the global-block registry into the bundle so the precompiled admin API
+        // (catchall.js) resolves declarations without reading .astro-blocks/runtime.mjs
+        // from disk — that gitignored artifact is often absent in deployed servers,
+        // which 404'd every global-block open/edit. Double-encode: the outer JSON.stringify
+        // emits a string literal that the route parses back with JSON.parse.
+        vite.define['import.meta.env.ASTRO_BLOCKS_GLOBAL_BLOCKS_REGISTRY'] = JSON.stringify(JSON.stringify(globalBlocksRegistry));
 
         const existingNoExternal = vite.ssr?.noExternal ?? [];
         const cmsNoExternal = ['animate.css', '@picocss/pico'];

--- a/routes/admin/cache.astro
+++ b/routes/admin/cache.astro
@@ -71,7 +71,10 @@ const cacheI18n = {
         btn.disabled = true;
         const token = (typeof window !== 'undefined' && window.getCmsToken) ? window.getCmsToken() : '';
         try {
-          const res = await fetch(url, { method: 'POST', headers: { 'Authorization': 'Bearer ' + token } });
+          // Non-form Content-Type avoids Astro's origin-check 403 for bodyless POSTs
+          // behind reverse proxies (see routes/admin/client/media.ts). Without any
+          // Content-Type header, Astro's middleware requires a same-origin match.
+          const res = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token } });
           const payload = await readPayload(res);
           if (res.ok) {
             window.cmsToast?.({ title: successTitle, message: payload.message || successMessage, tone: 'success' });

--- a/routes/admin/client/block-form.ts
+++ b/routes/admin/client/block-form.ts
@@ -38,11 +38,11 @@ import {
   isPrimitivePropDef,
 } from '../../../utils/block-validation.js';
 import { isSchemaPropLocalizable } from '../../../utils/localization.js';
-import { escapeHtml, getActiveContentLocale, getCmsToken } from './common.js';
+import { escapeHtml, getActiveContentLocale } from './common.js';
 import { ct } from '../i18n/client.js';
 import { toImageValue, parseImageValue, mediaEntryToImageValue, serializeImageValueAttr } from '../../../utils/image-value.js';
 import { toFileValue, parseFileValue, mediaEntryToFileValue, serializeFileValueAttr, isEmptyFileValue } from '../../../utils/file-value.js';
-import { fetchMedia, formatBytes, formatDimensions, formatMediaDate } from './media-fetch.js';
+import { fetchMedia, formatBytes, formatDimensions, formatMediaDate, uploadMedia } from './media-fetch.js';
 import type { MediaEntry as MediaFetchEntry } from './media-fetch.js';
 import { DEFAULT_ALLOWED_FILE_TYPES, intersectAccept } from '../../../utils/file-types.js';
 
@@ -668,14 +668,7 @@ async function openPickerDialog(
       const file = fileInput.files[0];
       uploadBtn.disabled = true;
       try {
-        const fd = new FormData();
-        fd.append('file', file);
-        const token = getCmsToken();
-        const uploadRes = await fetch('/cms/api/upload', {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${token}` },
-          body: fd,
-        });
+        const uploadRes = await uploadMedia(file);
         if (uploadRes.ok) {
           const uploadBody = await uploadRes.json() as { url?: string; entry?: MediaEntry };
           if (uploadBody.url) {

--- a/routes/admin/client/media-fetch.ts
+++ b/routes/admin/client/media-fetch.ts
@@ -68,6 +68,34 @@ export async function fetchMedia(params?: { q?: string; page?: number; limit?: n
   }
 }
 
+/**
+ * Upload a single file to /cms/api/upload.
+ *
+ * This is the ONLY supported upload protocol: the raw file bytes are sent as the
+ * request body, with the file's real MIME as Content-Type and the (percent-encoded)
+ * filename in the x-cms-filename header. The server reads the body via
+ * request.arrayBuffer() and does NOT parse multipart/form-data (see handleUpload in
+ * api/handlers.ts). Sending FormData here yields a multipart/form-data Content-Type,
+ * which the server rejects — and, being a form-like Content-Type, it also trips
+ * Astro's origin-check middleware behind reverse proxies. Auth is a JWT in the
+ * Authorization header, never an ambient cookie, so CSRF is a non-issue.
+ *
+ * Centralized so every caller (media grid, block picker, SEO image) stays in sync.
+ * Returns the raw Response; callers own success/error handling.
+ */
+export function uploadMedia(file: File): Promise<Response> {
+  const token = getCmsToken();
+  return fetch('/cms/api/upload', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': file.type || 'application/octet-stream',
+      'x-cms-filename': encodeURIComponent(file.name),
+    },
+    body: file,
+  });
+}
+
 // ─── Shared metadata formatters ───────────────────────────────────────────────
 
 /**

--- a/routes/admin/client/media.ts
+++ b/routes/admin/client/media.ts
@@ -10,7 +10,7 @@ Licensed under the Business Source License 1.1
  */
 
 import { getCmsToken, getCmsWindow } from './common.js';
-import { fetchMedia, formatBytes, formatDimensions, formatMediaDate } from './media-fetch.js';
+import { fetchMedia, formatBytes, formatDimensions, formatMediaDate, uploadMedia } from './media-fetch.js';
 import type { MediaListEnvelope, MediaEntry } from './media-fetch.js';
 import { ct } from '../i18n/client.js';
 
@@ -200,21 +200,7 @@ async function loadMedia(): Promise<void> {
 
 async function uploadFile(file: File): Promise<void> {
   const cmsWindow = getCmsWindow();
-  const token = getCmsToken();
-  // Send the raw binary body with the file's real MIME as Content-Type. CSRF is not a
-  // concern: the API authenticates via the JWT in the Authorization header (not a cookie),
-  // and the non-form Content-Type + custom x-cms-filename header force a CORS preflight.
-  // The non-form Content-Type also avoids Astro's origin-check 403 behind reverse proxies
-  // (see the rationale in api/handlers.ts handleUpload).
-  const res = await fetch('/cms/api/upload', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': file.type || 'application/octet-stream',
-      'x-cms-filename': encodeURIComponent(file.name),
-    },
-    body: file,
-  });
+  const res = await uploadMedia(file);
 
   if (res.ok) {
     cmsWindow.cmsToast?.({ title: ct('media.uploadSuccess'), message: ct('media.uploadSuccessMessage', { filename: file.name }), tone: 'success' });

--- a/routes/admin/client/page-editor.ts
+++ b/routes/admin/client/page-editor.ts
@@ -24,6 +24,7 @@ import {
 } from './common.js';
 import { ct } from '../i18n/client.js';
 import { mountBlockForm, type BlockFormHandle, type ArrayLimitInfo } from './block-form.js';
+import { uploadMedia } from './media-fetch.js';
 
 const trashIconSvg =
   '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>';
@@ -737,15 +738,9 @@ export function initPageEditor(): void {
   }
 
   async function uploadSeoImage(file: File): Promise<void> {
-    const formData = new FormData();
-    formData.append('file', file);
-
-    const data = await fetchJson<{ url?: string }>('/cms/api/upload', {
-      method: 'POST',
-      headers: authHeaders(false),
-      body: formData,
-    });
-
+    const response = await uploadMedia(file);
+    const data = await response.json().catch(() => ({})) as { url?: string; error?: string };
+    if (!response.ok) throw new Error(data.error || 'Request failed');
     if (data.url) updateSeoImagePreview(data.url);
   }
 

--- a/routes/api/catchall.ts
+++ b/routes/api/catchall.ts
@@ -13,6 +13,21 @@ import type { GlobalBlockRuntimeEntry } from '../../types/index.js';
 export const prerender = false;
 
 async function loadGlobalBlocksRegistry(): Promise<GlobalBlockRuntimeEntry[]> {
+  // Primary: the registry baked into the bundle at build time (vite.define). This is the
+  // robust source in every deployment. Reading .astro-blocks/runtime.mjs from disk (below)
+  // fails whenever that gitignored build artifact is absent from the deployed server —
+  // which 404'd global-block open/edit even though rendering worked via the bundled alias.
+  const baked = (import.meta as ImportMeta & { env?: Record<string, unknown> }).env?.ASTRO_BLOCKS_GLOBAL_BLOCKS_REGISTRY;
+  if (typeof baked === 'string' && baked.length > 0) {
+    try {
+      const parsed = JSON.parse(baked) as GlobalBlockRuntimeEntry[];
+      if (Array.isArray(parsed)) return parsed;
+    } catch {
+      // Malformed bake — fall through to the filesystem read.
+    }
+  }
+
+  // Fallback: dev/legacy filesystem read of the generated runtime module.
   try {
     const projectRoot = process.env.ASTRO_BLOCKS_PROJECT_ROOT || process.cwd();
     const runtimePath = path.join(projectRoot, '.astro-blocks', 'runtime.mjs');


### PR DESCRIPTION
## Summary

Three admin-panel regressions, each with a proven e2e guard. All are behind-the-scenes fixes — no public API, config, schema, auth, or route changes.

### 1. Block editor uploads failed (`fix(media)`)
Uploading an image/file from a block picker or the SEO image field sent `multipart/form-data` (FormData), but the upload endpoint reads the body via `request.arrayBuffer()` and never parses multipart — so those uploads failed while the media library worked. Root cause was a **missing shared helper**: three call sites hand-rolled the request and two fell behind when the protocol changed. Unified into `uploadMedia()` in `media-fetch.ts` (raw body + real MIME + `x-cms-filename`); migrated `block-form.ts`, `page-editor.ts`, and `media.ts`.

### 2. Cache invalidation returned 403 (`fix(cache)`)
The "Invalidate cache" action was a bodyless POST with no `Content-Type`, tripping Astro's origin-check middleware (`403 Cross-site POST forbidden`) behind reverse proxies. Now sends `application/json` like every other admin call.

### 3. Global-block open/edit returned 404 (`fix(global-blocks)`)
The admin API resolved block declarations from the **gitignored** `.astro-blocks/runtime.mjs`, read from disk at request time — absent in deployed server bundles, so the registry loaded empty (rendering was unaffected because it uses the bundled `astro-blocks-runtime` alias, which the precompiled API route cannot). The registry is now **baked into the bundle** via `vite.define` (same pattern as the cache settings); `catchall` reads `import.meta.env.ASTRO_BLOCKS_GLOBAL_BLOCKS_REGISTRY` with a filesystem fallback for dev.

## Testing

- **New e2e guards** (`e2e/admin-flow.spec.ts`), each validated against the buggy code (fails) and the fix (passes):
  - Test C/D — block image/file upload return `200` (revert to FormData → `415`)
  - Test E — cache invalidation `200` (was `403`)
  - Test F — global-block resolves `200` (was `404`; the e2e data-dir root has no `.astro-blocks`, reproducing the deploy condition)
- Full suite green: **6 e2e + 941 unit tests**, `tsc --noEmit` clean.

## Notes

- Fresh-context code review passed with no high-confidence issues.
- Follow-up (out of scope, pre-existing): `uploadSeoImage` / block picker upload swallow non-ok responses with no user-facing toast — worth a ticket to align with the project's `cmsToast`/`showAlert` conventions.