### PR TITLE
refactor: repoint media.ts to canonical html-escape module (#39)

### DIFF
--- a/routes/admin/client/media.ts
+++ b/routes/admin/client/media.ts
@@ -10,6 +10,7 @@ Licensed under the Business Source License 1.1
  */
 
 import { getCmsToken, getCmsWindow } from './common.js';
+import { escapeHtml, escapeAttr } from '../../../utils/html-escape.js';
 import {
   fetchMedia,
   formatBytes,
@@ -43,19 +44,6 @@ let reqSeq = 0;
 let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 // ─── Grid rendering ───────────────────────────────────────────────────────────
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-function escapeAttr(s: string): string {
-  return s.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
-}
 
 // Document SVG icon — rendered inside accessible document tiles (aria-hidden).
 const docIconSvg =

--- a/tests/media-canonical-escape.test.js
+++ b/tests/media-canonical-escape.test.js
@@ -1,0 +1,60 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * Source-level guard: routes/admin/client/media.ts must consume the
+ * canonical escapeHtml/escapeAttr pair from utils/html-escape.ts instead of
+ * defining its own local copies.
+ *
+ * Rule: no `function escapeHtml(` or `function escapeAttr(` declarations may
+ * exist in this file, and it must import both names from the canonical
+ * '../../../utils/html-escape.js' module. This is part of the issue #39
+ * consolidation effort (sub-slice 2b).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const root = process.cwd();
+const relPath = 'routes/admin/client/media.ts';
+
+test(`${relPath} — must not declare local escapeHtml/escapeAttr functions`, async () => {
+  const src = await readFile(join(root, relPath), 'utf-8');
+
+  assert.ok(
+    !/function\s+escapeHtml\(/.test(src),
+    `Found a local "function escapeHtml(" declaration in ${relPath}. ` +
+      'It must be deleted in favor of the canonical import.',
+  );
+  assert.ok(
+    !/function\s+escapeAttr\(/.test(src),
+    `Found a local "function escapeAttr(" declaration in ${relPath}. ` +
+      'It must be deleted in favor of the canonical import.',
+  );
+});
+
+test(`${relPath} — must import escapeHtml and escapeAttr from the canonical html-escape module`, async () => {
+  const src = await readFile(join(root, relPath), 'utf-8');
+
+  const importLineMatch = src.match(/^import\s*\{[^}]*\}\s*from\s*['"]\.\.\/\.\.\/\.\.\/utils\/html-escape\.js['"];?$/m);
+
+  assert.ok(
+    importLineMatch,
+    `Expected ${relPath} to import from '../../../utils/html-escape.js', but no matching import line was found.`,
+  );
+
+  const importLine = importLineMatch[0];
+
+  assert.ok(
+    importLine.includes('escapeHtml'),
+    `The canonical html-escape import line in ${relPath} does not include escapeHtml: ${importLine}`,
+  );
+  assert.ok(
+    importLine.includes('escapeAttr'),
+    `The canonical html-escape import line in ${relPath} does not include escapeAttr: ${importLine}`,
+  );
+});

--- a/tests/media-canonical-escape.test.js
+++ b/tests/media-canonical-escape.test.js
@@ -40,7 +40,9 @@ test(`${relPath} — must not declare local escapeHtml/escapeAttr functions`, as
 test(`${relPath} — must import escapeHtml and escapeAttr from the canonical html-escape module`, async () => {
   const src = await readFile(join(root, relPath), 'utf-8');
 
-  const importLineMatch = src.match(/^import\s*\{[^}]*\}\s*from\s*['"]\.\.\/\.\.\/\.\.\/utils\/html-escape\.js['"];?$/m);
+  const importLineMatch = src.match(
+    /^import\s*\{[^}]*\}\s*from\s*['"]\.\.\/\.\.\/\.\.\/utils\/html-escape\.js['"];?$/m,
+  );
 
   assert.ok(
     importLineMatch,


### PR DESCRIPTION
Part of #39 (P1-5, Slice 2 — sub-slice 2b). Does **not** close #39; Slice 2 completes across sub-slices 2a–2e.

## What

Repoint `routes/admin/client/media.ts` to the canonical `escapeHtml`/`escapeAttr` from `utils/html-escape.ts` (Slice 1) and delete its two local duplicate escapers.

## Why

Continues consolidating the divergent HTML-escape functions tracked in #39. media.ts carried a local escaper pair whose `escapeAttr` was **2-char** (`"` `'` only) — the exact under-escaping #39 flags. Switching to the canonical **5-char** `escapeAttr` (adds `& < >`) is a correctness improvement.

## Behavior equivalence (audited in fresh-context review)

- **escapeHtml**: old local (chained `.replace`, 5 chars) vs canonical (single-pass, same 5 chars) → **byte-identical**, no regression.
- **escapeAttr**: old 2-char → canonical 5-char = **strict widening**. Every media.ts call site feeds attribute values inside `innerHTML` templates that are read back via `.dataset.*` (the browser auto-decodes entities on parse), so the extra escaping round-trips transparently. The two `JSON.stringify` calls use raw dataset/input values, not `escapeAttr` output → no double-encoding. Browser-invisible, safe.

## Changes

| File | Change |
|------|--------|
| `routes/admin/client/media.ts` | +1 canonical import, −13 (deleted local `escapeHtml`/`escapeAttr`); zero call-site edits (names already matched) |
| `tests/media-canonical-escape.test.js` | New source-level guard: asserts canonical import + no local escaper defs (order-tolerant) |

## Verification

- **1022/1022 tests pass** (`npm run build && node --test tests/*.test.js`) — baseline 1020 + 2 new
- `npm run typecheck`: clean
- `npm run check` (Biome CI): **exit 0**, 0 errors — matches main's baseline (77 warnings / 114 infos), zero new issues
- Guard test confirmed RED on main, GREEN on branch
- Independent fresh-context review: PASS (escaper equivalence audited call-site by call-site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
