### PR TITLE
fix(security): require ASTRO_BLOCKS_JWT_SECRET in production; fix session-secret env var

### DIFF
--- a/AGENTS.consumer.md
+++ b/AGENTS.consumer.md
@@ -654,39 +654,46 @@ The `<GlobalBlock>` component resolves the correct locale value at render time u
 
 ## Authentication (admin UI)
 
-The admin UI at `/cms` uses JWT-based sessions. Sessions are created by logging in at `/cms` with an admin username and password.
+The admin UI at `/cms` uses stateless JWT sessions. The admin account is created on **first login** — there are no admin credentials to configure in the environment.
 
-### Required environment variables
+### Required environment variable
 
-You must set all three of the following for the admin UI to work:
+You must set one variable for the admin UI to be usable in production:
 
 | Variable | Description |
 |----------|-------------|
 | `ASTRO_BLOCKS_JWT_SECRET` | Secret used to sign and verify JWT session tokens. Use a long random string (32+ characters). |
-| `ASTRO_BLOCKS_ADMIN_USER` | Email address for the initial admin account. |
-| `ASTRO_BLOCKS_ADMIN_PASSWORD` | Password for the initial admin account. |
 
-**These variables must be set in your server environment — not committed to git.** Add them to your `.env` file locally and set them as environment/runtime variables in your deployment platform.
+> **Security (required in production):** if `ASTRO_BLOCKS_JWT_SECRET` is not set, a production
+> server **refuses to authenticate** — the login endpoint returns `503` and no session is issued.
+> This is deliberate: without a configured secret the server would fall back to a public built-in
+> value and anyone could forge an owner session token. In development the fallback is tolerated
+> with a loud warning so you can iterate without setup. `CMS_JWT_SECRET` is accepted as a
+> deprecated legacy alias and will be removed in a future release — prefer `ASTRO_BLOCKS_JWT_SECRET`.
+
+**Set this in your server environment — not committed to git.** Add it to your `.env` file locally and set it as an environment/runtime variable in your deployment platform.
 
 Example `.env` (for local development only — never commit real values):
 
 ```sh
 ASTRO_BLOCKS_JWT_SECRET=your-long-random-secret-here
-ASTRO_BLOCKS_ADMIN_USER=admin@example.com
-ASTRO_BLOCKS_ADMIN_PASSWORD=changeme
 ```
 
-### JWT flow
+### Login / session flow
 
-1. User POSTs credentials to `/cms/api/[...path]` (login endpoint).
-2. Server validates against `ASTRO_BLOCKS_ADMIN_USER` and `ASTRO_BLOCKS_ADMIN_PASSWORD`.
-3. On success, a signed JWT is set as an `httpOnly` cookie.
-4. Subsequent requests to `/cms/**` are authenticated by the cookie.
-5. The JWT is signed using `ASTRO_BLOCKS_JWT_SECRET` — rotating this secret invalidates all sessions.
+1. The user POSTs `{ email, password }` to the login endpoint under `/cms/api/[...path]`.
+2. **First login bootstraps the owner:** if no users exist yet, the first successful POST creates
+   the owner account with the submitted credentials. Subsequent logins validate the email and
+   password against the stored (scrypt-hashed) account.
+3. On success the server returns a signed JWT (HS256, 7-day expiry) in the JSON response body.
+4. The admin client stores that token and sends it as an `Authorization: Bearer <token>` header
+   (an `x-cms-token` header is also accepted) on subsequent `/cms/api/**` requests.
+5. The JWT is signed with `ASTRO_BLOCKS_JWT_SECRET` — rotating this secret invalidates all sessions.
 
 ### Accessing the admin UI in production
 
-Navigate to `https://yourdomain.com/cms` in a browser. Log in with the credentials set in your environment variables.
+Navigate to `https://yourdomain.com/cms` in a browser. The first person to log in creates the owner
+account, so complete that initial login yourself over a trusted connection right after deploying.
 
 ---
 
@@ -804,13 +811,11 @@ Uploaded files are stored in `public/uploads/` in your project root. This direct
 
 ## Environment Variables Reference (complete list)
 
-### Required
+### Required (production)
 
 | Variable | Description |
 |----------|-------------|
-| `ASTRO_BLOCKS_JWT_SECRET` | JWT signing secret. Required for admin login to work. Minimum 32 characters recommended. |
-| `ASTRO_BLOCKS_ADMIN_USER` | Admin account email address. |
-| `ASTRO_BLOCKS_ADMIN_PASSWORD` | Admin account password. |
+| `ASTRO_BLOCKS_JWT_SECRET` | JWT signing secret. **Required in production** — without it the admin login endpoint returns `503` and no session is issued. Minimum 32 characters recommended. Legacy alias: `CMS_JWT_SECRET` (deprecated). The admin account itself is created on first login; there are no admin username/password env vars. |
 
 ### Optional (with defaults)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [3.4.0] - 2026-07-02
+
+### Title
+
+Require ASTRO_BLOCKS_JWT_SECRET in production and fix the admin session-secret variable
+
+### Security
+
+- **Admin auth fails closed without a configured secret.** In a production build, if no JWT
+  signing secret is configured the login endpoint now returns `503` and no session is issued,
+  instead of silently falling back to a public built-in constant. Signing and verifying tokens
+  with that constant allowed an owner session token to be forged. Development keeps the fallback
+  with a loud warning so local iteration is unaffected. Production is detected via Astro's
+  build-time `import.meta.env.PROD` (with `NODE_ENV=production` as a secondary signal), so the
+  guard fires regardless of whether the host sets `NODE_ENV`.
+- **Session secret is now read from `ASTRO_BLOCKS_JWT_SECRET`.** Earlier releases read only
+  `CMS_JWT_SECRET` while the documentation specified `ASTRO_BLOCKS_JWT_SECRET`, so deployments
+  that followed the docs were running on the built-in fallback. `CMS_JWT_SECRET` is still accepted
+  as a deprecated legacy alias (with a warning) and will be removed in a future release.
+
+### Changed
+
+- **Action required for production:** set `ASTRO_BLOCKS_JWT_SECRET` to a strong random value.
+  Without it, the admin login is disabled (returns `503`) in production builds.
+
+### Documentation
+
+- Corrected the admin authentication docs in `README.md` and `AGENTS.consumer.md`: the admin
+  account is created on **first login** (there are no `ASTRO_BLOCKS_ADMIN_USER` /
+  `ASTRO_BLOCKS_ADMIN_PASSWORD` variables — they were never read by the code), and the session
+  token is returned in the login response and sent as an `Authorization: Bearer` header rather
+  than an `httpOnly` cookie.
+
 ## [3.3.2] - 2026-07-02
 
 ### Title

--- a/README.md
+++ b/README.md
@@ -142,23 +142,19 @@ yarn add @astroblocks/astro-blocks @astrojs/node
 
 ## Environment Setup
 
-The admin UI at `/cms` uses JWT-based sessions. You **must** set all three variables below in your server environment for admin login to work — **without them the admin login will not function**.
+The admin UI at `/cms` uses stateless JWT sessions. The admin account is created on **first login** — there are no admin username/password variables to configure.
 
 | Variable | Required | Description |
 | --- | --- | --- |
-| `ASTRO_BLOCKS_JWT_SECRET` | Yes | Secret used to sign and verify JWT session tokens. Use a long random string (32+ characters). Rotating it invalidates all sessions. |
-| `ASTRO_BLOCKS_ADMIN_USER` | Yes | Email address for the initial admin account. |
-| `ASTRO_BLOCKS_ADMIN_PASSWORD` | Yes | Password for the initial admin account. |
+| `ASTRO_BLOCKS_JWT_SECRET` | Yes (production) | Secret used to sign and verify JWT session tokens. Use a long random string (32+ characters). Rotating it invalidates all sessions. **Required in production** — without it the admin login returns `503` and no session is issued. Legacy alias `CMS_JWT_SECRET` is accepted but deprecated. |
 
 Example `.env` (local development only — **never commit real values**):
 
 ```sh
 ASTRO_BLOCKS_JWT_SECRET=your-long-random-secret-here
-ASTRO_BLOCKS_ADMIN_USER=admin@example.com
-ASTRO_BLOCKS_ADMIN_PASSWORD=changeme
 ```
 
-> Set these as environment/runtime variables on your deployment platform — not in committed files. For the complete list of optional variables (upload and import size limits, project-root override), see the [Environment Variables Reference](./AGENTS.consumer.md#environment-variables-reference-complete-list) in `AGENTS.consumer.md`.
+> Set this as an environment/runtime variable on your deployment platform — not in committed files. The **first person to log in at `/cms` creates the owner account**, so complete that initial login yourself over a trusted connection right after deploying. For the complete list of optional variables (upload and import size limits, project-root override), see the [Environment Variables Reference](./AGENTS.consumer.md#environment-variables-reference-complete-list) in `AGENTS.consumer.md`.
 
 ## Quick Start
 
@@ -668,7 +664,7 @@ The `.astro` component then stays a pure component (it does not export a schema)
 
 ### The admin login does not work
 
-The admin login requires the three environment variables from [Environment Setup](#environment-setup) — `ASTRO_BLOCKS_JWT_SECRET`, `ASTRO_BLOCKS_ADMIN_USER`, `ASTRO_BLOCKS_ADMIN_PASSWORD`. If any is missing from the server environment, login cannot succeed. Confirm they are set at runtime (in your deployment platform, not only in a local `.env`), and that they are not committed to git.
+The admin login requires `ASTRO_BLOCKS_JWT_SECRET` from [Environment Setup](#environment-setup) to be set in the server environment. In production, a missing secret makes the login endpoint return `503` (no session is issued) — confirm it is set at runtime (in your deployment platform, not only in a local `.env`) and not committed to git. The admin account is created on first login; there are no admin username/password variables.
 
 ### Content changes do not appear on the public site
 

--- a/api/handlers.ts
+++ b/api/handlers.ts
@@ -85,8 +85,85 @@ export function localizedJsonError(
   return jsonError(message, status, extra);
 }
 
-const JWT_SECRET = new TextEncoder().encode(process.env.CMS_JWT_SECRET || 'cms-jwt-secret-change-me');
+// SECURITY: this constant signs and verifies admin session tokens. When no secret is
+// configured we fall back to a well-known string ONLY to keep local development frictionless.
+// Signing/verifying with a public constant in production would let anyone forge an owner
+// token, so production refuses it (see classifyJwtSecret / jwtSecretMisconfigured below).
+const INSECURE_JWT_FALLBACK = 'cms-jwt-secret-change-me';
+
+export type JwtSecretStatus = 'configured' | 'insecure-dev' | 'insecure-production';
+
+/**
+ * Pure classification of the JWT secret configuration. Exported for unit testing.
+ * - 'configured': a non-empty secret is present — safe in any environment.
+ * - 'insecure-production': no secret AND running in production — auth must fail closed.
+ * - 'insecure-dev': no secret outside production — tolerated with a loud warning.
+ */
+export function classifyJwtSecret(
+  rawSecret: string | undefined,
+  isProduction: boolean
+): JwtSecretStatus {
+  if (rawSecret && rawSecret.trim()) return 'configured';
+  return isProduction ? 'insecure-production' : 'insecure-dev';
+}
+
+/**
+ * Whether the server is running as a production build. Uses Astro/Vite's build-time
+ * `import.meta.env.PROD` (baked into the production SSR bundle) as the primary signal so the
+ * guard fires even when the host does not set NODE_ENV; NODE_ENV==='production' is a secondary
+ * signal for platforms that do. Outside a Vite build (e.g. unit tests importing raw dist),
+ * `import.meta.env` is undefined and only NODE_ENV applies.
+ */
+function isProductionRuntime(): boolean {
+  const viteEnv = (import.meta as unknown as { env?: { PROD?: boolean } }).env;
+  return viteEnv?.PROD === true || process.env.NODE_ENV === 'production';
+}
+
+/**
+ * Resolve the configured JWT secret from the environment. The documented, prefix-consistent
+ * variable is ASTRO_BLOCKS_JWT_SECRET; CMS_JWT_SECRET is accepted as a deprecated legacy alias
+ * (earlier releases read only that name while the docs specified the ASTRO_BLOCKS_ one, so
+ * deployments that followed the docs were silently running on the built-in fallback).
+ */
+function resolveConfiguredJwtSecret(): string | undefined {
+  const primary = process.env.ASTRO_BLOCKS_JWT_SECRET?.trim();
+  if (primary) return primary;
+  const legacy = process.env.CMS_JWT_SECRET?.trim();
+  if (legacy) {
+    console.warn(
+      '[astro-blocks] CMS_JWT_SECRET is a deprecated alias and will be removed in a future release. ' +
+        'Rename it to ASTRO_BLOCKS_JWT_SECRET.'
+    );
+    return legacy;
+  }
+  return undefined;
+}
+
+const CONFIGURED_JWT_SECRET = resolveConfiguredJwtSecret();
+const JWT_SECRET_STATUS = classifyJwtSecret(CONFIGURED_JWT_SECRET, isProductionRuntime());
+const JWT_SECRET = new TextEncoder().encode(CONFIGURED_JWT_SECRET || INSECURE_JWT_FALLBACK);
 const JWT_EXPIRY = '7d';
+
+if (JWT_SECRET_STATUS === 'insecure-production') {
+  console.warn(
+    '[astro-blocks] SECURITY: ASTRO_BLOCKS_JWT_SECRET is not set. Admin authentication is DISABLED — ' +
+      'the server refuses to sign or verify tokens with the built-in fallback secret in production. ' +
+      'Set ASTRO_BLOCKS_JWT_SECRET to a strong random value and restart.'
+  );
+} else if (JWT_SECRET_STATUS === 'insecure-dev') {
+  console.warn(
+    '[astro-blocks] SECURITY WARNING: ASTRO_BLOCKS_JWT_SECRET is not set; using an insecure built-in fallback. ' +
+      'This is tolerated in development but MUST be set before deploying — otherwise anyone can forge an owner session token.'
+  );
+}
+
+/**
+ * True only when the secret is the insecure fallback AND we are in production. In that
+ * state every auth operation fails closed rather than trusting a publicly-known key.
+ */
+function jwtSecretMisconfigured(): boolean {
+  return JWT_SECRET_STATUS === 'insecure-production';
+}
 type AstroCache = APIContext['cache'];
 type HandlerContext = { cache?: AstroCache | null };
 const CONFIG_KEY_REGEX = /^[A-Za-z][A-Za-z0-9_.-]*$/;
@@ -687,6 +764,9 @@ async function createToken(user: Pick<User, 'id' | 'email' | 'role'>): Promise<s
 }
 
 export async function getAuth(request: Request): Promise<AuthResult | null> {
+  // Fail closed: never trust a token verified with the public fallback secret in production.
+  if (jwtSecretMisconfigured()) return null;
+
   const token =
     request.headers.get('authorization')?.replace(/^Bearer\s+/i, '')?.trim() ||
     request.headers.get('x-cms-token') ||
@@ -715,6 +795,11 @@ export function requireOwner(user?: AuthUser | null, request?: Request): Respons
 }
 
 export async function handleLogin(request: Request): Promise<Response> {
+  // Fail closed: refuse to issue tokens signed with the public fallback secret in production.
+  if (jwtSecretMisconfigured()) {
+    return jsonError('Authentication is unavailable: the ASTRO_BLOCKS_JWT_SECRET environment variable must be set.', 503);
+  }
+
   const { data: body, error } = await parseJsonBody<Record<string, unknown>>(request);
   if (error || !body) return error as Response;
 

--- a/meta/features.json
+++ b/meta/features.json
@@ -144,11 +144,11 @@
     {
       "id": "users-and-auth",
       "title": "Users and authentication",
-      "summary": "Session-based CMS authentication with owner and user roles.",
+      "summary": "Session-based CMS authentication with owner and user roles. Requires ASTRO_BLOCKS_JWT_SECRET in production; auth fails closed without it.",
       "category": "auth",
       "status": "alpha",
       "sinceVersion": "0.3.0",
-      "updatedIn": "0.3.0",
+      "updatedIn": "3.4.0",
       "docsPath": "#cms-routes"
     },
     {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -49,6 +49,8 @@ export default defineConfig({
       HOST: '127.0.0.1',
       PORT: '4321',
       ASTRO_BLOCKS_PROJECT_ROOT: path.join(__dirname, '.e2e-data'),
+      // The playground runs a production Astro build, so auth fails closed without a secret.
+      ASTRO_BLOCKS_JWT_SECRET: 'e2e-test-secret-not-for-production',
       NODE_V8_COVERAGE: path.join(__dirname, '.coverage-v8'),
     },
   },

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -263,6 +263,16 @@ export default function astroBlocks(options: AstroBlocksOptions): AstroIntegrati
           throw new Error('[astro-blocks] options.blocks is required and must be an array (e.g. blocks: [heroSchema, ...]).');
         }
 
+        const jwtSecretEnv =
+          process.env.ASTRO_BLOCKS_JWT_SECRET?.trim() || process.env.CMS_JWT_SECRET?.trim();
+        if (!jwtSecretEnv) {
+          console.warn(
+            '[astro-blocks] ASTRO_BLOCKS_JWT_SECRET is not set. Set it to a strong random value before deploying — ' +
+            'in production the admin panel refuses to authenticate with the built-in fallback secret, and ' +
+            'without it anyone could forge an owner session token.'
+          );
+        }
+
         if (Array.isArray(resolvedOptions.globalBlocks)) {
           validateGlobalBlocks(resolvedOptions.globalBlocks);
         }

--- a/tests/jwt-secret-hardening.test.js
+++ b/tests/jwt-secret-hardening.test.js
@@ -1,0 +1,117 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { classifyJwtSecret } from '../dist/api/handlers.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+// Run `fn` with a throwaway project root so a bootstrapped owner account is written to an
+// isolated temp dir (not the repo's ./data), then always clean it up.
+function withTempRoot(fn) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'astro-blocks-jwt-'));
+  try {
+    fn(root);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+// ─── Pure decision logic ──────────────────────────────────────────────────────
+
+test('classifyJwtSecret: a non-empty secret is accepted in any environment', () => {
+  assert.equal(classifyJwtSecret('a-real-secret', true), 'configured');
+  assert.equal(classifyJwtSecret('a-real-secret', false), 'configured');
+  assert.equal(classifyJwtSecret('  spaced-secret  ', true), 'configured');
+});
+
+test('classifyJwtSecret: a missing secret in production is a security misconfiguration', () => {
+  assert.equal(classifyJwtSecret(undefined, true), 'insecure-production');
+  assert.equal(classifyJwtSecret('', true), 'insecure-production');
+  assert.equal(classifyJwtSecret('   ', true), 'insecure-production');
+});
+
+test('classifyJwtSecret: a missing secret outside production is tolerated (dev)', () => {
+  assert.equal(classifyJwtSecret(undefined, false), 'insecure-dev');
+  assert.equal(classifyJwtSecret('', false), 'insecure-dev');
+});
+
+// ─── Behavioral: the auth layer fails closed in production without a secret ─────
+// The module resolves the secret once at load time, so these run in child
+// processes with the environment set before `../dist/api/handlers.js` is imported.
+
+function runInChildProcess(source, env) {
+  return execFileSync(process.execPath, ['--input-type=module', '-e', source], {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    stdio: 'pipe',
+  });
+}
+
+test('production without a JWT secret: handleLogin returns 503 and getAuth returns null', () => {
+  const source = `
+    import { handleLogin, getAuth } from './dist/api/handlers.js';
+    const login = await handleLogin(new Request('http://x/login', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'owner@example.com', password: 'password123' }),
+    }));
+    if (login.status !== 503) { console.error('expected 503, got', login.status); process.exit(2); }
+    const auth = await getAuth(new Request('http://x', { headers: { authorization: 'Bearer anything' } }));
+    if (auth !== null) { console.error('expected null auth'); process.exit(3); }
+    process.exit(0);
+  `;
+  // Neither env var set — a non-zero child exit surfaces as a thrown error here.
+  runInChildProcess(source, { NODE_ENV: 'production', ASTRO_BLOCKS_JWT_SECRET: '', CMS_JWT_SECRET: '' });
+});
+
+test('production WITH ASTRO_BLOCKS_JWT_SECRET: first login bootstraps the owner (200)', () => {
+  withTempRoot((root) => {
+    const source = `
+      import { handleLogin } from './dist/api/handlers.js';
+      // Isolated project root — first login creates the owner and returns 200.
+      const res = await handleLogin(new Request('http://x/login', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email: 'owner@example.com', password: 'password123' }),
+      }));
+      if (res.status !== 200) { console.error('expected 200, got', res.status); process.exit(2); }
+      process.exit(0);
+    `;
+    runInChildProcess(source, {
+      NODE_ENV: 'production',
+      ASTRO_BLOCKS_JWT_SECRET: 'a-strong-test-secret',
+      ASTRO_BLOCKS_PROJECT_ROOT: root,
+    });
+  });
+});
+
+test('production with the legacy CMS_JWT_SECRET alias also authenticates (200)', () => {
+  withTempRoot((root) => {
+    const source = `
+      import { handleLogin } from './dist/api/handlers.js';
+      const res = await handleLogin(new Request('http://x/login', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email: 'owner@example.com', password: 'password123' }),
+      }));
+      if (res.status !== 200) { console.error('legacy alias did not authenticate, got', res.status); process.exit(2); }
+      process.exit(0);
+    `;
+    runInChildProcess(source, {
+      NODE_ENV: 'production',
+      ASTRO_BLOCKS_JWT_SECRET: '',
+      CMS_JWT_SECRET: 'legacy-secret',
+      ASTRO_BLOCKS_PROJECT_ROOT: root,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The admin session JWT secret fell back to a hardcoded constant shipped in the package. Worse, the code read the secret from `CMS_JWT_SECRET` while all documentation specified `ASTRO_BLOCKS_JWT_SECRET` — so any deployment that followed the docs was signing and verifying tokens with the public fallback value, allowing an **owner session token to be forged**.

## Changes

- **Env var reconciled:** the secret is now read from `ASTRO_BLOCKS_JWT_SECRET` (documented, consistent with every other `ASTRO_BLOCKS_` variable). `CMS_JWT_SECRET` is accepted as a **deprecated legacy alias** (with a warning) so nobody who set it by reading the source breaks.
- **Fail closed in production:** without a configured secret, `getAuth()` returns `null` and `handleLogin()` returns `503` — no token is ever signed or verified with the fallback. The public site keeps rendering (no `throw` at module load).
- **Robust production detection:** uses Astro's build-time `import.meta.env.PROD` (baked into the SSR bundle regardless of `NODE_ENV`), with `NODE_ENV=production` as a secondary signal. Verified empirically that a plain `astro build` bakes `PROD: true` even when the host never sets `NODE_ENV`.
- **Dev is unaffected:** the built-in fallback is tolerated with a loud warning so local iteration needs no setup. `classifyJwtSecret()` is a pure, unit-tested decision.
- **Docs corrected** (`README.md`, `AGENTS.consumer.md`): the admin account is created on **first login**; there are no `ASTRO_BLOCKS_ADMIN_USER` / `ASTRO_BLOCKS_ADMIN_PASSWORD` variables (they were never read by the code); the session token is a `Bearer` header, not an `httpOnly` cookie.
- **e2e:** the production playground server now sets `ASTRO_BLOCKS_JWT_SECRET`.

## Action required for consumers

Production deployments must set `ASTRO_BLOCKS_JWT_SECRET`. Without it, admin login is disabled (`503`) in production builds.

## Testing

- `tests/jwt-secret-hardening.test.js`: pure decision cases + isolated child-process behavioral tests (503 without a secret, 200 with the primary var, 200 with the legacy alias). Temp project root — no repo/disk pollution.
- Full suite: **949 passing**. Typecheck, build, and features manifest all green.
- Independent fresh-context security review: no blocking findings; confirmed no code path mints or verifies a JWT while bypassing the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)