### PR TITLE
ci: run gates on pull requests and add Playwright e2e job (P0-2, P0-3)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -41,3 +44,62 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    needs: validate
+    timeout-minutes: 20
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - name: Build playground
+        run: npm run build:playground
+
+      - name: Run e2e tests
+        run: npm run e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+
+      - name: Upload test traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results/
+          retention-days: 7

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,8 +38,7 @@ export default defineConfig({
   },
 
   webServer: {
-    command:
-      'cd /Users/gnaue/GIT/PERSONAL/astro-blocks/playgrounds/basic && node ./dist/server/entry.mjs',
+    command: `cd ${path.join(__dirname, 'playgrounds', 'basic')} && node ./dist/server/entry.mjs`,
     url: 'http://127.0.0.1:4321/cms',
     reuseExistingServer: !process.env.CI,
     timeout: 30_000,


### PR DESCRIPTION
## Why

Two coupled **P0** CI gaps, both closed here in one cohesive change.

- **#33 [P0-2]** — `ci-main.yml` only triggered on `push: [main]`, so `typecheck`, `test` and `features:validate` ran **after** merge. A broken PR could land green and break `main`.
- **#34 [P0-3]** — `playwright.config.ts` pinned the webServer command to an absolute machine path (`/Users/gnaue/...`), so e2e ran nowhere but one laptop and never in CI. `block-form.js` / `common.js` are excluded from unit coverage (`scripts/coverage.mjs`) and only exercised by e2e — meaning they had **zero CI coverage**.

## What changed

- **`.github/workflows/ci-main.yml`**
  - Added `pull_request: branches: [main]` to the trigger (kept `push: [main]` so direct pushes stay verified).
  - Added a fail-fast `e2e` job (`needs: validate`, `timeout-minutes: 20`, `permissions: contents: read`): caches the Playwright chromium browser, `build:playground`, `npm run e2e`, uploads the report (`if: always()`) and traces (`if: failure()`).
  - `validate` job unchanged; `release-tag.yml` untouched.
- **`playwright.config.ts`** — webServer command is now `__dirname`-relative via `path.join(__dirname, 'playgrounds', 'basic')`.

## Safety

- No CI secrets required — e2e uses the fixed non-production test JWT already in `playwright.config.ts`.
- `pull_request` (not `pull_request_target`) + `permissions: contents: read` keep fork PRs safe.

## Verification

- `npm run build:playground && npm run e2e` → **6/6 passing** locally on the portable path.
- `grep -rn "/Users/gnaue"` over tracked source → **0 matches**.
- Trigger + gating behavior is proven by **this PR's own CI run** (validate → e2e).

Delivered via SDD (proposal → spec → design → tasks → apply → verify: PASS).

Closes #33
Closes #34