### PR TITLE
refactor: repoint table editors to canonical escapeHtml (#39)

### DIFF
--- a/routes/admin/client/configs-editor.ts
+++ b/routes/admin/client/configs-editor.ts
@@ -7,7 +7,6 @@ import type { ConfigEntry, ConfigsData } from '../../../types/index.js';
 import {
   authHeaders,
   closeDialog,
-  escapeHtml,
   fetchJson,
   fetchOk,
   openDialog,
@@ -16,7 +15,7 @@ import {
   showToast,
 } from './common.js';
 import { ct } from '../i18n/client.js';
-import { escapeAttr } from '../../../utils/html-escape.js';
+import { escapeAttr, escapeHtml } from '../../../utils/html-escape.js';
 
 const pencilSvg =
   '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>';

--- a/routes/admin/client/menus-editor.ts
+++ b/routes/admin/client/menus-editor.ts
@@ -8,7 +8,6 @@ import type { Menu, MenuItem, MenusData } from '../../../types/index.js';
 import {
   authHeaders,
   closeDialog,
-  escapeHtml,
   fetchJson,
   fetchOk,
   getActiveContentLocale,
@@ -18,7 +17,7 @@ import {
   showToast,
 } from './common.js';
 import { ct } from '../i18n/client.js';
-import { escapeAttr } from '../../../utils/html-escape.js';
+import { escapeAttr, escapeHtml } from '../../../utils/html-escape.js';
 
 const SELECTOR_REGEX = /^[a-zA-Z0-9_-]+$/;
 const dragHandleSvg =

--- a/routes/admin/client/page-editor.ts
+++ b/routes/admin/client/page-editor.ts
@@ -19,7 +19,6 @@ import {
 import {
   authHeaders,
   closeDialog,
-  escapeHtml,
   fetchJson,
   fetchOk,
   getActiveContentLocale,
@@ -31,7 +30,7 @@ import {
 import { ct } from '../i18n/client.js';
 import { mountBlockForm, type BlockFormHandle, type ArrayLimitInfo } from './block-form.js';
 import { uploadMedia } from './media-fetch.js';
-import { escapeAttr } from '../../../utils/html-escape.js';
+import { escapeAttr, escapeHtml } from '../../../utils/html-escape.js';
 
 const trashIconSvg =
   '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>';

--- a/routes/admin/client/redirects-editor.ts
+++ b/routes/admin/client/redirects-editor.ts
@@ -8,7 +8,6 @@ import { normalizeRedirectPath } from '../../../utils/redirects.js';
 import {
   authHeaders,
   closeDialog,
-  escapeHtml,
   fetchJson,
   fetchOk,
   openDialog,
@@ -17,7 +16,7 @@ import {
   showToast,
 } from './common.js';
 import { ct } from '../i18n/client.js';
-import { escapeAttr } from '../../../utils/html-escape.js';
+import { escapeAttr, escapeHtml } from '../../../utils/html-escape.js';
 
 const pencilSvg =
   '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>';

--- a/tests/table-editors-canonical-escape.test.js
+++ b/tests/table-editors-canonical-escape.test.js
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * Source-level guard: the four table-editor client modules must consume the
+ * canonical escapeHtml/escapeAttr pair from utils/html-escape.ts for BOTH
+ * attribute and text-content escaping, instead of splitting escapeHtml from
+ * ./common.js and escapeAttr from the canonical module.
+ *
+ * Rule: each file must import `escapeHtml` from the canonical
+ * '../../../utils/html-escape.js' module, and must NOT import `escapeHtml`
+ * from './common.js' anymore. This is part of the issue #39 consolidation
+ * effort (sub-slice 2c).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const root = process.cwd();
+
+const FILES = [
+  'routes/admin/client/configs-editor.ts',
+  'routes/admin/client/menus-editor.ts',
+  'routes/admin/client/redirects-editor.ts',
+  'routes/admin/client/page-editor.ts',
+];
+
+for (const relPath of FILES) {
+  test(`${relPath} — must import escapeHtml from the canonical html-escape module`, async () => {
+    const src = await readFile(join(root, relPath), 'utf-8');
+
+    const importLineMatch = src.match(
+      /^import\s*\{[^}]*\}\s*from\s*['"]\.\.\/\.\.\/\.\.\/utils\/html-escape\.js['"];?$/m,
+    );
+
+    assert.ok(
+      importLineMatch,
+      `Expected ${relPath} to import from '../../../utils/html-escape.js', but no matching import line was found.`,
+    );
+
+    const importLine = importLineMatch[0];
+
+    assert.ok(
+      importLine.includes('escapeHtml'),
+      `The canonical html-escape import line in ${relPath} does not include escapeHtml: ${importLine}`,
+    );
+    assert.ok(
+      importLine.includes('escapeAttr'),
+      `The canonical html-escape import line in ${relPath} does not include escapeAttr: ${importLine}`,
+    );
+  });
+
+  test(`${relPath} — must NOT import escapeHtml from ./common.js`, async () => {
+    const src = await readFile(join(root, relPath), 'utf-8');
+
+    const commonImportMatch = src.match(
+      /^import\s*\{([^}]*)\}\s*from\s*['"]\.\/common\.js['"];?$/m,
+    );
+
+    assert.ok(
+      commonImportMatch,
+      `Expected ${relPath} to still import other named exports from './common.js', but no matching import line was found.`,
+    );
+
+    const commonImportLine = commonImportMatch[0];
+
+    assert.ok(
+      !commonImportLine.includes('escapeHtml'),
+      `Found escapeHtml still imported from './common.js' in ${relPath}. ` +
+        'It must be imported from the canonical utils/html-escape.js module instead.',
+    );
+  });
+}


### PR DESCRIPTION
Part of #39 (P1-5, Slice 2 — sub-slice 2c). Does **not** close #39; 2d and 2e remain.

## What

Repoint the text-context `escapeHtml` in the four table-editor client modules (`configs-editor.ts`, `menus-editor.ts`, `redirects-editor.ts`, `page-editor.ts`) from `./common.js` to the canonical `utils/html-escape.ts`, and drop `escapeHtml` from each file's `./common.js` import.

## Why

Continues the #39 consolidation. Slice 1 already routed these files' attribute contexts through canonical `escapeAttr`; this moves their text contexts onto canonical `escapeHtml` too. Canonical `escapeHtml` is byte-identical to `common.ts`'s (both 5-char) — proven in the 2b review — so this is a **pure repoint, zero behavior change**.

## Deletion-safety

`common.ts`'s local `escapeHtml` is intentionally left in place: after this PR its only remaining importer is `block-form.ts` (the target of sub-slice 2d). Its deletion is deferred to 2e, gated on a zero-importer check.

## Changes

| File | Change |
|------|--------|
| `routes/admin/client/configs-editor.ts` | Import `escapeHtml` from canonical; drop it from `./common.js` |
| `routes/admin/client/menus-editor.ts` | Same |
| `routes/admin/client/redirects-editor.ts` | Same |
| `routes/admin/client/page-editor.ts` | Same |
| `tests/table-editors-canonical-escape.test.js` | New source-level guard: canonical import present + no `escapeHtml` from `./common.js` |

## Verification

- **1034/1034 tests pass** — baseline 1026 + 8 new guard assertions
- `npm run typecheck`: clean
- `npm run check` (Biome CI): **exit 0**, matches main baseline (77 warnings / 114 infos, 0 errors)
- Guard test confirmed RED on main, GREEN on branch
- Diff independently audited: only import lines changed; deletion-safety confirmed (`block-form.ts` is the sole remaining `common.js` `escapeHtml` importer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
