### PR TITLE
feat(plugin): require an SSR adapter with a config-time guard

### DIFF
--- a/AGENTS.consumer.md
+++ b/AGENTS.consumer.md
@@ -32,7 +32,9 @@ Astro 6.0 or higher is required. The integration registers Astro hooks via `astr
 
 ### Required Astro adapter (SSR mode)
 
-AstroBlocks runs in SSR mode by default. You must configure an Astro SSR adapter (`@astrojs/node`, `@astrojs/vercel`, etc.) in your `astro.config.mjs`. The only exception is if you set `publicRendering: 'static'` for all public pages — but admin routes still require SSR.
+AstroBlocks runs in SSR mode by default. You must configure an Astro SSR adapter (`@astrojs/node`, `@astrojs/vercel`, etc.) in your `astro.config.mjs`. The only exception is if you set `publicRendering: 'static'` for all public pages — but admin routes still require SSR, so an adapter is always required.
+
+The integration enforces this: if no adapter is configured, `astro build` fails fast with an actionable `[astro-blocks]` error instead of a cryptic Astro error. Under `astro dev` it logs a warning (dev renders on demand without an adapter) so the local workflow keeps working while still surfacing the problem.
 
 ---
 

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -237,13 +237,53 @@ export function validateFileProps(
   }
 }
 
+/**
+ * Guard the hard requirement that the consumer project has an SSR adapter configured.
+ *
+ * The CMS admin panel and its API routes are injected with `prerender = false`, so they
+ * render on demand and cannot be served by a purely static build. Any adapter satisfies
+ * this (@astrojs/node, @astrojs/vercel, @astrojs/netlify, @astrojs/cloudflare, …) — the
+ * integration is deliberately adapter-agnostic, which is why this is a config-time guard
+ * and not a `peerDependency` on a specific adapter package.
+ *
+ * `astro dev` renders on-demand routes without an adapter, so a missing adapter is only a
+ * hard error at build time; in dev we warn instead of throwing so the local workflow keeps
+ * working while still surfacing the problem early.
+ *
+ * Must run from `astro:config:done` (not `config:setup`): while a directly-declared
+ * `adapter:` is already present during `config:setup`, an adapter injected dynamically by
+ * another integration's `config:setup` (via `updateConfig`) may not be — and integration
+ * ordering is not guaranteed. `config:done` sees the final resolved config, avoiding that
+ * false negative. Note `config:done` does not expose `command`, so it is captured from
+ * `config:setup` into a closure.
+ */
+export function assertAdapterConfigured(
+  command: 'dev' | 'build' | 'preview' | 'sync',
+  adapter: unknown
+): void {
+  if (adapter) return;
+
+  const message =
+    '[astro-blocks] No SSR adapter is configured. The CMS admin panel and API routes render ' +
+    'on demand and require an adapter (e.g. @astrojs/node, @astrojs/vercel, @astrojs/netlify, ' +
+    '@astrojs/cloudflare). Add one via the `adapter` option in astro.config.';
+
+  if (command === 'build') {
+    throw new Error(`${message} Aborting build.`);
+  }
+
+  console.warn(`${message} \`astro build\` will fail until an adapter is configured.`);
+}
+
 export default function astroBlocks(options: AstroBlocksOptions): AstroIntegration {
   const resolvedOptions = resolveOptions(options);
+  let astroCommand: 'dev' | 'build' | 'preview' | 'sync' = 'dev';
 
   return {
     name: 'astro-blocks',
     hooks: {
-      'astro:config:setup': async ({ config, injectRoute }) => {
+      'astro:config:setup': async ({ config, command, injectRoute }) => {
+        astroCommand = command;
         const projectRoot = getProjectRoot(config);
         process.env.ASTRO_BLOCKS_PROJECT_ROOT = projectRoot;
 
@@ -367,6 +407,9 @@ export default function astroBlocks(options: AstroBlocksOptions): AstroIntegrati
           pattern: '/[...slug]',
           entrypoint: resolveCms(resolvedOptions.publicRendering === 'static' ? 'page-static.astro' : 'page.astro'),
         });
+      },
+      'astro:config:done': ({ config }) => {
+        assertAdapterConfigured(astroCommand, config.adapter);
       },
     },
   };

--- a/tests/plugin-adapter-guard.test.js
+++ b/tests/plugin-adapter-guard.test.js
@@ -1,0 +1,138 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import astroBlocks, { assertAdapterConfigured } from '../dist/plugin/index.js';
+
+const anAdapter = { name: '@astrojs/node' };
+
+// Capture console.warn output for the duration of `fn`.
+function captureWarnings(fn) {
+  const original = console.warn;
+  const warnings = [];
+  console.warn = (msg) => warnings.push(msg);
+  try {
+    fn();
+  } finally {
+    console.warn = original;
+  }
+  return warnings;
+}
+
+// ─── Pure guard: assertAdapterConfigured ──────────────────────────────────────
+
+test('build with no adapter throws an actionable error', () => {
+  assert.throws(
+    () => assertAdapterConfigured('build', undefined),
+    (err) => {
+      assert.ok(err instanceof Error);
+      assert.match(err.message, /astro-blocks/);
+      assert.match(err.message, /adapter/i);
+      assert.match(err.message, /Aborting build/);
+      return true;
+    }
+  );
+});
+
+test('build with an adapter present does not throw', () => {
+  assert.doesNotThrow(() => assertAdapterConfigured('build', anAdapter));
+});
+
+// Non-build commands warn (never throw) when the adapter is missing, so local
+// workflows like `astro dev` / `astro sync` keep working.
+for (const command of ['dev', 'preview', 'sync']) {
+  test(`${command} with no adapter warns but does not throw`, () => {
+    let warnings;
+    assert.doesNotThrow(() => {
+      warnings = captureWarnings(() => assertAdapterConfigured(command, undefined));
+    });
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /astro-blocks/);
+    assert.match(warnings[0], /astro build.*will fail/);
+    // The warning must not hard-code `astro dev`, which is misleading for sync/preview.
+    assert.doesNotMatch(warnings[0], /works under `astro dev`/);
+  });
+
+  test(`${command} with an adapter present is silent`, () => {
+    const warnings = captureWarnings(() => assertAdapterConfigured(command, anAdapter));
+    assert.equal(warnings.length, 0);
+  });
+}
+
+// ─── End-to-end hook wiring: config:setup captures command → config:done guards ──
+// Exercises the real closure (astroCommand) rather than the pure function alone.
+
+async function withTempProject(fn) {
+  const previousRoot = process.env.ASTRO_BLOCKS_PROJECT_ROOT;
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'astro-blocks-adapter-guard-'));
+  process.env.ASTRO_BLOCKS_PROJECT_ROOT = tempRoot;
+  try {
+    await fn(tempRoot);
+  } finally {
+    if (previousRoot === undefined) {
+      delete process.env.ASTRO_BLOCKS_PROJECT_ROOT;
+    } else {
+      process.env.ASTRO_BLOCKS_PROJECT_ROOT = previousRoot;
+    }
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+async function runSetup(integration, tempRoot, command) {
+  const configStub = {
+    root: tempRoot,
+    vite: { define: {}, resolve: { alias: {} }, server: {}, ssr: {} },
+  };
+  await integration.hooks['astro:config:setup']({
+    config: configStub,
+    command,
+    injectRoute: () => {},
+  });
+}
+
+// Each astroBlocks() call returns a fresh integration with its own `astroCommand` closure.
+
+test('e2e: config:done throws when build ran config:setup with no adapter', async () => {
+  await withTempProject(async (tempRoot) => {
+    const integration = astroBlocks({ blocks: [] });
+    await runSetup(integration, tempRoot, 'build');
+    assert.throws(
+      () => integration.hooks['astro:config:done']({ config: { adapter: undefined } }),
+      /Aborting build/
+    );
+  });
+});
+
+test('e2e: config:done stays silent when build has an adapter', async () => {
+  await withTempProject(async (tempRoot) => {
+    const integration = astroBlocks({ blocks: [] });
+    await runSetup(integration, tempRoot, 'build');
+    const warnings = captureWarnings(() =>
+      assert.doesNotThrow(() =>
+        integration.hooks['astro:config:done']({ config: { adapter: anAdapter } })
+      )
+    );
+    assert.equal(warnings.length, 0);
+  });
+});
+
+test('e2e: config:done warns (no throw) when dev ran config:setup with no adapter', async () => {
+  await withTempProject(async (tempRoot) => {
+    const integration = astroBlocks({ blocks: [] });
+    await runSetup(integration, tempRoot, 'dev');
+    const warnings = captureWarnings(() =>
+      assert.doesNotThrow(() =>
+        integration.hooks['astro:config:done']({ config: { adapter: undefined } })
+      )
+    );
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /astro-blocks/);
+  });
+});


### PR DESCRIPTION
Closes #54.

## What

The CMS admin panel and its API routes are injected with `prerender = false` (admin pages, `/cms/api/[...path]`, `/uploads/[...path]`, sitemap, robots), so they render on demand and cannot be served by a static build without an SSR adapter. Nothing enforced this — a consumer who forgot the adapter hit a cryptic Astro build error far from the real cause.

This adds an **adapter-agnostic**, fail-fast guard:

- New exported `assertAdapterConfigured(command, adapter)` in [plugin/index.ts](../blob/main/plugin/index.ts).
- Wired from a **new `astro:config:done` hook** — the resolved config is where `config.adapter` is reliably populated (an adapter injected by another integration's `config:setup` may not be set yet during ours, and integration ordering is not guaranteed). `config:done` does not expose `command`, so it is captured from `config:setup` into a closure.
- **Throws at `build`** (hard requirement); **warns under `dev`/`preview`/`sync`** so local workflows keep working while still surfacing the problem.

## Why a guard, not a peerDependency

`@astrojs/node` is not a published dependency (it only lives in `playgrounds/basic`); consumers bring their own adapter (Node, Vercel, Netlify, Cloudflare). Adding it to `peerDependencies` would over-constrain and break non-Node deployers, and `peerDependencies` cannot express "any one of N adapters". A config-time guard inspects the resolved config for **any** adapter, which is the correct tool.

## Tests

`tests/plugin-adapter-guard.test.js` — 11 tests:
- Pure guard across the full command × adapter matrix (`build`/`dev`/`preview`/`sync`).
- **End-to-end wiring** tests that build the integration, run `astro:config:setup` (to capture `command`), then invoke `astro:config:done` — exercising the real `astroCommand` closure, not just the pure function.

Full suite: 977/977 pass, typecheck clean, features manifest valid.

## Docs

`AGENTS.consumer.md` documents the fail-fast behavior. The adapter requirement itself was already documented (README §Installation/§Deployment).

## Review

A fresh-context adversarial review verified the hook choice and closure approach against Astro's compiled internals (no functional bugs); its two test-coverage findings (`sync` coverage + end-to-end wiring) and message/docstring nitpicks are all addressed in this PR.

## Independent of Astro 7

This works on Astro 6 today and does not depend on the Astro 7 migration (#55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)