### PR TITLE
chore(tooling): adopt Biome linter + formatter (#41) [PR1/3]

### DIFF
--- a/api/handlers.ts
+++ b/api/handlers.ts
@@ -188,7 +188,7 @@ let _allowedFileTypesCache: Set<string> | null = null;
 function getAllowedFileTypes(): Set<string> {
   if (_allowedFileTypesCache !== null) return _allowedFileTypesCache;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // biome-ignore lint/suspicious/noExplicitAny: import.meta.env is untyped at this call site; narrowed immediately below
   const raw: string = ((import.meta as any).env as Record<string, unknown> | undefined)?.ASTRO_BLOCKS_ALLOWED_FILE_TYPES as string ?? '';
   let parsed: string[] | null = null;
   if (typeof raw === 'string' && raw.trim().length > 0) {

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": [
+      "api/**",
+      "plugin/**",
+      "contract/**",
+      "utils/**",
+      "routes/**",
+      "types/**",
+      "components/**",
+      "scripts/**",
+      "tests/**",
+      "e2e/**",
+      "!**/*.astro",
+      "!**/dist"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "astro-blocks": "dist/plugin/cli/index.js"
       },
       "devDependencies": {
+        "@biomejs/biome": "2.5.2",
         "@playwright/test": "^1.60.0",
         "@types/node": "^26.0.1",
         "astro": "^6.4.6",
@@ -184,6 +185,181 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.2.tgz",
+      "integrity": "sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.5.2",
+        "@biomejs/cli-darwin-x64": "2.5.2",
+        "@biomejs/cli-linux-arm64": "2.5.2",
+        "@biomejs/cli-linux-arm64-musl": "2.5.2",
+        "@biomejs/cli-linux-x64": "2.5.2",
+        "@biomejs/cli-linux-x64-musl": "2.5.2",
+        "@biomejs/cli-win32-arm64": "2.5.2",
+        "@biomejs/cli-win32-x64": "2.5.2"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.2.tgz",
+      "integrity": "sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.2.tgz",
+      "integrity": "sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.2.tgz",
+      "integrity": "sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.2.tgz",
+      "integrity": "sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.2.tgz",
+      "integrity": "sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.2.tgz",
+      "integrity": "sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.2.tgz",
+      "integrity": "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.2.tgz",
+      "integrity": "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@capsizecss/unpack": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,11 @@
     "build:watch": "node scripts/build.mjs --watch",
     "features:validate": "node scripts/validate-features.mjs",
     "typecheck": "tsc --noEmit",
+    "lint": "biome lint .",
+    "lint:fix": "biome lint --write .",
+    "format": "biome format --write .",
+    "format:check": "biome format .",
+    "check": "biome ci .",
     "test": "npm run build && node --test tests/*.test.js",
     "coverage": "node scripts/coverage.mjs",
     "coverage:badge": "node scripts/coverage-badge.mjs",
@@ -92,6 +97,7 @@
     "sortablejs": "^1.15.7"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.5.2",
     "@playwright/test": "^1.60.0",
     "@types/node": "^26.0.1",
     "astro": "^6.4.6",

--- a/scripts/coverage.mjs
+++ b/scripts/coverage.mjs
@@ -114,7 +114,6 @@ function main() {
     `${JSON.stringify(summaryOut, null, 2)}\n`
   );
 
-  // eslint-disable-next-line no-console
   console.log(`\nCombined line coverage: ${pct}%`);
 }
 


### PR DESCRIPTION
Part 1 of 3 for #41 (introduce a linter + formatter — there was none).

## What
Adopt **Biome 2.5.2** (single fast binary, lint + format) as the project's linter/formatter. Config only — no source reformatting yet.

- `biome.json`: formatter + recommended linter, scoped to `TS/JS/JSON` source dirs. `.astro` **excluded** (Biome does not format Astro templates; still covered by `.editorconfig`).
- Config matches existing conventions to keep the follow-up format pass minimal: single quotes, semicolons, 2-space indent, trailing commas, `lineWidth 100`.
- `package.json`: `lint`, `lint:fix`, `format`, `format:check`, `check` scripts + `@biomejs/biome` devDep.
- Migrate the 2 orphaned `eslint-disable` comments (Biome has no eslint config): one converted to `biome-ignore`, one dead comment removed.

## Why
155 TS/JS files were never linted; only `.editorconfig` existed, enforced by nothing.

## Notes
No CI gate in this PR — the format pass (PR2) and lint-error fixes (PR3) must land before the gate can go green.

## Stack
- **PR1 (this)** → `main`
- PR2 format pass → `feat/biome-tooling`
- PR3 lint fixes + CI gate → `chore/biome-format-pass`

🤖 Generated with [Claude Code](https://claude.com/claude-code)