### PR TITLE
refactor(api): stand up handlers shim + shared + cache-invalidation + site domain (#35)

### DIFF
--- a/api/handlers.ts
+++ b/api/handlers.ts
@@ -7,15 +7,9 @@ import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import type { APIContext } from 'astro';
 import { SignJWT, jwtVerify } from 'jose';
 import { imageSize } from 'image-size';
-import {
-  getGlobalCachePaths,
-  getGlobalCacheTags,
-  getPageCachePath,
-  getPageCacheTags,
-} from '../utils/cache.js';
+import { getGlobalCachePaths, getGlobalCacheTags } from '../utils/cache.js';
 import { validateBlocks } from '../utils/blocks.js';
 import {
   getDefaultLanguageCode,
@@ -65,7 +59,6 @@ import type {
   RedirectRule,
   SchemaMap,
   SeoData,
-  Site,
   User,
 } from '../types/index.js';
 import * as data from './data.js';
@@ -73,33 +66,21 @@ import { buildExportStream, runImportPipeline } from './backup.js';
 import { UNIT_TO_DATA_FILES } from './manifest.js';
 import type { ExportUnit } from './manifest.js';
 import { readCeilingEnvVars } from './import-utils.js';
-import { resolveUiLocale } from '../routes/admin/i18n/resolve.js';
 import { catalogs } from '../routes/admin/i18n/catalogs.js';
 import { t as translateFn } from '../routes/admin/i18n/t.js';
-
-/** Resolve the UI locale from the incoming API request (cookie > Accept-Language > 'en'). */
-function resolveRequestUiLocale(
-  request: Request,
-): import('../routes/admin/i18n/types.js').UiLocale {
-  return resolveUiLocale({
-    cookie: request.headers.get('cookie'),
-    acceptLanguage: request.headers.get('accept-language'),
-  });
-}
-
-/** Return a localized JSON error response. The wire shape { error: string } is preserved. */
-export function localizedJsonError(
-  request: Request,
-  key: string,
-  status = 400,
-  params?: Record<string, string | number>,
-  extra?: Record<string, unknown>,
-): Response {
-  const locale = resolveRequestUiLocale(request);
-  const catalog = catalogs[locale];
-  const message = translateFn(catalog, key, params);
-  return jsonError(message, status, extra);
-}
+import {
+  jsonError,
+  localizedJsonError,
+  parseJsonBody,
+  resolveRequestUiLocale,
+} from './handlers/shared.js';
+import type { HandlerContext } from './handlers/shared.js';
+import {
+  invalidateGlobalContentCache,
+  invalidatePageContentCache,
+} from './handlers/cache-invalidation.js';
+export { localizedJsonError } from './handlers/shared.js';
+export { handleGetSite, handlePutSite } from './handlers/site.js';
 
 // SECURITY: this constant signs and verifies admin session tokens. When no secret is
 // configured we fall back to a well-known string ONLY to keep local development frictionless.
@@ -180,8 +161,6 @@ if (JWT_SECRET_STATUS === 'insecure-production') {
 function jwtSecretMisconfigured(): boolean {
   return JWT_SECRET_STATUS === 'insecure-production';
 }
-type AstroCache = APIContext['cache'];
-type HandlerContext = { cache?: AstroCache | null };
 const CONFIG_KEY_REGEX = /^[A-Za-z][A-Za-z0-9_.-]*$/;
 
 // Media upload constants
@@ -245,13 +224,6 @@ const MAX_UPLOAD_BYTES = (() => {
   }
   return 5 * 1024 * 1024; // 5 MB default
 })();
-
-function jsonError(message: string, status = 400, extra?: Record<string, unknown>): Response {
-  return new Response(JSON.stringify({ error: message, ...extra }), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  });
-}
 
 function normalizeSlugInput(rawSlug: unknown): string | string[] {
   if (Array.isArray(rawSlug)) {
@@ -336,76 +308,6 @@ function ensureEnabledDefaultLanguage(
     ...language,
     isDefault: defaultCode ? normalizeLanguageCode(language.code) === defaultCode : false,
   }));
-}
-
-async function invalidateCachePath(
-  cache: AstroCache | null | undefined,
-  pathname: string,
-): Promise<boolean> {
-  if (!cache?.enabled) return false;
-
-  try {
-    await cache.invalidate({ path: pathname });
-    return true;
-  } catch (error) {
-    console.warn(`[astro-blocks] Failed to invalidate cache path "${pathname}":`, error);
-    return false;
-  }
-}
-
-async function invalidateCacheTags(
-  cache: AstroCache | null | undefined,
-  tags: string[],
-): Promise<boolean> {
-  if (!cache?.enabled || tags.length === 0) return false;
-
-  try {
-    await cache.invalidate({ tags });
-    return true;
-  } catch (error) {
-    console.warn('[astro-blocks] Failed to invalidate cache tags:', tags, error);
-    return false;
-  }
-}
-
-async function invalidateGlobalContentCache(cache: AstroCache | null | undefined): Promise<void> {
-  await invalidateCacheTags(cache, getGlobalCacheTags());
-  for (const pathname of getGlobalCachePaths()) {
-    await invalidateCachePath(cache, pathname);
-  }
-}
-
-async function invalidatePageContentCache(
-  cache: AstroCache | null | undefined,
-  locale: string,
-  defaultLocale: string,
-  currentPage?: Pick<Page, 'id' | 'slug'> | null,
-  previousPage?: Pick<Page, 'id' | 'slug'> | null,
-): Promise<void> {
-  const tags = new Set<string>(getGlobalCacheTags());
-  const paths = new Set<string>(getGlobalCachePaths());
-
-  for (const page of [currentPage, previousPage]) {
-    if (!page) continue;
-    paths.add(getPageCachePath(page, locale, defaultLocale));
-    for (const tag of getPageCacheTags(page, locale, defaultLocale)) tags.add(tag);
-  }
-
-  for (const pathname of paths) {
-    await invalidateCachePath(cache, pathname);
-  }
-
-  await invalidateCacheTags(cache, Array.from(tags));
-}
-
-async function parseJsonBody<T>(
-  request: Request,
-): Promise<{ data: T | null; error: Response | null }> {
-  try {
-    return { data: (await request.json()) as T, error: null };
-  } catch {
-    return { data: null, error: localizedJsonError(request, 'errors.invalidBody') };
-  }
 }
 
 function scryptAsync(password: string, salt: crypto.BinaryLike, keylen: number): Promise<Buffer> {
@@ -1297,24 +1199,6 @@ export async function handleDeletePage(
   await data.savePages(pagesData);
   await invalidatePageContentCache(context.cache, locale, defaultLocale, null, deletedPage);
   return new Response(null, { status: 204 });
-}
-
-export async function handleGetSite(): Promise<Response> {
-  return Response.json(await data.loadSite());
-}
-
-export async function handlePutSite(
-  request: Request,
-  context: HandlerContext = {},
-): Promise<Response> {
-  const { data: body, error } = await parseJsonBody<Partial<Site>>(request);
-  if (error || !body) return error as Response;
-
-  const existing = await data.loadSite();
-  const site = { ...existing, ...body };
-  await data.saveSite(site);
-  await invalidateGlobalContentCache(context.cache);
-  return Response.json(site);
 }
 
 export async function handleGetMenus(request: Request): Promise<Response> {

--- a/api/handlers/cache-invalidation.ts
+++ b/api/handlers/cache-invalidation.ts
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+import {
+  getGlobalCachePaths,
+  getGlobalCacheTags,
+  getPageCachePath,
+  getPageCacheTags,
+} from '../../utils/cache.js';
+import type { Page } from '../../types/index.js';
+import type { AstroCache } from './shared.js';
+
+export async function invalidateCachePath(
+  cache: AstroCache | null | undefined,
+  pathname: string,
+): Promise<boolean> {
+  if (!cache?.enabled) return false;
+
+  try {
+    await cache.invalidate({ path: pathname });
+    return true;
+  } catch (error) {
+    console.warn(`[astro-blocks] Failed to invalidate cache path "${pathname}":`, error);
+    return false;
+  }
+}
+
+export async function invalidateCacheTags(
+  cache: AstroCache | null | undefined,
+  tags: string[],
+): Promise<boolean> {
+  if (!cache?.enabled || tags.length === 0) return false;
+
+  try {
+    await cache.invalidate({ tags });
+    return true;
+  } catch (error) {
+    console.warn('[astro-blocks] Failed to invalidate cache tags:', tags, error);
+    return false;
+  }
+}
+
+export async function invalidateGlobalContentCache(
+  cache: AstroCache | null | undefined,
+): Promise<void> {
+  await invalidateCacheTags(cache, getGlobalCacheTags());
+  for (const pathname of getGlobalCachePaths()) {
+    await invalidateCachePath(cache, pathname);
+  }
+}
+
+export async function invalidatePageContentCache(
+  cache: AstroCache | null | undefined,
+  locale: string,
+  defaultLocale: string,
+  currentPage?: Pick<Page, 'id' | 'slug'> | null,
+  previousPage?: Pick<Page, 'id' | 'slug'> | null,
+): Promise<void> {
+  const tags = new Set<string>(getGlobalCacheTags());
+  const paths = new Set<string>(getGlobalCachePaths());
+
+  for (const page of [currentPage, previousPage]) {
+    if (!page) continue;
+    paths.add(getPageCachePath(page, locale, defaultLocale));
+    for (const tag of getPageCacheTags(page, locale, defaultLocale)) tags.add(tag);
+  }
+
+  for (const pathname of paths) {
+    await invalidateCachePath(cache, pathname);
+  }
+
+  await invalidateCacheTags(cache, Array.from(tags));
+}

--- a/api/handlers/shared.ts
+++ b/api/handlers/shared.ts
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+import type { APIContext } from 'astro';
+import { resolveUiLocale } from '../../routes/admin/i18n/resolve.js';
+import { catalogs } from '../../routes/admin/i18n/catalogs.js';
+import { t as translateFn } from '../../routes/admin/i18n/t.js';
+
+export type AstroCache = APIContext['cache'];
+export type HandlerContext = { cache?: AstroCache | null };
+
+/** Resolve the UI locale from the incoming API request (cookie > Accept-Language > 'en'). */
+export function resolveRequestUiLocale(
+  request: Request,
+): import('../../routes/admin/i18n/types.js').UiLocale {
+  return resolveUiLocale({
+    cookie: request.headers.get('cookie'),
+    acceptLanguage: request.headers.get('accept-language'),
+  });
+}
+
+/** Return a localized JSON error response. The wire shape { error: string } is preserved. */
+export function localizedJsonError(
+  request: Request,
+  key: string,
+  status = 400,
+  params?: Record<string, string | number>,
+  extra?: Record<string, unknown>,
+): Response {
+  const locale = resolveRequestUiLocale(request);
+  const catalog = catalogs[locale];
+  const message = translateFn(catalog, key, params);
+  return jsonError(message, status, extra);
+}
+
+export function jsonError(
+  message: string,
+  status = 400,
+  extra?: Record<string, unknown>,
+): Response {
+  return new Response(JSON.stringify({ error: message, ...extra }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export async function parseJsonBody<T>(
+  request: Request,
+): Promise<{ data: T | null; error: Response | null }> {
+  try {
+    return { data: (await request.json()) as T, error: null };
+  } catch {
+    return { data: null, error: localizedJsonError(request, 'errors.invalidBody') };
+  }
+}

--- a/api/handlers/site.ts
+++ b/api/handlers/site.ts
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+import type { Site } from '../../types/index.js';
+import * as data from '../data.js';
+import { invalidateGlobalContentCache } from './cache-invalidation.js';
+import { parseJsonBody } from './shared.js';
+import type { HandlerContext } from './shared.js';
+
+export async function handleGetSite(): Promise<Response> {
+  return Response.json(await data.loadSite());
+}
+
+export async function handlePutSite(
+  request: Request,
+  context: HandlerContext = {},
+): Promise<Response> {
+  const { data: body, error } = await parseJsonBody<Partial<Site>>(request);
+  if (error || !body) return error as Response;
+
+  const existing = await data.loadSite();
+  const site = { ...existing, ...body };
+  await data.saveSite(site);
+  await invalidateGlobalContentCache(context.cache);
+  return Response.json(site);
+}


### PR DESCRIPTION
**Part of #35** — PR 2 of 8 in the chained decomposition of `api/handlers.ts` (P1-1). Stacked-to-main. Bases on PR1 (already merged).

## Summary
- **Stands up the shim.** `api/handlers.ts` becomes a hybrid re-export shim: moved definitions are removed and re-exposed via **explicit named re-exports** (never `export *`), keeping the public surface byte-stable.
- Proof-of-pattern slice — exercises the full shared → concern → domain → shim round-trip in the smallest domain (`site`), validating the decomposition pattern before the larger slices.
- **No behavior change.** All moved code is byte-verbatim (only `export` keywords + `../` → `../../` specifier depth adjusted).

## Changes
| File | Change |
|------|--------|
| `api/handlers/shared.ts` | New — stateless HTTP-response helpers (`jsonError`, `localizedJsonError`, `resolveRequestUiLocale`, `parseJsonBody`, `HandlerContext`/`AstroCache` types), moved verbatim |
| `api/handlers/cache-invalidation.ts` | New — 4 internal cache-invalidation helpers (used by 7/12 domains), distinct from the `handleInvalidateCache` route handler |
| `api/handlers/site.ts` | New — `handleGetSite`, `handlePutSite`, moved verbatim |
| `api/handlers.ts` | Converted to hybrid shim: internal imports + explicit named re-exports |

## Test plan (all four gates)
- [x] `tsc --noEmit` → clean
- [x] `npm run build` → ok
- [x] `node --test tests/*.test.js` → **1056 pass / 0 fail** (incl. `jwt-secret-hardening` 6/6, `handlers-export-baseline` 2/2)
- [x] `biome ci .` → **0 errors** (79 pre-existing warnings)
- [x] Byte-verbatim moves confirmed; public export surface unchanged (50 names)
- [x] No domain→domain imports / no cycle; `resolveRequestUiLocale` is module-internal only (not in the public shim surface)

## Notes
- Import-direction rule enforced: domains → shared/concern/utils only, never domain→domain.
- JWT singletons and media cache untouched (deferred to PR3/PR6). `handleInvalidateCache` route handler stays inline (PR8).
- Under the 400-line budget (~174 add / 130 del) — no `size:exception`.
