### PR TITLE
refactor(api): extract locale-resolution + schema-loading + languages domains (#35)

### DIFF
--- a/api/handlers.ts
+++ b/api/handlers.ts
@@ -6,10 +6,8 @@ Licensed under the Business Source License 1.1
 import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
 import { imageSize } from 'image-size';
 import { getGlobalCachePaths, getGlobalCacheTags } from '../utils/cache.js';
-import { validateBlocks } from '../utils/blocks.js';
 import {
   getDefaultLanguageCode,
   getLocalizedValue,
@@ -18,7 +16,7 @@ import {
   setLocalizedValue,
 } from '../utils/localization.js';
 import { joinSlugSegments, slugToPath, splitSlugSegments } from '../utils/slug.js';
-import { getProjectRoot, getUploadsDir, resolveUploadPath } from '../utils/paths.js';
+import { getUploadsDir, resolveUploadPath } from '../utils/paths.js';
 import { generateAndPersistVariants } from '../utils/variant-generator.js';
 import {
   DEFAULT_ALLOWED_FILE_TYPES,
@@ -33,18 +31,16 @@ import {
   validateRedirectPathInput,
 } from '../utils/redirects.js';
 import { validateBlockPropsAgainstSchema } from '../utils/block-validation.js';
-import { getLanguageLocaleKeys, normalizeLanguageCode } from '../utils/language-locales.js';
+import { getLanguageLocaleKeys } from '../utils/language-locales.js';
 import {
   mergeBlockPropsForLocale,
   projectBlockProps,
   removeLocaleFromLocalizedMap,
-  removeLocaleFromPage,
 } from '../utils/locale-projection.js';
 import type {
   AuthUser,
   BlockInstance,
   ConfigEntry,
-  ContentLanguage,
   GlobalBlockRuntimeEntry,
   LanguagesData,
   MediaEntry,
@@ -77,6 +73,8 @@ import {
   invalidatePageContentCache,
 } from './handlers/cache-invalidation.js';
 import { getAuth, requireOwner } from './handlers/auth-core.js';
+import { normalizeLocaleFromRequest, resolveLocaleFromBody } from './handlers/locale-resolution.js';
+import { ensureValidBlocks, loadSchemaMap } from './handlers/schema-loading.js';
 export { localizedJsonError } from './handlers/shared.js';
 export { handleGetSite, handlePutSite } from './handlers/site.js';
 export {
@@ -94,6 +92,12 @@ export {
   handlePutUser,
   handleDeleteUser,
 } from './handlers/users.js';
+export {
+  handleGetLanguages,
+  handlePostLanguages,
+  handlePutLanguage,
+  handleDeleteLanguage,
+} from './handlers/languages.js';
 
 const CONFIG_KEY_REGEX = /^[A-Za-z][A-Za-z0-9_.-]*$/;
 
@@ -193,55 +197,6 @@ function normalizePageSeo(input: unknown): SeoData {
     ...(typeof seo.image === 'string' && seo.image.trim() ? { image: seo.image.trim() } : {}),
     ...(seo.nofollow !== undefined ? { nofollow: Boolean(seo.nofollow) } : {}),
   };
-}
-
-function normalizeLocaleFromRequest(request: Request, languagesData: LanguagesData): string {
-  const url = new URL(request.url);
-  const queryLocale = normalizeLocaleCode(url.searchParams.get('locale'));
-  const headerLocale = normalizeLocaleCode(request.headers.get('x-cms-locale'));
-  const defaultLocale = getDefaultLanguageCode(languagesData);
-  const locale = queryLocale || headerLocale || defaultLocale;
-  return data.ensureLocaleAvailable(locale, languagesData);
-}
-
-function resolveLocaleFromBody(
-  body: Record<string, unknown>,
-  request: Request,
-  languagesData: LanguagesData,
-): string {
-  const bodyLocale = normalizeLocaleCode(typeof body.locale === 'string' ? body.locale : '');
-  return data.ensureLocaleAvailable(
-    bodyLocale || normalizeLocaleFromRequest(request, languagesData),
-    languagesData,
-  );
-}
-
-function ensureEnabledDefaultLanguage(
-  languages: ContentLanguage[],
-  preferredCode?: string,
-  fallbackToFirst = false,
-): ContentLanguage[] {
-  if (!Array.isArray(languages) || languages.length === 0) return languages;
-
-  let defaultCode = normalizeLanguageCode(preferredCode || '');
-  if (!defaultCode) {
-    const currentDefault = languages.find(
-      (language) => language.isDefault && language.enabled !== false,
-    );
-    defaultCode = normalizeLanguageCode(currentDefault?.code || '');
-  }
-  if (!defaultCode) {
-    const firstEnabled = languages.find((language) => language.enabled !== false);
-    defaultCode = normalizeLanguageCode(firstEnabled?.code || '');
-  }
-  if (!defaultCode && fallbackToFirst) {
-    defaultCode = normalizeLanguageCode(languages[0]?.code || '');
-  }
-
-  return languages.map((language) => ({
-    ...language,
-    isDefault: defaultCode ? normalizeLanguageCode(language.code) === defaultCode : false,
-  }));
 }
 
 /** Returns a catalog error key (not a user-facing string) or null. */
@@ -445,223 +400,6 @@ function projectPageForLocale(
       props: projectBlockProps(block, schemaMap, locale, localeKeys),
     })),
   };
-}
-
-async function loadSchemaMap(): Promise<{
-  schemaMap?: SchemaMap;
-  error?: string;
-  missing?: string[];
-}> {
-  const projectRoot = getProjectRoot();
-  const schemaMapPath = path.join(projectRoot, '.astro-blocks', 'schema-map.mjs');
-
-  try {
-    const schemaMapUrl = pathToFileURL(schemaMapPath).href;
-    const mod = (await import(/* @vite-ignore */ schemaMapUrl)) as { schemaMap?: SchemaMap };
-    const schemaMap = mod.schemaMap || {};
-    const missing = Object.entries(schemaMap)
-      .filter(([, value]) => value === undefined)
-      .map(([key]) => key);
-
-    if (missing.length > 0) return { error: 'Missing block schema', missing };
-
-    return { schemaMap };
-  } catch {
-    return { error: 'Failed to load block schemas', missing: [] };
-  }
-}
-
-async function ensureValidBlocks(blocks: unknown, request?: Request): Promise<Response | null> {
-  if (blocks === undefined) return null;
-
-  if (!Array.isArray(blocks) || blocks.length > 0) {
-    const result = await loadSchemaMap();
-    if (result.error) {
-      if (request)
-        return localizedJsonError(request, 'errors.loadBlockSchemasFailed', 500, undefined, {
-          missing: result.missing || [],
-        });
-      return jsonError(result.error, 500, { missing: result.missing || [] });
-    }
-
-    const validation = validateBlocks(result.schemaMap || {}, blocks);
-    if (validation) {
-      if (request && validation.messageKey) {
-        return localizedJsonError(request, validation.messageKey, 400, validation.params);
-      }
-      return jsonError(validation.message);
-    }
-  }
-
-  return null;
-}
-
-export async function handleGetLanguages(): Promise<Response> {
-  return Response.json(await data.loadLanguages());
-}
-
-export async function handlePostLanguages(
-  request: Request,
-  context: HandlerContext = {},
-): Promise<Response> {
-  const { data: body, error } = await parseJsonBody<Record<string, unknown>>(request);
-  if (error || !body) return error as Response;
-
-  const languagesData = await data.loadLanguages();
-  const code = normalizeLanguageCode(typeof body.code === 'string' ? body.code : '');
-  const label = typeof body.label === 'string' && body.label.trim() ? body.label.trim() : code;
-  const enabled = body.enabled !== false;
-  const isDefault = body.isDefault === true;
-
-  if (!code) return localizedJsonError(request, 'errors.languageCodeRequired');
-  if (!/^[a-z]{2,3}(?:-[a-z0-9]{2,8})*$/.test(code)) {
-    return localizedJsonError(request, 'errors.invalidLanguageCode');
-  }
-
-  if (languagesData.languages.some((language) => normalizeLanguageCode(language.code) === code)) {
-    return localizedJsonError(request, 'errors.languageCodeExists');
-  }
-
-  const newLanguage: ContentLanguage = { code, label, enabled, isDefault };
-  languagesData.languages.push(newLanguage);
-
-  if (isDefault) {
-    languagesData.languages = ensureEnabledDefaultLanguage(languagesData.languages, code);
-  }
-
-  if (
-    !languagesData.languages.some((language) => language.isDefault && language.enabled !== false)
-  ) {
-    languagesData.languages = ensureEnabledDefaultLanguage(languagesData.languages);
-  }
-
-  await data.saveLanguages(languagesData);
-  await invalidateGlobalContentCache(context.cache);
-  return Response.json(newLanguage);
-}
-
-export async function handlePutLanguage(
-  code: string,
-  request: Request,
-  context: HandlerContext = {},
-): Promise<Response> {
-  const normalizedCode = normalizeLanguageCode(code);
-  const { data: body, error } = await parseJsonBody<Record<string, unknown>>(request);
-  if (error || !body) return error as Response;
-
-  const languagesData = await data.loadLanguages();
-  const index = languagesData.languages.findIndex(
-    (language) => normalizeLanguageCode(language.code) === normalizedCode,
-  );
-  if (index === -1) return localizedJsonError(request, 'errors.notFound', 404);
-
-  const current = languagesData.languages[index];
-  const next: ContentLanguage = {
-    ...current,
-    label: typeof body.label === 'string' && body.label.trim() ? body.label.trim() : current.label,
-    enabled: body.enabled === undefined ? current.enabled : Boolean(body.enabled),
-    isDefault: body.isDefault === undefined ? current.isDefault : Boolean(body.isDefault),
-  };
-
-  languagesData.languages[index] = next;
-
-  if (next.isDefault) {
-    languagesData.languages = ensureEnabledDefaultLanguage(languagesData.languages, next.code);
-  }
-
-  if (!languagesData.languages.some((language) => language.enabled !== false)) {
-    return localizedJsonError(request, 'errors.mustHaveEnabledLanguage');
-  }
-
-  if (
-    !languagesData.languages.some((language) => language.isDefault && language.enabled !== false)
-  ) {
-    languagesData.languages = ensureEnabledDefaultLanguage(languagesData.languages);
-  }
-
-  await data.saveLanguages(languagesData);
-  await invalidateGlobalContentCache(context.cache);
-  return Response.json(languagesData.languages[index]);
-}
-
-export async function handleDeleteLanguage(
-  code: string,
-  context: HandlerContext = {},
-  request?: Request,
-): Promise<Response> {
-  const normalizedCode = normalizeLanguageCode(code);
-
-  const [languagesData, pagesData, menusData, schemaResult] = await Promise.all([
-    data.loadLanguages(),
-    data.loadPages(),
-    data.loadMenus(),
-    loadSchemaMap(),
-  ]);
-
-  const languageIndex = languagesData.languages.findIndex(
-    (language) => normalizeLanguageCode(language.code) === normalizedCode,
-  );
-  if (languageIndex === -1)
-    return request
-      ? localizedJsonError(request, 'errors.notFound', 404)
-      : jsonError('Not found', 404);
-  if (languagesData.languages.length <= 1) {
-    return request
-      ? localizedJsonError(request, 'errors.cannotDeleteLastLanguage')
-      : jsonError('Cannot delete the last language.');
-  }
-
-  const localeKeys = getLanguageLocaleKeys(languagesData);
-
-  const affectedPages = pagesData.pages.filter((page) => {
-    return Object.prototype.hasOwnProperty.call(page.status || {}, normalizedCode);
-  }).length;
-
-  const affectedMenus = menusData.menus.filter((menu) => {
-    return Object.prototype.hasOwnProperty.call(menu.items || {}, normalizedCode);
-  }).length;
-
-  pagesData.pages = pagesData.pages
-    .map((page) =>
-      removeLocaleFromPage(page, normalizedCode, schemaResult.schemaMap || null, localeKeys),
-    )
-    .filter(Boolean) as Page[];
-
-  menusData.menus = menusData.menus
-    .map((menu) => {
-      const items = { ...(menu.items || {}) };
-      delete items[normalizedCode];
-      if (Object.keys(items).length === 0) return null;
-      return { ...menu, items };
-    })
-    .filter(Boolean) as Menu[];
-
-  languagesData.languages.splice(languageIndex, 1);
-
-  if (
-    !languagesData.languages.some((language) => language.isDefault && language.enabled !== false)
-  ) {
-    languagesData.languages = ensureEnabledDefaultLanguage(
-      languagesData.languages,
-      undefined,
-      true,
-    );
-  }
-
-  await Promise.all([
-    data.savePages(pagesData),
-    data.saveMenus(menusData),
-    data.saveLanguages(languagesData),
-  ]);
-
-  await invalidateGlobalContentCache(context.cache);
-
-  return Response.json({
-    ok: true,
-    deletedLocale: normalizedCode,
-    affectedPages,
-    affectedMenus,
-  });
 }
 
 export async function handleGetPages(request: Request): Promise<Response> {

--- a/api/handlers/languages.ts
+++ b/api/handlers/languages.ts
@@ -1,0 +1,209 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+import { normalizeLanguageCode, getLanguageLocaleKeys } from '../../utils/language-locales.js';
+import { removeLocaleFromPage } from '../../utils/locale-projection.js';
+import type { ContentLanguage, Menu, Page } from '../../types/index.js';
+import * as data from '../data.js';
+import { invalidateGlobalContentCache } from './cache-invalidation.js';
+import { loadSchemaMap } from './schema-loading.js';
+import { jsonError, localizedJsonError, parseJsonBody } from './shared.js';
+import type { HandlerContext } from './shared.js';
+
+function ensureEnabledDefaultLanguage(
+  languages: ContentLanguage[],
+  preferredCode?: string,
+  fallbackToFirst = false,
+): ContentLanguage[] {
+  if (!Array.isArray(languages) || languages.length === 0) return languages;
+
+  let defaultCode = normalizeLanguageCode(preferredCode || '');
+  if (!defaultCode) {
+    const currentDefault = languages.find(
+      (language) => language.isDefault && language.enabled !== false,
+    );
+    defaultCode = normalizeLanguageCode(currentDefault?.code || '');
+  }
+  if (!defaultCode) {
+    const firstEnabled = languages.find((language) => language.enabled !== false);
+    defaultCode = normalizeLanguageCode(firstEnabled?.code || '');
+  }
+  if (!defaultCode && fallbackToFirst) {
+    defaultCode = normalizeLanguageCode(languages[0]?.code || '');
+  }
+
+  return languages.map((language) => ({
+    ...language,
+    isDefault: defaultCode ? normalizeLanguageCode(language.code) === defaultCode : false,
+  }));
+}
+
+export async function handleGetLanguages(): Promise<Response> {
+  return Response.json(await data.loadLanguages());
+}
+
+export async function handlePostLanguages(
+  request: Request,
+  context: HandlerContext = {},
+): Promise<Response> {
+  const { data: body, error } = await parseJsonBody<Record<string, unknown>>(request);
+  if (error || !body) return error as Response;
+
+  const languagesData = await data.loadLanguages();
+  const code = normalizeLanguageCode(typeof body.code === 'string' ? body.code : '');
+  const label = typeof body.label === 'string' && body.label.trim() ? body.label.trim() : code;
+  const enabled = body.enabled !== false;
+  const isDefault = body.isDefault === true;
+
+  if (!code) return localizedJsonError(request, 'errors.languageCodeRequired');
+  if (!/^[a-z]{2,3}(?:-[a-z0-9]{2,8})*$/.test(code)) {
+    return localizedJsonError(request, 'errors.invalidLanguageCode');
+  }
+
+  if (languagesData.languages.some((language) => normalizeLanguageCode(language.code) === code)) {
+    return localizedJsonError(request, 'errors.languageCodeExists');
+  }
+
+  const newLanguage: ContentLanguage = { code, label, enabled, isDefault };
+  languagesData.languages.push(newLanguage);
+
+  if (isDefault) {
+    languagesData.languages = ensureEnabledDefaultLanguage(languagesData.languages, code);
+  }
+
+  if (
+    !languagesData.languages.some((language) => language.isDefault && language.enabled !== false)
+  ) {
+    languagesData.languages = ensureEnabledDefaultLanguage(languagesData.languages);
+  }
+
+  await data.saveLanguages(languagesData);
+  await invalidateGlobalContentCache(context.cache);
+  return Response.json(newLanguage);
+}
+
+export async function handlePutLanguage(
+  code: string,
+  request: Request,
+  context: HandlerContext = {},
+): Promise<Response> {
+  const normalizedCode = normalizeLanguageCode(code);
+  const { data: body, error } = await parseJsonBody<Record<string, unknown>>(request);
+  if (error || !body) return error as Response;
+
+  const languagesData = await data.loadLanguages();
+  const index = languagesData.languages.findIndex(
+    (language) => normalizeLanguageCode(language.code) === normalizedCode,
+  );
+  if (index === -1) return localizedJsonError(request, 'errors.notFound', 404);
+
+  const current = languagesData.languages[index];
+  const next: ContentLanguage = {
+    ...current,
+    label: typeof body.label === 'string' && body.label.trim() ? body.label.trim() : current.label,
+    enabled: body.enabled === undefined ? current.enabled : Boolean(body.enabled),
+    isDefault: body.isDefault === undefined ? current.isDefault : Boolean(body.isDefault),
+  };
+
+  languagesData.languages[index] = next;
+
+  if (next.isDefault) {
+    languagesData.languages = ensureEnabledDefaultLanguage(languagesData.languages, next.code);
+  }
+
+  if (!languagesData.languages.some((language) => language.enabled !== false)) {
+    return localizedJsonError(request, 'errors.mustHaveEnabledLanguage');
+  }
+
+  if (
+    !languagesData.languages.some((language) => language.isDefault && language.enabled !== false)
+  ) {
+    languagesData.languages = ensureEnabledDefaultLanguage(languagesData.languages);
+  }
+
+  await data.saveLanguages(languagesData);
+  await invalidateGlobalContentCache(context.cache);
+  return Response.json(languagesData.languages[index]);
+}
+
+export async function handleDeleteLanguage(
+  code: string,
+  context: HandlerContext = {},
+  request?: Request,
+): Promise<Response> {
+  const normalizedCode = normalizeLanguageCode(code);
+
+  const [languagesData, pagesData, menusData, schemaResult] = await Promise.all([
+    data.loadLanguages(),
+    data.loadPages(),
+    data.loadMenus(),
+    loadSchemaMap(),
+  ]);
+
+  const languageIndex = languagesData.languages.findIndex(
+    (language) => normalizeLanguageCode(language.code) === normalizedCode,
+  );
+  if (languageIndex === -1)
+    return request
+      ? localizedJsonError(request, 'errors.notFound', 404)
+      : jsonError('Not found', 404);
+  if (languagesData.languages.length <= 1) {
+    return request
+      ? localizedJsonError(request, 'errors.cannotDeleteLastLanguage')
+      : jsonError('Cannot delete the last language.');
+  }
+
+  const localeKeys = getLanguageLocaleKeys(languagesData);
+
+  const affectedPages = pagesData.pages.filter((page) => {
+    return Object.prototype.hasOwnProperty.call(page.status || {}, normalizedCode);
+  }).length;
+
+  const affectedMenus = menusData.menus.filter((menu) => {
+    return Object.prototype.hasOwnProperty.call(menu.items || {}, normalizedCode);
+  }).length;
+
+  pagesData.pages = pagesData.pages
+    .map((page) =>
+      removeLocaleFromPage(page, normalizedCode, schemaResult.schemaMap || null, localeKeys),
+    )
+    .filter(Boolean) as Page[];
+
+  menusData.menus = menusData.menus
+    .map((menu) => {
+      const items = { ...(menu.items || {}) };
+      delete items[normalizedCode];
+      if (Object.keys(items).length === 0) return null;
+      return { ...menu, items };
+    })
+    .filter(Boolean) as Menu[];
+
+  languagesData.languages.splice(languageIndex, 1);
+
+  if (
+    !languagesData.languages.some((language) => language.isDefault && language.enabled !== false)
+  ) {
+    languagesData.languages = ensureEnabledDefaultLanguage(
+      languagesData.languages,
+      undefined,
+      true,
+    );
+  }
+
+  await Promise.all([
+    data.savePages(pagesData),
+    data.saveMenus(menusData),
+    data.saveLanguages(languagesData),
+  ]);
+
+  await invalidateGlobalContentCache(context.cache);
+
+  return Response.json({
+    ok: true,
+    deletedLocale: normalizedCode,
+    affectedPages,
+    affectedMenus,
+  });
+}

--- a/api/handlers/locale-resolution.ts
+++ b/api/handlers/locale-resolution.ts
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+import { getDefaultLanguageCode, normalizeLocaleCode } from '../../utils/localization.js';
+import type { LanguagesData } from '../../types/index.js';
+import * as data from '../data.js';
+
+export function normalizeLocaleFromRequest(request: Request, languagesData: LanguagesData): string {
+  const url = new URL(request.url);
+  const queryLocale = normalizeLocaleCode(url.searchParams.get('locale'));
+  const headerLocale = normalizeLocaleCode(request.headers.get('x-cms-locale'));
+  const defaultLocale = getDefaultLanguageCode(languagesData);
+  const locale = queryLocale || headerLocale || defaultLocale;
+  return data.ensureLocaleAvailable(locale, languagesData);
+}
+
+export function resolveLocaleFromBody(
+  body: Record<string, unknown>,
+  request: Request,
+  languagesData: LanguagesData,
+): string {
+  const bodyLocale = normalizeLocaleCode(typeof body.locale === 'string' ? body.locale : '');
+  return data.ensureLocaleAvailable(
+    bodyLocale || normalizeLocaleFromRequest(request, languagesData),
+    languagesData,
+  );
+}

--- a/api/handlers/schema-loading.ts
+++ b/api/handlers/schema-loading.ts
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { validateBlocks } from '../../utils/blocks.js';
+import { getProjectRoot } from '../../utils/paths.js';
+import type { SchemaMap } from '../../types/index.js';
+import { jsonError, localizedJsonError } from './shared.js';
+
+export async function loadSchemaMap(): Promise<{
+  schemaMap?: SchemaMap;
+  error?: string;
+  missing?: string[];
+}> {
+  const projectRoot = getProjectRoot();
+  const schemaMapPath = path.join(projectRoot, '.astro-blocks', 'schema-map.mjs');
+
+  try {
+    const schemaMapUrl = pathToFileURL(schemaMapPath).href;
+    const mod = (await import(/* @vite-ignore */ schemaMapUrl)) as { schemaMap?: SchemaMap };
+    const schemaMap = mod.schemaMap || {};
+    const missing = Object.entries(schemaMap)
+      .filter(([, value]) => value === undefined)
+      .map(([key]) => key);
+
+    if (missing.length > 0) return { error: 'Missing block schema', missing };
+
+    return { schemaMap };
+  } catch {
+    return { error: 'Failed to load block schemas', missing: [] };
+  }
+}
+
+export async function ensureValidBlocks(
+  blocks: unknown,
+  request?: Request,
+): Promise<Response | null> {
+  if (blocks === undefined) return null;
+
+  if (!Array.isArray(blocks) || blocks.length > 0) {
+    const result = await loadSchemaMap();
+    if (result.error) {
+      if (request)
+        return localizedJsonError(request, 'errors.loadBlockSchemasFailed', 500, undefined, {
+          missing: result.missing || [],
+        });
+      return jsonError(result.error, 500, { missing: result.missing || [] });
+    }
+
+    const validation = validateBlocks(result.schemaMap || {}, blocks);
+    if (validation) {
+      if (request && validation.messageKey) {
+        return localizedJsonError(request, validation.messageKey, 400, validation.params);
+      }
+      return jsonError(validation.message);
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
**Part of #35** — PR 4 of 8 in the chained decomposition of `api/handlers.ts` (P1-1). Stacked-to-main. Bases on PR1–PR3 (merged).

## Summary
- Extracts two data-coupled concern modules (`locale-resolution.ts`, `schema-loading.ts`) and the `languages.ts` domain out of the shim.
- **No behavior change** — verbatim moves; language mutation authz stays declarative at the route-table (independently confirmed: zero `requireOwner` in languages, `route-table.ts` unchanged).

## Changes
| File | Change |
|------|--------|
| `api/handlers/locale-resolution.ts` | New — `normalizeLocaleFromRequest`, `resolveLocaleFromBody` (data-coupled, call `data.ensureLocaleAvailable`) |
| `api/handlers/schema-loading.ts` | New — `loadSchemaMap`, `ensureValidBlocks` |
| `api/handlers/languages.ts` | New — `handleGetLanguages/PostLanguages/PutLanguage/DeleteLanguage` + private `ensureEnabledDefaultLanguage` |
| `api/handlers.ts` | Shim: pruned dead imports, added concern imports + explicit named re-exports for the 4 languages handlers |

## Test plan (all four gates)
- [x] `tsc --noEmit` → clean
- [x] `npm run build` → ok
- [x] `node --test tests/*.test.js` → **1056 pass / 0 fail**
- [x] `biome ci .` → **0 errors** (79 pre-existing warnings; count unchanged vs baseline)
- [x] Byte-verbatim moves confirmed via `git diff -w`; public surface unchanged (50 names); internal helpers not leaked
- [x] No domain→domain imports / no cycle; `route-table.ts` diff empty (authz unchanged)

## Notes
- `size:exception` — ~583 changed lines (verbatim move).
- Out-of-scope untouched: `handleGetBlockSchemas` (PR5), media cache (PR6), `handleInvalidateCache`/backup-routes (PR8).
