### PR TITLE
fix: resolve Biome lint errors + enable CI gate (#41) [PR3/3]

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint & format (Biome)
+        run: npm run check
+
       - name: Validate features catalog
         run: npm run features:validate
 

--- a/biome.json
+++ b/biome.json
@@ -40,5 +40,8 @@
     "rules": {
       "recommended": true
     }
+  },
+  "assist": {
+    "enabled": false
   }
 }

--- a/routes/admin/client/block-form.ts
+++ b/routes/admin/client/block-form.ts
@@ -1341,7 +1341,9 @@ export function mountBlockForm(options: BlockFormOptions): BlockFormHandle {
   }
 
   function render(): void {
-    sortables.forEach((s) => s.destroy());
+    sortables.forEach((s) => {
+      s.destroy();
+    });
     sortables.length = 0;
 
     let html = '<div class="cms-stack cms-block-item-fields">';
@@ -1642,7 +1644,9 @@ export function mountBlockForm(options: BlockFormOptions): BlockFormHandle {
 
   return {
     destroy(): void {
-      sortables.forEach((s) => s.destroy());
+      sortables.forEach((s) => {
+        s.destroy();
+      });
       sortables.length = 0;
       window.removeEventListener('cms:content-locale-change', localeChangeHandler);
       container.innerHTML = '';

--- a/routes/admin/client/menus-editor.ts
+++ b/routes/admin/client/menus-editor.ts
@@ -85,7 +85,9 @@ export function initMenusEditor(): void {
   function destroySortables(): void {
     sortableMain?.destroy();
     sortableMain = null;
-    sortableChildren.forEach((sortable) => sortable.destroy());
+    sortableChildren.forEach((sortable) => {
+      sortable.destroy();
+    });
     sortableChildren.length = 0;
   }
 

--- a/routes/admin/client/page-editor.ts
+++ b/routes/admin/client/page-editor.ts
@@ -176,7 +176,9 @@ export function initPageEditor(): void {
   }
 
   function destroyBlockFormHandles(): void {
-    blockFormHandles.forEach((handle) => handle.destroy());
+    blockFormHandles.forEach((handle) => {
+      handle.destroy();
+    });
     blockFormHandles.clear();
   }
 
@@ -449,7 +451,9 @@ export function initPageEditor(): void {
     }
 
     openArrayItemByKey.clear();
-    next.forEach((value, key) => openArrayItemByKey.set(key, value));
+    next.forEach((value, key) => {
+      openArrayItemByKey.set(key, value);
+    });
   }
 
   function adjustOpenBlockIndexAfterMove(oldIndex: number, newIndex: number): void {
@@ -688,7 +692,9 @@ export function initPageEditor(): void {
           nextMap.set(arrayStateKey(nextIndex, propName), openRow);
         }
         openArrayItemByKey.clear();
-        nextMap.forEach((value, key) => openArrayItemByKey.set(key, value));
+        nextMap.forEach((value, key) => {
+          openArrayItemByKey.set(key, value);
+        });
 
         inlineErrors.clear();
         renderBlocksList();

--- a/tests/i18n-no-spanish-leak.test.js
+++ b/tests/i18n-no-spanish-leak.test.js
@@ -168,6 +168,7 @@ function extractStringLiterals(line) {
   const stringRe = /(['"])((?:[^\\]|\\.)*?)\1/g;
 
   let match;
+  // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic regex.exec() iteration loop
   while ((match = stringRe.exec(noComment)) !== null) {
     const startIndex = match.index;
     const content = match[2];

--- a/tests/media-handlers.test.js
+++ b/tests/media-handlers.test.js
@@ -1445,6 +1445,7 @@ test('T-CSRF-03: non-ASCII filename round-trip — decodes correctly, no 500', a
       'entry.filename must be the decoded original filename',
     );
     // url must not contain raw non-ASCII bytes
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: \x00-\x7F is the intended ASCII range guard
     assert.doesNotMatch(body.url, /[^\x00-\x7F]/, 'url must not contain raw non-ASCII characters');
   });
 });

--- a/tests/paths.test.js
+++ b/tests/paths.test.js
@@ -142,9 +142,12 @@ test('SEC-04: resolveUploadPath rejects sibling directory with uploads-foo prefi
       !siblingPath.startsWith(uploadsDir + path.sep),
       'Fix: sibling path does NOT start with uploadsDir + sep (guard is correct)',
     );
-    // The uploadsDir itself must still be matched (resolved === uploadsDir edge case)
+    // The uploadsDir itself must still be matched (resolved === uploadsDir edge case).
+    // resolvedSelf is a distinct string with the same value as uploadsDir, so the
+    // `===` term exercises the equal branch by value (not a self-compare tautology).
+    const resolvedSelf = path.join(fakeRoot, 'public', 'uploads');
     assert.ok(
-      uploadsDir === uploadsDir || uploadsDir.startsWith(uploadsDir + path.sep),
+      resolvedSelf === uploadsDir || resolvedSelf.startsWith(uploadsDir + path.sep),
       'Fix: the uploads dir itself passes (equal branch)',
     );
 

--- a/utils/html-escape.ts
+++ b/utils/html-escape.ts
@@ -42,7 +42,7 @@ const HTML_SIGNIFICANT = /[&<>"']/g;
  * Shared single-pass escaper. Coerces to string first so it is a safe drop-in
  * for the legacy escapers (escapePickerHtml wrapped its input in String()).
  */
-function escape(value: string): string {
+function escapeString(value: string): string {
   return String(value).replace(HTML_SIGNIFICANT, (char) => HTML_ENTITIES[char] ?? char);
 }
 
@@ -51,7 +51,7 @@ function escape(value: string): string {
  * Encodes & < > " '.
  */
 export function escapeHtml(text: string): string {
-  return escape(text);
+  return escapeString(text);
 }
 
 /**
@@ -60,5 +60,5 @@ export function escapeHtml(text: string): string {
  * characters that prevent attribute breakout.
  */
 export function escapeAttr(value: string): string {
-  return escape(value);
+  return escapeString(value);
 }


### PR DESCRIPTION
Part 3 of 3 for #41. **Stacked on #62 (PR2)** — review/merge PR1 and PR2 first. Closes #41.

## What
Bring the linter to **zero errors** and wire `biome ci` into the CI `validate` job (before typecheck).

### The 10 lint errors, triaged
| Rule | Sites | Resolution |
|------|-------|-----------|
| `useIterableCallbackReturn` | 6 (block-form, menus-editor, page-editor) | `forEach` callbacks → block bodies. **No behavior change** (forEach ignores the implicit return). |
| `noShadowRestrictedNames` | `html-escape.ts` | rename internal `escape` → `escapeString` (was shadowing the deprecated global `escape()`). |
| `noAssignInExpressions` | test | `biome-ignore` — idiomatic `regex.exec()` loop. |
| `noControlCharactersInRegex` | test | `biome-ignore` — `\x00-\x7F` is the intended ASCII-range guard. |
| `noSelfCompare` | `paths.test.js` | **Real finding.** `uploadsDir === uploadsDir` was tautologically `true` → the assertion tested nothing. Now compares a distinct equal-valued string so the equal branch is actually exercised. |

## Decisions
- **`assist` (organizeImports) disabled** for now: import reordering is a large, separate change (121 files) out of scope for this pass — a future ratchet.
- **77 lint warnings remain and are intentionally non-blocking** (`biome ci` fails on errors only). Ratchet them up in follow-ups.

## Verification
- `biome ci .` exits 0 (gate passes)
- `tsc --noEmit` clean
- **1018/1018 tests pass**

## Stack
- PR1 config → `main` (#61)
- PR2 format pass → `feat/biome-tooling` (#62)
- **PR3 (this)** → `chore/biome-format-pass`

🤖 Generated with [Claude Code](https://claude.com/claude-code)