### PR TITLE
fix(admin): surface upload failures via toast (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [3.3.2] - 2026-07-02
+
+### Title
+
+Surface admin upload failures to the user
+
+### Fixed
+
+- **Admin upload feedback**: two admin upload call sites silently swallowed failed uploads (non-2xx responses or network errors) — the SEO image field and the block media picker. A failed upload now shows an error toast with the server-provided message, matching the media library's behavior. Reuses the existing `media.uploadError` / `media.uploadFailed` messages, so no new translations are required.
+
 ## [3.3.1] - 2026-07-02
 
 ### Title

--- a/routes/admin/client/block-form.ts
+++ b/routes/admin/client/block-form.ts
@@ -38,7 +38,7 @@ import {
   isPrimitivePropDef,
 } from '../../../utils/block-validation.js';
 import { isSchemaPropLocalizable } from '../../../utils/localization.js';
-import { escapeHtml, getActiveContentLocale } from './common.js';
+import { escapeHtml, getActiveContentLocale, showToast } from './common.js';
 import { ct } from '../i18n/client.js';
 import { toImageValue, parseImageValue, mediaEntryToImageValue, serializeImageValueAttr } from '../../../utils/image-value.js';
 import { toFileValue, parseFileValue, mediaEntryToFileValue, serializeFileValueAttr, isEmptyFileValue } from '../../../utils/file-value.js';
@@ -687,7 +687,12 @@ async function openPickerDialog(
               selectPickerImage(value);
             }
           }
+        } else {
+          const errBody = await uploadRes.json().catch(() => ({})) as { error?: string };
+          showToast(errBody.error || ct('media.uploadFailed'), 'error', ct('media.uploadError'));
         }
+      } catch {
+        showToast(ct('media.uploadFailed'), 'error', ct('media.uploadError'));
       } finally {
         uploadBtn.disabled = false;
       }

--- a/routes/admin/client/page-editor.ts
+++ b/routes/admin/client/page-editor.ts
@@ -738,10 +738,17 @@ export function initPageEditor(): void {
   }
 
   async function uploadSeoImage(file: File): Promise<void> {
-    const response = await uploadMedia(file);
-    const data = await response.json().catch(() => ({})) as { url?: string; error?: string };
-    if (!response.ok) throw new Error(data.error || 'Request failed');
-    if (data.url) updateSeoImagePreview(data.url);
+    try {
+      const response = await uploadMedia(file);
+      const data = await response.json().catch(() => ({})) as { url?: string; error?: string };
+      if (!response.ok) {
+        showToast(data.error || ct('media.uploadFailed'), 'error', ct('media.uploadError'));
+        return;
+      }
+      if (data.url) updateSeoImagePreview(data.url);
+    } catch {
+      showToast(ct('media.uploadFailed'), 'error', ct('media.uploadError'));
+    }
   }
 
   async function removeSeoImage(): Promise<void> {

--- a/tests/admin-upload-error-feedback.test.js
+++ b/tests/admin-upload-error-feedback.test.js
@@ -1,0 +1,83 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * Source-level guard: asserts that admin upload call sites surface failures to
+ * the user instead of swallowing them (issue #31).
+ *
+ * Two client call sites previously ignored non-2xx / network upload failures:
+ *   - page-editor.ts  uploadSeoImage()  — threw inside an unawaited async fn
+ *   - block-form.ts   picker upload     — only acted on `if (uploadRes.ok)`
+ *
+ * Both must now route failures through showToast(...) with the shared
+ * media.uploadError / media.uploadFailed i18n keys, mirroring media.ts.
+ *
+ * These are DOM event handlers with no jsdom harness in this suite, so we guard
+ * at the source level (same approach as block-form-attr-escaping.test.js) to
+ * catch any future regression in CI before it ships.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const root = process.cwd();
+
+const pageEditor = await readFile(
+  join(root, 'routes/admin/client/page-editor.ts'),
+  'utf-8'
+);
+const blockForm = await readFile(
+  join(root, 'routes/admin/client/block-form.ts'),
+  'utf-8'
+);
+
+test('page-editor.ts — SEO image upload surfaces failures via showToast', () => {
+  const fn = pageEditor.slice(
+    pageEditor.indexOf('async function uploadSeoImage'),
+    pageEditor.indexOf('async function removeSeoImage')
+  );
+  assert.ok(fn.length > 0, 'uploadSeoImage() not found');
+  assert.ok(
+    !/throw new Error/.test(fn),
+    'uploadSeoImage() still throws instead of surfacing the error to the user'
+  );
+  assert.ok(
+    /media\.uploadError/.test(fn),
+    'uploadSeoImage() must call showToast with the media.uploadError title'
+  );
+  // Guard against a silent-swallow regression on the non-2xx branch specifically:
+  // the response-error path (distinct from the network-error catch, which uses
+  // ct('media.uploadFailed')) must forward the server-provided error message.
+  assert.ok(
+    /showToast\(\s*data\.error/.test(fn),
+    'uploadSeoImage() must forward the server error (data.error) to showToast on a non-ok response'
+  );
+});
+
+test('block-form.ts — picker upload surfaces failures via showToast', () => {
+  const handler = blockForm.slice(
+    blockForm.indexOf("uploadBtn?.addEventListener('click'"),
+    blockForm.indexOf('uploadBtn.disabled = false;')
+  );
+  assert.ok(handler.length > 0, 'picker upload handler not found');
+  assert.ok(
+    /media\.uploadError/.test(handler),
+    'picker upload must use the media.uploadError title'
+  );
+  // The non-ok branch must READ the server error body and surface it. This
+  // cannot be satisfied by an empty `else {}` (the issue #31 regression) nor by
+  // the network-error catch block, which uses ct('media.uploadFailed') and never
+  // parses the response — so it pins the exact bug this guard exists to catch.
+  assert.ok(
+    /const errBody = await uploadRes\.json\(\)/.test(handler),
+    'picker upload must read the server error body on a non-ok response'
+  );
+  assert.ok(
+    /showToast\(\s*errBody\.error/.test(handler),
+    'picker upload must forward the server error (errBody.error) to showToast on a non-ok response'
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #31 — two admin client upload call sites silently swallowed failed uploads (non-2xx responses or network errors), inconsistent with the media library which surfaces errors via `cmsToast`:

- **SEO image upload** — `routes/admin/client/page-editor.ts` `uploadSeoImage()` threw inside an unawaited async fn (`void uploadSeoImage(file)`) → unhandled rejection, zero user feedback.
- **Block media picker upload** — `routes/admin/client/block-form.ts` only acted on `if (uploadRes.ok)`; a non-ok response was ignored.

Both now route failures through `showToast(...)`, reading the server-provided `error` field, faithfully mirroring `routes/admin/client/media.ts` `uploadFile()`. Reuses the existing `media.uploadError` / `media.uploadFailed` i18n keys (present in `es.ts` and `en.ts`) — **no new translations required**.

## Testing

- New source-level guard `tests/admin-upload-error-feedback.test.js` — these client DOM handlers have no jsdom harness in this suite, so it guards at the source level (same approach as `block-form-attr-escaping.test.js`). Sharpened after review to pin the **non-2xx branch specifically** (asserts the server error body is forwarded), so the exact silent-swallow regression from #31 cannot reappear undetected. Verified: injecting the regression makes the guard fail.
- `tsc --noEmit` clean.
- Full suite: **943 tests pass**.

## Scope

Client-side error handling only. No public API, config, block schema, auth, admin route, or env-var changes — no `AGENTS.consumer.md` update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)