### PR TITLE
fix: serialize login-vs-bootstrap first-user creation (#25)

### DIFF
--- a/api/backup.ts
+++ b/api/backup.ts
@@ -574,8 +574,16 @@ export interface ApplyImportResult {
 
 /**
  * Replace live data from staging using the existing atomic savers.
- * - Uses per-unit data savers (savePages/saveSite/etc.) which run under withFileLock.
- * - For the media unit: replaces public/uploads tree, then calls reconcileMedia.
+ * - Per-unit savers (savePages/saveSite/etc.) write atomically via writeJson
+ *   (temp file + rename); they are NOT individually mutex-guarded.
+ * - The users unit is the exception: bootstrap import callers hold
+ *   withUsersLock across the whole pipeline run (see
+ *   `_runImportPipelineCore`'s bootstrapMode branch), and handleLogin's
+ *   first-user path acquires the same lock — so users.json IS
+ *   lock-protected, via withUsersLock rather than withFileLock directly.
+ * - For the media unit: replaces public/uploads tree, then calls
+ *   reconcileMedia (media writes go through withFileLock(mediaLockKey())
+ *   inside data.ts — a separate mutex from withUsersLock).
  * - Calls handleInvalidateCache equivalent (invalidates global cache via context.cache).
  * - Returns { usersReplaced } based on whether users unit was in selectedUnits.
  *
@@ -728,17 +736,19 @@ export interface ImportPipelineOptions {
   selectedUnits?: ExportUnit[];
   context: { cache?: unknown };
   /**
-   * When true the pipeline re-checks users.length === 0 INSIDE the lock
-   * (after lock acquisition, before extraction) to close the TOCTOU window
-   * between the outer gate in handleBootstrapImport and the pipeline start.
+   * When true the pipeline re-checks users.length === 0 INSIDE the users
+   * lock (after lock acquisition, before extraction) to close the TOCTOU
+   * window between the outer gate in handleBootstrapImport and the
+   * pipeline start.
    *
-   * Residual narrow window: if handleLogin's saveUsers completes DURING
-   * extractToStaging (i.e. after this re-check but before applyImport),
-   * the pipeline will still apply the import on a no-longer-empty instance.
-   * Fully eliminating this residual would require wrapping handleLogin's
-   * saveUsers in the same _importLock, which is a larger cross-cutting
-   * refactor deferred to a future hardening pass. The in-lock re-check
-   * covers the concurrent-bootstrap-POST race fully.
+   * The held lock (withUsersLock) now spans the ENTIRE run — from this
+   * in-lock re-check through applyImport's users write — so a concurrent
+   * handleLogin first-user creation cannot interleave with any part of the
+   * bootstrap pipeline while it holds the lock. No residual window remains
+   * for the login-vs-bootstrap race (GitHub #25, closed via withUsersLock
+   * shared between this pipeline and handleLogin). Concurrent bootstrap
+   * imports racing each other still fall through to this same re-check
+   * (see the B1 tests).
    */
   bootstrapMode?: boolean;
 }
@@ -794,89 +804,110 @@ async function _runImportPipelineCore(
 ): Promise<ImportPipelineResult> {
   const { projectRoot, ceilings, context } = opts;
 
-  // B1 — in-lock bootstrap re-check (TOCTOU hardening).
-  // This runs AFTER the lock is acquired, closing the race window between
-  // the outer gate in handleBootstrapImport and this pipeline execution.
-  // Two concurrent bootstrap POSTs cannot both pass: the second one will
-  // observe users written by the first inside this serialized check.
-  if (opts.bootstrapMode) {
-    const currentUsers = await data.loadUsers();
-    if (currentUsers.users.length !== 0) {
-      return {
-        ok: false,
-        errorCode: 'bootstrap-users-exist',
-        reason: 'instance already has users (in-lock check)',
-      };
+  const run = async (): Promise<ImportPipelineResult> => {
+    // B1 — in-lock bootstrap re-check (TOCTOU hardening).
+    // This runs AFTER the users lock is acquired, closing the race window
+    // between the outer gate in handleBootstrapImport and this pipeline
+    // execution. Two concurrent bootstrap POSTs cannot both pass: the
+    // second one will observe users written by the first inside this
+    // serialized check. It also closes the race against a concurrent
+    // handleLogin first-user creation (GitHub #25), since both paths now
+    // share the same withUsersLock.
+    if (opts.bootstrapMode) {
+      const currentUsers = await data.loadUsers();
+      if (currentUsers.users.length !== 0) {
+        return {
+          ok: false,
+          errorCode: 'bootstrap-users-exist',
+          reason: 'instance already has users (in-lock check)',
+        };
+      }
     }
-  }
 
-  if (!body || body.length === 0) {
-    return { ok: false, errorCode: 'empty', reason: 'request body is empty' };
-  }
+    if (!body || body.length === 0) {
+      return { ok: false, errorCode: 'empty', reason: 'request body is empty' };
+    }
 
-  // Create a temp staging dir under os.tmpdir() (not inside the project to avoid
-  // polluting data/_backups before validation is complete)
-  const stagingDir = path.join(
-    (await import('node:os')).default.tmpdir(),
-    `astro-import-${crypto.randomBytes(6).toString('hex')}`,
-  );
+    // Create a temp staging dir under os.tmpdir() (not inside the project to avoid
+    // polluting data/_backups before validation is complete)
+    const stagingDir = path.join(
+      (await import('node:os')).default.tmpdir(),
+      `astro-import-${crypto.randomBytes(6).toString('hex')}`,
+    );
 
-  try {
-    // Step 1: Extract with guards
     try {
-      await extractToStaging(body, stagingDir, ceilings, projectRoot);
-    } catch (err) {
-      if (err instanceof CeilingExceededError) {
-        return { ok: false, errorCode: 'ceiling', reason: (err as Error).message };
-      }
-      return { ok: false, errorCode: 'corrupt', reason: (err as Error).message };
-    }
-
-    // Determine which units to import: all units declared in the manifest
-    let selectedUnits: ExportUnit[];
-    if (opts.selectedUnits) {
-      selectedUnits = opts.selectedUnits;
-    } else {
-      // Read manifest to discover available units
+      // Step 1: Extract with guards
       try {
-        const manifestRaw = await fs.readFile(path.join(stagingDir, 'manifest.json'), 'utf-8');
-        const manifest = JSON.parse(manifestRaw) as BackupManifest;
-        selectedUnits = manifest.units as ExportUnit[];
-      } catch {
-        return { ok: false, errorCode: 'corrupt', reason: 'could not read manifest from staging' };
+        await extractToStaging(body, stagingDir, ceilings, projectRoot);
+      } catch (err) {
+        if (err instanceof CeilingExceededError) {
+          return { ok: false, errorCode: 'ceiling', reason: (err as Error).message };
+        }
+        return { ok: false, errorCode: 'corrupt', reason: (err as Error).message };
       }
-    }
 
-    // Step 2: Validate (manifest + checksums + structural)
-    const validationResult = await validateStagedImport(stagingDir, selectedUnits, projectRoot);
-    if (!validationResult.ok) {
-      return { ok: false, errorCode: 'validation', reason: validationResult.reason };
-    }
+      // Determine which units to import: all units declared in the manifest
+      let selectedUnits: ExportUnit[];
+      if (opts.selectedUnits) {
+        selectedUnits = opts.selectedUnits;
+      } else {
+        // Read manifest to discover available units
+        try {
+          const manifestRaw = await fs.readFile(path.join(stagingDir, 'manifest.json'), 'utf-8');
+          const manifest = JSON.parse(manifestRaw) as BackupManifest;
+          selectedUnits = manifest.units as ExportUnit[];
+        } catch {
+          return {
+            ok: false,
+            errorCode: 'corrupt',
+            reason: 'could not read manifest from staging',
+          };
+        }
+      }
 
-    // Step 3: Backup snapshot BEFORE any live writes (FIX 5b: used for rollback on apply failure)
-    const snapshotDir = await createBackupSnapshot(projectRoot, selectedUnits);
+      // Step 2: Validate (manifest + checksums + structural)
+      const validationResult = await validateStagedImport(stagingDir, selectedUnits, projectRoot);
+      if (!validationResult.ok) {
+        return { ok: false, errorCode: 'validation', reason: validationResult.reason };
+      }
 
-    // Step 4: Atomic replace per unit — with rollback on failure
-    try {
-      const applyResult = await applyImport(stagingDir, projectRoot, selectedUnits, context);
-      return { ok: true, usersReplaced: applyResult.usersReplaced };
-    } catch (applyErr) {
-      // Attempt rollback from the snapshot just created
+      // Step 3: Backup snapshot BEFORE any live writes (FIX 5b: used for rollback on apply failure)
+      const snapshotDir = await createBackupSnapshot(projectRoot, selectedUnits);
+
+      // Step 4: Atomic replace per unit — with rollback on failure
       try {
-        await _rollbackFromSnapshot(snapshotDir, projectRoot, selectedUnits);
-      } catch {
-        // Rollback failure is non-fatal here — return the original apply error
+        const applyResult = await applyImport(stagingDir, projectRoot, selectedUnits, context);
+        return { ok: true, usersReplaced: applyResult.usersReplaced };
+      } catch (applyErr) {
+        // Attempt rollback from the snapshot just created
+        try {
+          await _rollbackFromSnapshot(snapshotDir, projectRoot, selectedUnits);
+        } catch {
+          // Rollback failure is non-fatal here — return the original apply error
+        }
+        return {
+          ok: false,
+          errorCode: 'apply-failed',
+          reason: `apply failed: ${(applyErr as Error).message}`,
+        };
       }
-      return {
-        ok: false,
-        errorCode: 'apply-failed',
-        reason: `apply failed: ${(applyErr as Error).message}`,
-      };
+    } finally {
+      // Always cleanup staging dir (success AND failure paths)
+      await fs.rm(stagingDir, { recursive: true, force: true });
     }
-  } finally {
-    // Always cleanup staging dir (success AND failure paths)
-    await fs.rm(stagingDir, { recursive: true, force: true });
-  }
+  };
+
+  // SAME-MICROTASK INVARIANT (GitHub #25 — do not break on refactor): this
+  // call MUST happen with ZERO awaits between _runImportPipelineCore's
+  // entry and here, so withUsersLock's key (getDataPath('users.json'),
+  // read from the ambient ASTRO_BLOCKS_PROJECT_ROOT) is captured against
+  // the SAME ambient root that opts.projectRoot was resolved from,
+  // synchronously, at handleBootstrapImport's call site. Verified in the
+  // apply phase's T0 risk check — see design doc D1/D3.
+  //
+  // Non-bootstrap imports (bootstrapMode falsy) never acquire the users
+  // lock, so authenticated imports keep their existing latency profile.
+  return opts.bootstrapMode ? data.withUsersLock(run) : run();
 }
 
 /**

--- a/api/data.ts
+++ b/api/data.ts
@@ -313,6 +313,18 @@ function withFileLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
   return next;
 }
 
+// Narrow, exported seam over withFileLock: serializes all mutating access to
+// users.json across call sites (handleLogin's first-user creation and the
+// bootstrap import pipeline's users existence-check-through-apply span).
+// The generic withFileLock stays private — callers must use this wrapper
+// (or a future users.json-specific wrapper) rather than acquiring an
+// arbitrary key. Non-reentrant: a path that already holds this lock MUST
+// NOT call withUsersLock again (see saveUsers, which stays unlocked so it
+// can be called from inside an already-held lock without deadlocking).
+export function withUsersLock<T>(fn: () => Promise<T>): Promise<T> {
+  return withFileLock(getDataPath('users.json'), fn);
+}
+
 export async function loadPages(): Promise<PagesData> {
   const data = await readJson(getDataPath('pages.json'), DEFAULT_PAGES);
   const pages = Array.isArray(data.pages)

--- a/api/handlers.ts
+++ b/api/handlers.ts
@@ -897,17 +897,37 @@ export async function handleLogin(request: Request): Promise<Response> {
   if (!email || !password) return localizedJsonError(request, 'errors.emailPasswordRequired');
 
   const usersData = await data.loadUsers();
-  const users = usersData.users || [];
+  let users = usersData.users || [];
 
   if (users.length === 0) {
-    const id = data.generateId();
-    const createdAt = new Date().toISOString();
-    const passwordHash = await hashPassword(password);
-    const newUser: User = { id, email, passwordHash, role: 'owner', createdAt };
-    users.push(newUser);
-    await data.saveUsers({ users });
-    const token = await createToken(newUser);
-    return Response.json({ token, user: { id, email, role: 'owner' } });
+    // First-user creation races against a concurrent bootstrap import
+    // (GitHub #25): serialize via withUsersLock and re-check INSIDE the
+    // lock (check-and-write atomic) so neither path silently overwrites
+    // the owner the other one just created/applied.
+    const result = await data.withUsersLock(async () => {
+      const fresh = await data.loadUsers();
+      if ((fresh.users?.length ?? 0) !== 0) {
+        return { kind: 'raced' as const, users: fresh.users || [] };
+      }
+      const id = data.generateId();
+      const createdAt = new Date().toISOString();
+      const passwordHash = await hashPassword(password);
+      const newUser: User = { id, email, passwordHash, role: 'owner', createdAt };
+      await data.saveUsers({ users: [newUser] });
+      return { kind: 'created' as const, user: newUser };
+    });
+
+    if (result.kind === 'created') {
+      const token = await createToken(result.user);
+      return Response.json({
+        token,
+        user: { id: result.user.id, email: result.user.email, role: 'owner' },
+      });
+    }
+
+    // Raced: a concurrent bootstrap import created the owner first. Fall
+    // through to the shared find/verify path using the fresh users list.
+    users = result.users;
   }
 
   const user = users.find((entry) => entry.email === email);

--- a/tests/import-export-bootstrap.test.js
+++ b/tests/import-export-bootstrap.test.js
@@ -21,7 +21,7 @@ import path from 'node:path';
 
 import { ensureDefaultFiles, loadUsers, saveUsers } from '../dist/api/data.js';
 import { buildExportStream, runImportPipeline } from '../dist/api/backup.js';
-import { handleBootstrapImport } from '../dist/api/handlers.js';
+import { handleBootstrapImport, handleLogin } from '../dist/api/handlers.js';
 import { DATA_SCHEMA_VERSION } from '../dist/api/schema-version.js';
 
 // ---------------------------------------------------------------------------
@@ -644,4 +644,137 @@ test('B5: Content-Length exceeds compressed ceiling → 413 with no staging/back
       }
     }
   });
+});
+
+// ---------------------------------------------------------------------------
+// C1: login vs bootstrap concurrency (GitHub #25 — TOCTOU hardening)
+//
+// handleLogin's first-user creation and the bootstrap pipeline's users
+// existence-check-through-apply span now serialize through a shared
+// withUsersLock. This does NOT guarantee a fixed winner — it guarantees the
+// INVARIANT: exactly one coherent owner survives the race, and neither path
+// silently overwrites the owner the other one just created/applied.
+// ---------------------------------------------------------------------------
+
+function makeLoginRequest(email, password) {
+  return new Request('http://localhost/cms/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+}
+
+async function assertSingleCoherentOwner(loginEmail, importedEmail, bootstrapResponse) {
+  const finalUsers = await loadUsers();
+  assert.equal(
+    finalUsers.users.length,
+    1,
+    `expected exactly 1 user after the race, got ${finalUsers.users.length}: ${JSON.stringify(finalUsers.users)}`,
+  );
+
+  if (bootstrapResponse.status === 200) {
+    // Bootstrap won the race: the imported owner must survive untouched —
+    // login must not have silently overwritten it.
+    assert.equal(
+      finalUsers.users[0].email,
+      importedEmail,
+      'bootstrap won the race: surviving owner must be the imported user',
+    );
+  } else {
+    // Login won the race: bootstrap must be rejected (the outer gate and
+    // the in-lock re-check both surface as 403 with the same message), and
+    // the login-created owner must survive untouched.
+    assert.equal(
+      bootstrapResponse.status,
+      403,
+      `bootstrap must be rejected with 403 when login wins the race, got ${bootstrapResponse.status}`,
+    );
+    assert.equal(
+      finalUsers.users[0].email,
+      loginEmail,
+      'login won the race: surviving owner must be the login-created user',
+    );
+  }
+}
+
+const C1_ITERATIONS = 3;
+
+test('C1: login-first ordering — concurrent first-user login vs bootstrap import never silently overwrites owner', async () => {
+  for (let i = 0; i < C1_ITERATIONS; i++) {
+    await withTempProject(async (tempRoot) => {
+      const importedEmail = 'imported-owner@example.com';
+      const loginEmail = 'login-owner@example.com';
+
+      // Build the bootstrap zip with a distinct 'users' unit BEFORE any
+      // mutation, then reset the instance back to zero users so both
+      // concurrent requests race against an empty instance.
+      await saveUsers({
+        users: [
+          {
+            id: 'imported-owner-id',
+            email: importedEmail,
+            passwordHash: 'hash',
+            role: 'owner',
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      });
+      const zipBody = await buildZipBody(['users'], tempRoot);
+      await saveUsers({ users: [] });
+
+      const loginReq = makeLoginRequest(loginEmail, 'secret123');
+      const importReq = makeRequest(zipBody);
+
+      const [loginRes, bootstrapRes] = await Promise.all([
+        handleLogin(loginReq),
+        handleBootstrapImport(importReq, { cache: null }),
+      ]);
+
+      assert.ok(
+        loginRes.status === 200 || loginRes.status === 401,
+        `login must resolve to 200 (created/verified) or 401 (raced against a different owner), got ${loginRes.status}`,
+      );
+
+      await assertSingleCoherentOwner(loginEmail, importedEmail, bootstrapRes);
+    });
+  }
+});
+
+test('C1: bootstrap-first ordering — concurrent bootstrap import vs first-user login never silently overwrites owner', async () => {
+  for (let i = 0; i < C1_ITERATIONS; i++) {
+    await withTempProject(async (tempRoot) => {
+      const importedEmail = 'imported-owner@example.com';
+      const loginEmail = 'login-owner@example.com';
+
+      await saveUsers({
+        users: [
+          {
+            id: 'imported-owner-id',
+            email: importedEmail,
+            passwordHash: 'hash',
+            role: 'owner',
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      });
+      const zipBody = await buildZipBody(['users'], tempRoot);
+      await saveUsers({ users: [] });
+
+      const loginReq = makeLoginRequest(loginEmail, 'secret123');
+      const importReq = makeRequest(zipBody);
+
+      // Same pair, array order swapped per the design's Testing Strategy.
+      const [bootstrapRes, loginRes] = await Promise.all([
+        handleBootstrapImport(importReq, { cache: null }),
+        handleLogin(loginReq),
+      ]);
+
+      assert.ok(
+        loginRes.status === 200 || loginRes.status === 401,
+        `login must resolve to 200 (created/verified) or 401 (raced against a different owner), got ${loginRes.status}`,
+      );
+
+      await assertSingleCoherentOwner(loginEmail, importedEmail, bootstrapRes);
+    });
+  }
 });


### PR DESCRIPTION
Closes #25.

## What

Closes the residual login-vs-bootstrap TOCTOU on the unauthenticated `POST /cms/api/import/bootstrap` path. Before this change, `handleLogin`'s first-user `saveUsers` ran outside any lock the import pipeline observed, so it could land between the pipeline's in-lock re-check and `applyImport`'s users write (during `extractToStaging`) — silently overwriting a just-created owner account.

## Approach

Bring `handleLogin` first-user creation and the bootstrap users mutation into **one serialization domain** via a narrow exported `withUsersLock(fn)` (built on the existing private per-file mutex, keyed on the resolved `users.json` path):

- `handleLogin`: cheap pre-check outside the lock; if zero users, re-check `length === 0` **inside** `withUsersLock` (check-and-write atomic), returning a discriminated `created`/`raced` result. All existing HTTP responses preserved.
- Bootstrap pipeline: `_runImportPipelineCore`'s body extracted into an inner `run()`, wrapped in `withUsersLock` **only when `bootstrapMode`**. The lock spans from the in-lock re-check through `applyImport`'s users write, across the wide extraction window. The authenticated-import path acquires no users lock (no latency regression).
- **Single-acquisition invariant** (the mutex is a non-reentrant promise-chain): `saveUsers` and `applyImport`'s `users` case stay unlocked — the outer `withUsersLock` is the only acquire per run, so no self-deadlock. Lock ordering `_importLock` (outer) ⊃ `withUsersLock` (inner) is acyclic (`handleLogin` only ever acquires `withUsersLock`).

Also corrected two stale doc comments (`api/backup.ts:577` and the option-doc residual-window note) that falsely claimed all per-unit savers were `withFileLock`-guarded.

## Changes

| File | Change |
|------|--------|
| `api/data.ts` | New exported `withUsersLock<T>(fn)` wrapping the private `withFileLock` on `users.json` |
| `api/handlers.ts` | `handleLogin` first-user branch: atomic check-and-write inside the lock, `created`/`raced` result |
| `api/backup.ts` | `_runImportPipelineCore` body → inner `run()`, wrapped in `withUsersLock` when `bootstrapMode`; doc-comment corrections |
| `tests/import-export-bootstrap.test.js` | Two C1 concurrency tests (login-first / bootstrap-first orderings) asserting the single-coherent-owner invariant |

## Verification

- **Tests: 1020/1020 pass** (`npm run build && node --test tests/*.test.js`) — +2 new, no regressions
- `npm run typecheck`: clean
- `npm run check` (Biome CI): exit 0
- **RED reproduced independently**: checking out the pre-fix implementation (keeping the new tests) makes both C1 tests fail with the actual silent-overwrite bug — the tests genuinely catch it, they are not tautological.

## Known limitation (pre-existing, not introduced here)

The same-microtask key-capture guarantee assumes a single ambient `ASTRO_BLOCKS_PROJECT_ROOT` per process (already relied on elsewhere in the codebase). A hypothetical multi-tenant deployment swapping that env var between concurrent requests would break key parity — an existing architectural constraint, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
