### PR TITLE
feat(api): add pure route matcher foundation (route-table-auth-gating PR1/3)

### DIFF
--- a/api/route-matcher.ts
+++ b/api/route-matcher.ts
@@ -1,0 +1,115 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * api/route-matcher.ts — pure route-table mechanics for the CMS API dispatcher.
+ *
+ * Phase 1 (PR1) of route-table-auth-gating: types + `defineRoute` + the
+ * hand-rolled `matchRoute`/`matchPattern` matcher. Zero runtime dependency,
+ * zero handler coupling — the only import from `handlers.js` is `import type`,
+ * which is erased at compile time (verbatimModuleSyntax). This module never
+ * imports the route table; `matchRoute` receives the table as a parameter
+ * (dependency injection) so PR2/PR3 can build `api/route-table.ts` and
+ * `routes/api/catchall.ts` on top without ever creating a circular import.
+ *
+ * See design ADR-1 (module location), ADR-2 (closed auth union), ADR-3
+ * (typed handler/auth contract), and ADR-4 (hand-rolled arity-exact,
+ * declaration-order, first-match-wins matching).
+ */
+
+import type { APIContext } from 'astro';
+import type { getAuth } from './handlers.js';
+
+/** HTTP methods dispatched by the CMS API router. */
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+/**
+ * Closed authorization tiers (ADR-2). No role hierarchy, no speculative
+ * roles — extension cost is one literal here plus one branch in `dispatch`.
+ */
+export type AuthLevel = 'public' | 'user' | 'owner';
+
+/** The authenticated user shape resolved by `handlers.getAuth`. */
+export type AuthUser = NonNullable<Awaited<ReturnType<typeof getAuth>>>['user'];
+
+/**
+ * Binds `RouteContext.user` nullability to the route's auth level (ADR-3):
+ * `public` handlers receive `AuthUser | null`; `user`/`owner` handlers are
+ * guaranteed a non-null `AuthUser` by the central dispatcher before they run.
+ */
+export type UserForAuth<A extends AuthLevel> = A extends 'public' ? AuthUser | null : AuthUser;
+
+/** The uniform context every route handler receives, generic over its auth level. */
+export interface RouteContext<A extends AuthLevel = AuthLevel> {
+  request: Request;
+  params: Record<string, string>;
+  cache: APIContext['cache'];
+  user: UserForAuth<A>;
+}
+
+export type RouteHandler<A extends AuthLevel> = (ctx: RouteContext<A>) => Response | Promise<Response>;
+
+/** A single declared route: method + seg-relative pattern + auth level + handler. */
+export interface RouteDescriptor<A extends AuthLevel = AuthLevel> {
+  method: HttpMethod;
+  pattern: string;
+  auth: A;
+  handler: RouteHandler<A>;
+}
+
+/**
+ * Captures the literal `A` per call site so the handler is type-checked
+ * against `RouteContext<A>`, then erases to the widened union for storage
+ * in a homogeneous `RouteDescriptor[]` table. A bare object literal (without
+ * this helper) would widen `auth` to the `AuthLevel` union and collapse the
+ * per-entry nullability guarantee from ADR-3.
+ */
+export function defineRoute<A extends AuthLevel>(descriptor: RouteDescriptor<A>): RouteDescriptor {
+  return descriptor as RouteDescriptor;
+}
+
+/** Result of a successful match: the matched descriptor plus extracted `:param` values. */
+export interface RouteMatch {
+  descriptor: RouteDescriptor;
+  params: Record<string, string>;
+}
+
+/**
+ * Scans `table` in declaration order and returns the first descriptor whose
+ * `method` and `pattern` match — mirroring the original if-chain's first-match
+ * semantics exactly (ADR-4). Returns `null` when nothing matches.
+ */
+export function matchRoute(method: HttpMethod, segments: string[], table: RouteDescriptor[]): RouteMatch | null {
+  for (const descriptor of table) {
+    if (descriptor.method !== method) continue;
+    const params = matchPattern(descriptor.pattern, segments);
+    if (params) return { descriptor, params };
+  }
+  return null;
+}
+
+/**
+ * Matches a single seg-relative pattern (e.g. `'media/:id/usage'`) against a
+ * segment array. Exact arity (same segment count) is required — this mirrors
+ * the `seg.length` checks in the original if-chain dispatcher. `:name`
+ * segments capture the corresponding value unless it is empty; a literal
+ * segment must match exactly.
+ */
+function matchPattern(pattern: string, segments: string[]): Record<string, string> | null {
+  const parts = pattern.split('/').filter(Boolean);
+  if (parts.length !== segments.length) return null;
+
+  const params: Record<string, string> = {};
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part.startsWith(':')) {
+      if (!segments[i]) return null;
+      params[part.slice(1)] = segments[i];
+    } else if (part !== segments[i]) {
+      return null;
+    }
+  }
+  return params;
+}

--- a/tests/route-matcher.test.js
+++ b/tests/route-matcher.test.js
@@ -1,0 +1,185 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * route-matcher.test.js — Phase 1 (PR1) of route-table-auth-gating.
+ *
+ * Pure unit tests for `api/route-matcher.ts`: `matchRoute` + `defineRoute`.
+ * No handlers, no I/O, no HTTP — fixture route tables only. This is the
+ * foundation module other phases (PR2/PR3) build on; it must prove
+ * exact-arity matching, `:param` extraction, and declaration-order
+ * first-match semantics BEFORE the real 43-entry table exists.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { defineRoute, matchRoute } from '../dist/api/route-matcher.js';
+
+// Fixture handler — never invoked by these tests, only referenced for typing/identity.
+const noopHandler = () => new Response(null, { status: 204 });
+
+// ─── Exact static match ─────────────────────────────────────────────────────
+
+test('matchRoute: exact static pattern matches identical segments', () => {
+  const routes = [defineRoute({ method: 'GET', pattern: 'pages', auth: 'user', handler: noopHandler })];
+
+  const match = matchRoute('GET', ['pages'], routes);
+
+  assert.ok(match);
+  assert.equal(match.descriptor.pattern, 'pages');
+  assert.deepEqual(match.params, {});
+});
+
+// ─── Arity-exact rejection ──────────────────────────────────────────────────
+
+test('matchRoute: arity mismatch (extra segment) never matches', () => {
+  const routes = [defineRoute({ method: 'GET', pattern: 'pages', auth: 'user', handler: noopHandler })];
+
+  assert.equal(matchRoute('GET', ['pages', 'extra'], routes), null);
+});
+
+test('matchRoute: arity mismatch (missing segment) never matches', () => {
+  const routes = [defineRoute({ method: 'GET', pattern: 'media/:id/usage', auth: 'user', handler: noopHandler })];
+
+  assert.equal(matchRoute('GET', ['media', '123'], routes), null);
+});
+
+// ─── Literal mismatch ───────────────────────────────────────────────────────
+
+test('matchRoute: literal segment mismatch never matches', () => {
+  const routes = [defineRoute({ method: 'GET', pattern: 'pages', auth: 'user', handler: noopHandler })];
+
+  assert.equal(matchRoute('GET', ['menus'], routes), null);
+});
+
+// ─── Dynamic :param extraction ──────────────────────────────────────────────
+
+test('matchRoute: single :param captures the segment value', () => {
+  const routes = [defineRoute({ method: 'PUT', pattern: 'languages/:id', auth: 'owner', handler: noopHandler })];
+
+  const match = matchRoute('PUT', ['languages', 'es'], routes);
+
+  assert.ok(match);
+  assert.deepEqual(match.params, { id: 'es' });
+});
+
+test('matchRoute: nested :param mid-pattern captures correctly (media/:id/usage)', () => {
+  const routes = [defineRoute({ method: 'GET', pattern: 'media/:id/usage', auth: 'user', handler: noopHandler })];
+
+  const match = matchRoute('GET', ['media', 'abc-123', 'usage'], routes);
+
+  assert.ok(match);
+  assert.deepEqual(match.params, { id: 'abc-123' });
+});
+
+test('matchRoute: empty-segment never captures a :param (no match)', () => {
+  const routes = [defineRoute({ method: 'GET', pattern: 'media/:id/usage', auth: 'user', handler: noopHandler })];
+
+  assert.equal(matchRoute('GET', ['media', '', 'usage'], routes), null);
+});
+
+test('matchRoute: multiple :params in one pattern each capture independently', () => {
+  const routes = [defineRoute({ method: 'GET', pattern: 'a/:x/:y', auth: 'user', handler: noopHandler })];
+
+  const match = matchRoute('GET', ['a', '1', '2'], routes);
+
+  assert.ok(match);
+  assert.deepEqual(match.params, { x: '1', y: '2' });
+});
+
+test('matchRoute: leading :param (first segment) captures correctly', () => {
+  const routes = [defineRoute({ method: 'GET', pattern: ':id', auth: 'user', handler: noopHandler })];
+
+  const match = matchRoute('GET', ['42'], routes);
+
+  assert.ok(match);
+  assert.deepEqual(match.params, { id: '42' });
+});
+
+// ─── Method filter ──────────────────────────────────────────────────────────
+
+test('matchRoute: same pattern, different declared method, does not cross-match', () => {
+  const routes = [defineRoute({ method: 'GET', pattern: 'languages/:id', auth: 'owner', handler: noopHandler })];
+
+  assert.equal(matchRoute('DELETE', ['languages', 'es'], routes), null);
+});
+
+test('matchRoute: method filter still returns the correct entry when methods differ', () => {
+  const routes = [
+    defineRoute({ method: 'GET', pattern: 'languages/:id', auth: 'user', handler: noopHandler }),
+    defineRoute({ method: 'DELETE', pattern: 'languages/:id', auth: 'owner', handler: noopHandler }),
+  ];
+
+  const match = matchRoute('DELETE', ['languages', 'es'], routes);
+
+  assert.ok(match);
+  assert.equal(match.descriptor.auth, 'owner');
+});
+
+// ─── Declaration-order, first-match-wins (ADR-4) ────────────────────────────
+
+test('matchRoute: first declared match wins when two entries could both match', () => {
+  const first = defineRoute({ method: 'GET', pattern: 'media/:id', auth: 'user', handler: noopHandler });
+  const second = defineRoute({ method: 'GET', pattern: 'media/:id', auth: 'owner', handler: noopHandler });
+
+  const match = matchRoute('GET', ['media', '42'], [first, second]);
+
+  assert.ok(match);
+  assert.equal(match.descriptor.auth, 'user');
+});
+
+test('matchRoute: reordering the same two entries changes which one wins (order-dependent, not type-dependent)', () => {
+  const paramFirst = defineRoute({ method: 'GET', pattern: 'media/:id', auth: 'user', handler: noopHandler });
+  const staticSecond = defineRoute({ method: 'GET', pattern: 'media/replace', auth: 'owner', handler: noopHandler });
+
+  // "media/replace" as a concrete segment set would also satisfy "media/:id" — first
+  // declaration wins regardless of static vs. param shape (no special precedence rule).
+  const match = matchRoute('GET', ['media', 'replace'], [paramFirst, staticSecond]);
+
+  assert.ok(match);
+  assert.equal(match.descriptor.pattern, 'media/:id');
+});
+
+// ─── No match → null ─────────────────────────────────────────────────────────
+
+test('matchRoute: unknown path returns null (no matching descriptor at all)', () => {
+  const routes = [defineRoute({ method: 'GET', pattern: 'pages', auth: 'user', handler: noopHandler })];
+
+  assert.equal(matchRoute('GET', ['does-not-exist'], routes), null);
+});
+
+test('matchRoute: empty table always returns null', () => {
+  assert.equal(matchRoute('GET', ['pages'], []), null);
+});
+
+// ─── /cms/api mount-prefix handling (patterns are already seg-relative) ─────
+
+test('matchRoute: patterns are mount-relative — no leading/trailing slash noise affects matching', () => {
+  // getPathSegments() already strips the /cms/api mount prefix (slice(2)) before
+  // segments reach the matcher, so patterns never carry a leading slash. The
+  // matcher must be robust to accidental slashes via split('/').filter(Boolean).
+  const routes = [defineRoute({ method: 'GET', pattern: '/global-blocks/:id/', auth: 'user', handler: noopHandler })];
+
+  const match = matchRoute('GET', ['global-blocks', 'hero'], routes);
+
+  assert.ok(match);
+  assert.deepEqual(match.params, { id: 'hero' });
+});
+
+// ─── declaration order across a mixed table (declaration order = original branch order) ─
+
+test('matchRoute: scans in declaration order and stops at first match, ignoring later matches', () => {
+  const routes = [
+    defineRoute({ method: 'GET', pattern: 'auth/status', auth: 'public', handler: noopHandler }),
+    defineRoute({ method: 'GET', pattern: 'pages', auth: 'user', handler: noopHandler }),
+    defineRoute({ method: 'GET', pattern: 'pages', auth: 'owner', handler: noopHandler }), // unreachable duplicate
+  ];
+
+  const match = matchRoute('GET', ['pages'], routes);
+
+  assert.ok(match);
+  assert.equal(match.descriptor.auth, 'user');
+});


### PR DESCRIPTION
PR **1 of 3** for the `route-table-auth-gating` change — resolves GH #36 (declarative route table) + #37 (owner-only authz correct-by-construction). Tracking issues: #36, #37.

## Scope (intentionally minimal)

This PR adds ONLY the pure foundation — a hand-rolled path matcher + types + unit tests. It does **not** wire anything into the live router yet; that is PR3. "Not used anywhere" is expected.

- `api/route-matcher.ts` (new) — `matchRoute`, `defineRoute`, and the descriptor/auth types (`HttpMethod`, `AuthLevel`, `RouteDescriptor<A>`, `UserForAuth<A>`, `RouteContext<A>`, `RouteHandler<A>`). Zero runtime deps; type-only import from handlers (erased at compile time). Implements design ADR-1/2/3/4.
- `tests/route-matcher.test.js` (new) — 17 unit tests: exact/arity-exact/literal-mismatch, single/nested/multi/leading `:param` extraction, empty-segment rejection, method filtering, declaration-order first-match, catch-all segment contract.

## Why a matcher, not a routing dep

Published npm package — a ~25-line hand-rolled arity-exact matcher avoids bloating the tarball. Matching is declaration-order first-match (no implicit static-over-dynamic precedence, by design — an authoring constraint PR3 honors).

## Delivery

Chained PRs, **stacked-to-main**. PR2 = router-level regression safety-net tests (green against the current if-chain, additive-only). PR3 = the 43-entry route table + `catchall.ts` dispatch rewrite that makes owner-gating impossible to forget.

## Verification

Full suite **994/994 pass**, typecheck clean. Strict TDD followed (tests red → impl → green).

## Review

Fresh-context adversarial review found no algorithm bugs; its one coverage-gap finding (multi-param / leading-param) is already addressed in this PR. Two carry-forward constraints for PR2/PR3 were recorded (static-before-dynamic declaration order; hardcoded verb literals in dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)