### PR TITLE
refactor: delete dead common.ts escapeHtml, complete escaper consolidation (#39)

### DIFF
--- a/routes/admin/client/common.ts
+++ b/routes/admin/client/common.ts
@@ -144,12 +144,6 @@ export function closeDialog(dialog: HTMLDialogElement | null): void {
   dialog?.close();
 }
 
-export function escapeHtml(value: string): string {
-  const div = document.createElement('div');
-  div.textContent = value;
-  return div.innerHTML;
-}
-
 export function formatDisplayDate(value?: string | null): string {
   if (!value) return ct('common.noDate');
   try {

--- a/tests/common-escapehtml-deleted.test.js
+++ b/tests/common-escapehtml-deleted.test.js
@@ -1,0 +1,70 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * Source-level guard: routes/admin/client/common.ts must NOT declare a local
+ * DOM-based escapeHtml function (the `div.textContent = v; return
+ * div.innerHTML` implementation). It was dead code with zero importers
+ * repo-wide once block-form.ts was repointed to the canonical
+ * utils/html-escape.ts module (sub-slice 2d, issue #39). This is the final
+ * cleanup, sub-slice 2e.
+ *
+ * A second, repo-wide guard scans every routes/admin/client/*.ts file (via
+ * glob, not a hardcoded list) and asserts none of them import `escapeHtml`
+ * from './common.js', to keep the guard honest as new files are added.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const root = process.cwd();
+const relPath = 'routes/admin/client/common.ts';
+const clientDir = join(root, 'routes/admin/client');
+
+test(`${relPath} — must not declare a local escapeHtml function`, async () => {
+  const src = await readFile(join(root, relPath), 'utf-8');
+
+  assert.ok(
+    !/function\s+escapeHtml\(/.test(src),
+    `Found a local "function escapeHtml(" declaration in ${relPath}. ` +
+      'It is dead code with zero importers repo-wide and must be deleted.',
+  );
+});
+
+test('no file under routes/admin/client/*.ts imports escapeHtml from ./common.js', async () => {
+  const entries = await readdir(clientDir, { withFileTypes: true });
+  const tsFiles = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.ts'))
+    .map((entry) => entry.name);
+
+  assert.ok(tsFiles.length > 0, `Expected to find .ts files under ${clientDir}, found none.`);
+
+  const offenders = [];
+
+  for (const fileName of tsFiles) {
+    const filePath = join(clientDir, fileName);
+    const src = await readFile(filePath, 'utf-8');
+
+    const commonImportMatches = src.matchAll(
+      /^import\s*\{([^}]*)\}\s*from\s*['"](?:\.\/)?common\.js['"];?$/gm,
+    );
+
+    for (const match of commonImportMatches) {
+      const importedNames = match[1];
+      if (/\bescapeHtml\b/.test(importedNames)) {
+        offenders.push(fileName);
+      }
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `Found escapeHtml still imported from './common.js' in: ${offenders.join(', ')}. ` +
+      'Repoint these files to the canonical utils/html-escape.js module.',
+  );
+});


### PR DESCRIPTION
Part of #39 (P1-5, Slice 2 — sub-slice 2e, FINAL). Does **not** close #39; the consolidating release closes it.

## What

Delete the dead, unused local DOM `escapeHtml` from `routes/admin/client/common.ts`:

```ts
export function escapeHtml(value: string): string {
  const div = document.createElement('div');
  div.textContent = value;
  return div.innerHTML;
}
```

## Why

This was the last of the three divergent HTML-escape functions #39 set out to consolidate. Its final importer, `block-form.ts`, was repointed to the canonical `utils/html-escape.ts` in sub-slice 2d (PR #72). With that merged, this function has **zero importers repo-wide** and zero internal uses — it is pure dead code. Removing it completes the consolidation: every escaper in the codebase now flows through the single canonical `utils/html-escape.ts` module.

## Deletion-safety

Gated on a zero-importer invariant, verified on `main` after PR #72: a glob-based repo-wide scan of every `./common.js` import finds no remaining `escapeHtml` importer. No canonical rewiring is needed — nothing calls this function.

## Changes

| File | Change |
|------|--------|
| `routes/admin/client/common.ts` | Delete the dead DOM `escapeHtml` function (no other export touched) |
| `tests/common-escapehtml-deleted.test.js` | New guard test: asserts `escapeHtml` is no longer declared in common.ts, and a glob-based repo-wide scan finds zero `escapeHtml` imports from `./common.js` |

## Verification

- **1040/1040 tests pass** — baseline 1038 + 2 new guard assertions
- `npm run typecheck`: clean (exit 0)
- `npm run check` (Biome CI): **exit 0**, matches main baseline (77 warnings / 114 infos, 0 errors)
- Guard test confirmed RED on branch pre-deletion, GREEN after
- Diff independently re-derived: only the 5-line function removed (cleanly, between `closeDialog` and `formatDisplayDate`); no other `common.ts` export altered
- **No e2e required**: the deleted function had zero callers — there is nothing to exercise dynamically. Guard + full unit suite + typecheck + Biome is sufficient coverage for a dead-code removal.

## Notes for reviewers

- Blast radius: one deleted function + one new test file. ~76 lines. No public API, route, or env-var change.
- Completes Slice 2 of #39. A release consolidating the whole #39 series follows this merge; #39 is closed at release time, not here.
