### PR TITLE
refactor: collapse value serializers onto canonical escapeAttr (#39)

### DIFF
--- a/tests/file-value.test.js
+++ b/tests/file-value.test.js
@@ -24,6 +24,7 @@ import {
   mediaEntryToFileValue,
   fileDownloadUrl,
 } from '../dist/utils/file-value.js';
+import { escapeAttr } from '../dist/utils/html-escape.js';
 
 // ─── toFileValue ──────────────────────────────────────────────────────────────
 
@@ -153,6 +154,21 @@ test('serializeFileValueAttr — encodes &, <, >, \', "', () => {
   assert.ok(!serialized.includes('&b'), 'raw & must be encoded');
   assert.ok(!serialized.includes('<c>'), 'raw < > must be encoded');
   assert.ok(!serialized.includes('"e'), 'raw " must be encoded');
+});
+
+// ─── byte-identity guard vs canonical escapeAttr (consolidation, issue #39) ────
+// Locks that serializeFileValueAttr delegates to the exact same escaping as the
+// canonical escapeAttr(JSON.stringify(value)) — must stay green before AND after
+// the internal implementation is collapsed onto the canonical helper.
+
+test('serializeFileValueAttr — byte-identical to escapeAttr(JSON.stringify(value)) (special chars)', () => {
+  const value = { url: '/uploads/doc.pdf', filename: 'my "report".pdf' };
+  assert.equal(serializeFileValueAttr(value), escapeAttr(JSON.stringify(value)));
+});
+
+test('serializeFileValueAttr — byte-identical to escapeAttr(JSON.stringify(value)) (safe value)', () => {
+  const value = { url: '/uploads/doc.pdf', filename: 'report.pdf' };
+  assert.equal(serializeFileValueAttr(value), escapeAttr(JSON.stringify(value)));
 });
 
 // ─── isEmptyFileValue ─────────────────────────────────────────────────────────

--- a/tests/image-value.test.js
+++ b/tests/image-value.test.js
@@ -22,6 +22,7 @@ import {
   serializeImageValueAttr,
   getCaption,
 } from '../dist/utils/image-value.js';
+import { escapeAttr } from '../dist/utils/html-escape.js';
 
 // ─── toImageValue ─────────────────────────────────────────────────────────────
 
@@ -404,6 +405,21 @@ test('FIX-3: serializeImageValueAttr — quote-blind escaper would FAIL (proves 
     !serialized.includes('"'),
     'regression guard: if this fails, the call site was reverted to a quote-blind escaper',
   );
+});
+
+// ─── byte-identity guard vs canonical escapeAttr (consolidation, issue #39) ────
+// Locks that serializeImageValueAttr delegates to the exact same escaping as the
+// canonical escapeAttr(JSON.stringify(value)) — must stay green before AND after
+// the internal implementation is collapsed onto the canonical helper.
+
+test('serializeImageValueAttr — byte-identical to escapeAttr(JSON.stringify(value)) (special chars)', () => {
+  const value = { url: '/img.jpg', alt: 'say "hi" <b>&\'x' };
+  assert.equal(serializeImageValueAttr(value), escapeAttr(JSON.stringify(value)));
+});
+
+test('serializeImageValueAttr — byte-identical to escapeAttr(JSON.stringify(value)) (safe value)', () => {
+  const value = { url: '/a.jpg', alt: 'Cat' };
+  assert.equal(serializeImageValueAttr(value), escapeAttr(JSON.stringify(value)));
 });
 
 // ─── caption pass-through (P1-T5) ─────────────────────────────────────────────

--- a/utils/file-value.ts
+++ b/utils/file-value.ts
@@ -22,6 +22,7 @@ Licensed under the Business Source License 1.1
  */
 
 import type { FileFieldValue, MediaEntry } from '../types/index.js';
+import { escapeAttr } from './html-escape.js';
 
 /** Sentinel returned for null / undefined / malformed input. */
 const EMPTY: FileFieldValue = { url: '' };
@@ -109,13 +110,7 @@ export function parseFileValue(raw: string): FileFieldValue {
  * parseFileValue(input.value) receives clean JSON — no explicit decoding needed.
  */
 export function serializeFileValueAttr(value: FileFieldValue): string {
-  const json = JSON.stringify(value);
-  return json
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+  return escapeAttr(JSON.stringify(value));
 }
 
 /**

--- a/utils/image-value.ts
+++ b/utils/image-value.ts
@@ -18,6 +18,7 @@ Licensed under the Business Source License 1.1
  */
 
 import type { ImageFieldValue, MediaEntry, MediaVariant } from '../types/index.js';
+import { escapeAttr } from './html-escape.js';
 
 /** Sentinel returned for null / undefined / malformed input. */
 const EMPTY: ImageFieldValue = { url: '', alt: '' };
@@ -175,13 +176,7 @@ export function isEmptyImageValue(value: unknown): boolean {
  * no explicit decoding step is needed on read.
  */
 export function serializeImageValueAttr(value: ImageFieldValue): string {
-  const json = JSON.stringify(value);
-  return json
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+  return escapeAttr(JSON.stringify(value));
 }
 
 /**


### PR DESCRIPTION
Part of #39 (P1-5, Slice 2 — sub-slice 2a). Does **not** close #39; Slice 2 completes across sub-slices 2a–2e.

## What

Collapse the two value-serializer attribute escapers onto the canonical `escapeAttr` from `utils/html-escape.ts` (shipped in Slice 1), removing two hand-rolled 5-step chained `.replace()` implementations.

- `serializeImageValueAttr` (`utils/image-value.ts`) and `serializeFileValueAttr` (`utils/file-value.ts`) now return `escapeAttr(JSON.stringify(value))`.

## Why

Part of consolidating the three+ divergent HTML-escape functions tracked in #39. This sub-slice removes the value-serializer duplicates. **Pure refactor — proven byte-identical**, not a behavior change.

## Byte-identity proof

The old chained `.replace(/&/,...).replace(/</,...)...` and the canonical single-pass `escapeAttr` produce identical output: none of the five entity replacements (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&#39;`) contains any of the other four target characters or a fresh `&`, so replacement order never affects the result. Verified empirically across 388 cases (all 120 permutations of `& < > " '` + pre-encoded-looking substrings) with 0 mismatches, and the existing serializer tests (87/87) pass **both before and after** the refactor.

## Changes

| File | Change |
|------|--------|
| `utils/image-value.ts` | Body of `serializeImageValueAttr` → `escapeAttr(JSON.stringify(value))` + canonical import |
| `utils/file-value.ts` | Same for `serializeFileValueAttr` |
| `tests/image-value.test.js` | +2 byte-identity characterization tests |
| `tests/file-value.test.js` | +2 byte-identity characterization tests |

## Verification

- **1024/1024 tests pass** (`npm run build && node --test tests/*.test.js`) — baseline 1020 + 4 new
- `npm run typecheck`: clean
- `npm run check` (Biome): zero new issues
- Independent fresh-context review: PASS (byte-identity re-proven across 388 cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
