### PR TITLE
refactor(api): localize the unauthenticated 401 body in the CMS API dispatch

### DIFF
--- a/changes/archive/2026-07-08-localize-api-dispatch-401/design.md
+++ b/changes/archive/2026-07-08-localize-api-dispatch-401/design.md
@@ -1,0 +1,55 @@
+<!--
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+-->
+
+# Design — Localize the unauthenticated 401 body
+
+> This change introduces **no new design decision**. It applies an existing, already-approved
+> pattern (`localizedJsonError`) to two call sites for consistency. This document records the
+> mechanism, the two non-obvious nuances, and the alternatives considered, so the reviewer has the
+> full picture. No ADR is warranted (nothing here is non-obvious or reversible-costly).
+
+## Mechanism
+
+`localizedJsonError(request, key, status)` (`api/handlers/shared.ts`) resolves the request UI locale
+(`resolveRequestUiLocale` → `cms-ui-locale` cookie → `Accept-Language` → English fallback), looks
+the key up in the matching catalog, and returns `jsonError(message, status)` which serializes
+`{ error: message }` with `Content-Type: application/json`. It is re-exported from the `api/handlers.ts`
+shim, which `catchall.ts` already imports and already uses for the 404 sibling. So the change is a
+one-to-one substitution at two sites — no new imports, no new helpers.
+
+## Nuance 1 — info-hiding is preserved
+
+`dispatch()` returns 401 (not 404) for an **unmatched path when unauthenticated**, on purpose: it
+must not reveal whether a route exists to an unauthenticated caller. Because both 401 sites resolve
+the **same** key (`errors.unauthorized`), they produce byte-identical bodies. Localizing them does
+not create an oracle: "unknown path" and "known path, no auth" remain indistinguishable. The
+authenticated unmatched-path case keeps returning the localized 404, unchanged.
+
+## Nuance 2 — Content-Type correction (intended, minor)
+
+The current raw responses `new Response(JSON.stringify(...), { status: 401 })` omit the
+`Content-Type` header; `localizedJsonError`/`jsonError` add `application/json`. This aligns the 401
+with every other API error response. It is a behavior change only in the header, harmless to clients
+that parse by content, and desirable for correctness.
+
+## Alternatives considered
+
+- **Leave as-is.** Rejected — the whole point of #60 is removing the 401's inconsistency with 403/404.
+- **A bespoke inline localized response** instead of `localizedJsonError`. Rejected — it would
+  duplicate the resolver and diverge from the established pattern (`CONTEXT.md`: "bodyless/error
+  responses go through the shared helpers"). The helper already does exactly this.
+- **Centralize the 401 into the route-table layer.** Out of scope — that is a larger refactor of the
+  auth ladder; #60 is a targeted body-localization only.
+
+## Testing approach (TDD)
+
+The dispatch-level 401 body is **not** covered today: `tests/i18n-api-errors.test.js` localizes only
+`handleAuthMe`'s self-reported 401, not the `dispatch()` gate. TDD anchor:
+
+1. Add a failing test asserting the `dispatch()` 401 body is localized for both sites and both
+   locales (es → "No autorizado.", en → "Unauthorized.") — driven through the exported verb handlers,
+   consistent with `tests/catchall-authz-routing.test.js`.
+2. Apply the two-site substitution → test goes green.
+3. Confirm `tests/catchall-authz-routing.test.js` (status-only asserts) stays green.

--- a/changes/archive/2026-07-08-localize-api-dispatch-401/proposal.md
+++ b/changes/archive/2026-07-08-localize-api-dispatch-401/proposal.md
@@ -1,0 +1,62 @@
+<!--
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+-->
+
+# Proposal — Localize the unauthenticated 401 body in the CMS API dispatch
+
+- **Issue:** #60 (`enhancement`, `P3`, `refactor`)
+- **Status:** Proposed
+- **Slug:** `localize-api-dispatch-401`
+
+## Problem
+
+The central API dispatcher (`routes/api/catchall.ts`, introduced in #59) returns a plain,
+non-localized body for unauthenticated requests: `{ error: "Unauthorized" }`. Its sibling
+responses in the same `dispatch()` function are already localized:
+
+- **403** → `requireOwner(...)` → `localizedJsonError`
+- **404** → `localizedJsonError(request, "errors.notFound", 404)`
+
+So the **401** is the odd one out. This is not a regression — #59 deliberately preserved the
+plain 401 to keep the route-table refactor behavior-equivalent (identical status codes across all
+43 routes). #60 is the intentionally deferred consistency follow-up.
+
+## Proposed change
+
+Replace the **two** hardcoded 401 responses in `dispatch()` with the existing localized pattern:
+
+```ts
+// before
+return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+// after
+return localizedJsonError(request, 'errors.unauthorized', 401);
+```
+
+Both call sites (`routes/api/catchall.ts` L57 and L67) are affected:
+
+- **L57** — unmatched path + unauthenticated → 401 (info-hiding: never 404, so route existence is
+  not leaked).
+- **L67** — matched route that requires auth, no session → 401.
+
+The `errors.unauthorized` i18n key already exists in both catalogs
+(`routes/admin/i18n/en.ts` → "Unauthorized.", `routes/admin/i18n/es.ts` → "No autorizado."), and
+`localizedJsonError` already preserves the `{ error: string }` wire shape, so no new key, catalog
+entry, or response shape is introduced.
+
+## Consequences (summary — see `design.md`)
+
+- Both 401 bodies become locale-aware (resolved from the request, like 403/404).
+- Info-hiding is preserved: both sites return the **same** localized body, so an unauthenticated
+  caller still cannot distinguish "route exists" from "route does not exist".
+- Side effect: `localizedJsonError` also sets `Content-Type: application/json`, which the raw 401
+  responses currently omit — a small, desirable correction.
+- HTTP **status is unchanged (401)**, so the 43 router-level authz tests (which assert status only)
+  stay green.
+
+## No-goals
+
+- No change to status codes, the auth ladder, or route matching.
+- No new i18n keys or catalogs.
+- No change to `handleAuthMe`'s self-reported 401 (already localized and separately tested).
+- No ADR: this applies an existing pattern for consistency; it is not a non-obvious decision.

--- a/changes/archive/2026-07-08-localize-api-dispatch-401/spec-delta.md
+++ b/changes/archive/2026-07-08-localize-api-dispatch-401/spec-delta.md
@@ -1,0 +1,67 @@
+<!--
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+-->
+
+# Spec delta — Localize the unauthenticated 401 body
+
+`specs/` does not exist yet; this change **inaugurates** it. The `ADDED` section below is the first
+living spec (`specs/api-dispatch.md`) and describes the auth ladder in its **post-#60** state — at
+Archive it is written verbatim into `specs/`. The `MODIFIED` section records the specific transition
+#60 introduces relative to the pre-#60 (post-#59) behavior.
+
+---
+
+## ADDED: `specs/api-dispatch.md` — CMS API dispatch & auth ladder
+
+**Capability.** All CMS REST traffic enters through one injected catchall
+(`routes/api/catchall.ts`) whose five per-verb exports delegate to a single `dispatch()`. Requests
+are matched against the route table (`api/route-table.ts` + `api/route-matcher.ts`); each route
+declares an auth tier: `public`, `user`, or `owner`.
+
+**Requirements.**
+
+- **R1 — Route matching.** `dispatch()` strips the `/cms/api` prefix, matches `(method, segments)`
+  against the route table, and either resolves a `{ descriptor, params }` or no match.
+- **R2 — Public tier.** A matched `public` route runs its handler unconditionally (no auth required),
+  receiving `user: auth?.user ?? null`.
+- **R3 — Auth ladder.** For a matched non-public route:
+  - unauthenticated → **401** with a **localized** body `{ error }`.
+  - authenticated but `owner`-tier and caller is not the owner → **403** (localized, via `requireOwner`).
+  - otherwise → the handler runs with the resolved `user`.
+- **R4 — Unmatched path (info-hiding).** An unmatched path returns:
+  - **401** (localized) when the caller is unauthenticated — deliberately **not** 404, so route
+    existence is not disclosed to anonymous callers.
+  - **404** (localized, `errors.notFound`) when the caller is authenticated.
+- **R5 — Localized error bodies.** All 401/403/404 responses use `localizedJsonError`, which resolves
+  the request UI locale (`cms-ui-locale` cookie → `Accept-Language` → English fallback), preserves the
+  `{ error: string }` wire shape, and sets `Content-Type: application/json`.
+- **R6 — Info-hiding is body-stable.** The unmatched-unauthenticated 401 (R4) and the matched-route
+  unauthenticated 401 (R3) return byte-identical bodies (same `errors.unauthorized` key), so the two
+  cases are indistinguishable to an anonymous caller.
+
+**Scenarios.**
+
+- Unauthenticated `PUT /cms/api/site` with `Accept-Language: es` → 401, body `{ error: "No autorizado." }`.
+- Unauthenticated `GET /cms/api/does-not-exist` → 401 (never 404), body localized, indistinguishable
+  from R3's 401.
+- Authenticated non-owner `GET /cms/api/users` → 403 (localized).
+- Authenticated `GET /cms/api/does-not-exist` → 404 (`errors.notFound`, localized).
+
+---
+
+## MODIFIED: unauthenticated 401 response body
+
+**Before (#59 baseline):** both 401 sites in `dispatch()` returned a raw, non-localized body
+`{ error: "Unauthorized" }` with no `Content-Type` header — inconsistent with the already-localized
+403 and 404 siblings.
+
+**After (#60):** both sites return `localizedJsonError(request, "errors.unauthorized", 401)` →
+locale-aware `{ error }` body plus `Content-Type: application/json`. Status (401) unchanged; the auth
+ladder and route matching are unchanged. Satisfies R3, R4, R5, R6 above.
+
+---
+
+## REMOVED
+
+_None._

--- a/changes/archive/2026-07-08-localize-api-dispatch-401/tasks.md
+++ b/changes/archive/2026-07-08-localize-api-dispatch-401/tasks.md
@@ -1,0 +1,61 @@
+<!--
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+-->
+
+# Tasks — Localize the unauthenticated 401 body
+
+One vertical slice (the whole change is a two-site substitution guarded by one new test).
+Executed straight-through with TDD discipline in the Implement phase. Mark each `[x]` as it lands.
+
+Test note: this repo's tests import the **compiled** `dist/`, so every run is
+`npm run build && node --test …` (per `CONTEXT.md` / ADR-0002).
+
+## Slice 1 — Dispatch 401 body localization
+
+- [x] **T0 — Branch.** Create `refactor/localize-api-dispatch-401` off `main` (currently on `main`;
+      never commit the change straight to the default branch).
+      - Verify: `git rev-parse --abbrev-ref HEAD` → `refactor/localize-api-dispatch-401`.
+
+- [x] **T1 — RED: failing test for the localized dispatch 401.**
+      - File: `tests/i18n-api-errors.test.js` — add a section "dispatch 401 localization" driving the
+        catchall verb exports (`dist/routes/api/catchall.js`), unauthenticated (no token):
+        - matched route (`PUT /cms/api/site`), `Accept-Language: es` → `status 401`, `body.error === "No autorizado."`
+        - same, `Accept-Language: en` (or no header) → `body.error === "Unauthorized."`
+        - unmatched path (`GET /cms/api/does-not-exist`), `es` → `status 401`, `body.error === "No autorizado."`
+          (proves R4 info-hiding + R6 body-stable)
+      - Also assert `Content-Type` is `application/json` on the 401.
+      - Verify: `npm run build && node --test tests/i18n-api-errors.test.js` → new cases FAIL
+        (current body is `{error:"Unauthorized"}`, no Content-Type), pre-existing cases still pass.
+
+- [x] **T2 — GREEN: substitute both 401 sites.**
+      - File: `routes/api/catchall.ts` — replace the two
+        `new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })` at L57 (unmatched-path
+        unauthenticated) and L67 (matched-route unauthenticated) with
+        `localizedJsonError(request, 'errors.unauthorized', 401)`. `localizedJsonError` is already imported
+        (L24); `request` is in scope in `dispatch()`.
+      - Verify: `npm run build && node --test tests/i18n-api-errors.test.js` → new cases GREEN.
+
+- [x] **T3 — Refactor + full gate.**
+      - No structural refactor expected (2-line change). Confirm no dead code / no other hardcoded
+        `"Unauthorized"` bodies remain in `routes/` or `api/` (grep).
+      - Verify (all exit 0):
+        - `npm run build && node --test tests/*.test.js` — full suite green, especially
+          `tests/catchall-authz-routing.test.js` (status-only asserts, must stay green).
+        - `npx tsc --noEmit`
+        - `npx biome ci .` (if the changed test file trips a format error, `npx biome format --write`
+          it — never `biome check --write`, per ADR-0013).
+
+- [x] **T4 — Commit (dev commit, no version bump).**
+      - Conventional Commit, English, with `Reviewed-by: Nauel Gómez <ngomez@codiara.com>` footer; no
+        agent/bot trailers. Message:
+        `refactor(api): localize the unauthenticated 401 body in the CMS API dispatch (#60)`
+      - No `package.json`/`CHANGELOG` bump here — versioning happens only at the explicit close/release
+        gate the human triggers (per `AGENTS.md` › Versionado).
+      - Verify: `git log --oneline -1` shows the commit on the feature branch; working tree clean.
+
+## Out of this slice (deferred)
+
+- Push + open PR for #60 — a "close" action; only on explicit request.
+- Version bump / `CHANGELOG` entry — only at the release gate.
+- `specs/` inauguration write — happens in the **Archive** phase from `spec-delta.md`, not here.

--- a/routes/api/catchall.ts
+++ b/routes/api/catchall.ts
@@ -54,7 +54,7 @@ async function dispatch(method: HttpMethod, context: APIContext): Promise<Respon
   const auth = await handlers.getAuth(request);
 
   if (!match) {
-    if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+    if (!auth) return localizedJsonError(request, 'errors.unauthorized', 401);
     return localizedJsonError(request, 'errors.notFound', 404);
   }
 
@@ -64,7 +64,7 @@ async function dispatch(method: HttpMethod, context: APIContext): Promise<Respon
     return descriptor.handler({ request, cache, params, user: auth?.user ?? null });
   }
 
-  if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  if (!auth) return localizedJsonError(request, 'errors.unauthorized', 401);
 
   if (descriptor.auth === 'owner') {
     const forbidden = handlers.requireOwner(auth.user, request);

--- a/specs/api-dispatch.md
+++ b/specs/api-dispatch.md
@@ -1,0 +1,53 @@
+<!--
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+-->
+
+# Spec — CMS API dispatch & auth ladder
+
+> Living specification. Describes the current behavior of the CMS REST entry point. Changed via the
+> cycle's `spec-delta.md` mechanism (see `AGENTS.md`). History: inaugurated by change
+> `localize-api-dispatch-401` (#60).
+
+## Capability
+
+All CMS REST traffic enters through one injected catchall (`routes/api/catchall.ts`) whose five
+per-verb exports (`GET`/`POST`/`PUT`/`PATCH`/`DELETE`) delegate to a single `dispatch()`. Requests
+are matched against the route table (`api/route-table.ts` + `api/route-matcher.ts`); each route
+declares an auth tier: `public`, `user`, or `owner`.
+
+## Requirements
+
+- **R1 — Route matching.** `dispatch()` strips the `/cms/api` prefix, matches `(method, segments)`
+  against the route table, and either resolves a `{ descriptor, params }` or no match.
+- **R2 — Public tier.** A matched `public` route runs its handler unconditionally (no auth required),
+  receiving `user: auth?.user ?? null`.
+- **R3 — Auth ladder.** For a matched non-public route:
+  - unauthenticated → **401** with a **localized** body `{ error }`.
+  - authenticated but `owner`-tier and caller is not the owner → **403** (localized, via `requireOwner`).
+  - otherwise → the handler runs with the resolved `user`.
+- **R4 — Unmatched path (info-hiding).** An unmatched path returns:
+  - **401** (localized) when the caller is unauthenticated — deliberately **not** 404, so route
+    existence is not disclosed to anonymous callers.
+  - **404** (localized, `errors.notFound`) when the caller is authenticated.
+- **R5 — Localized error bodies.** All 401/403/404 responses use `localizedJsonError`, which resolves
+  the request UI locale (`cms-ui-locale` cookie → `Accept-Language` → English fallback), preserves the
+  `{ error: string }` wire shape, and sets `Content-Type: application/json`. The 401 uses the
+  `errors.unauthorized` key (en: "Unauthorized.", es: "No autorizado.").
+- **R6 — Info-hiding is body-stable.** The unmatched-unauthenticated 401 (R4) and the matched-route
+  unauthenticated 401 (R3) return byte-identical bodies (same `errors.unauthorized` key), so the two
+  cases are indistinguishable to an anonymous caller.
+
+## Scenarios
+
+- Unauthenticated `PUT /cms/api/site` with `Accept-Language: es` → 401, `{ error: "No autorizado." }`.
+- Unauthenticated `PUT /cms/api/site`, no locale requested → 401, `{ error: "Unauthorized." }`.
+- Unauthenticated `GET /cms/api/does-not-exist` → 401 (never 404), body localized and identical to the
+  matched-route 401 for the same locale.
+- Authenticated non-owner `GET /cms/api/users` → 403 (localized).
+- Authenticated `GET /cms/api/does-not-exist` → 404 (`errors.notFound`, localized).
+
+## Coverage
+
+- `tests/catchall-authz-routing.test.js` — the 401→403→404 status ladder across every auth tier.
+- `tests/catchall-401-localization.test.js` — R3/R4/R5/R6 localized-body behavior (#60).

--- a/tests/catchall-401-localization.test.js
+++ b/tests/catchall-401-localization.test.js
@@ -1,0 +1,103 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * catchall-401-localization.test.js — issue #60.
+ *
+ * The central dispatch() (routes/api/catchall.ts) must return a LOCALIZED body for the
+ * unauthenticated 401, consistent with its 403/404 siblings. Two call sites:
+ *   - matched route requiring auth, no session      -> 401 (localized)
+ *   - unmatched path, unauthenticated (info-hiding)  -> 401 (localized, never 404)
+ *
+ * Drives the exported verb handlers directly (same harness as catchall-authz-routing.test.js).
+ * Locale resolution order is cookie > Accept-Language > 'en' (api/handlers/shared.ts).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { ensureDefaultFiles } from '../dist/api/data.js';
+import { GET, PUT } from '../dist/routes/api/catchall.js';
+
+async function withTempProject(fn) {
+  const previousRoot = process.env.ASTRO_BLOCKS_PROJECT_ROOT;
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'astro-blocks-catchall-401-'));
+  process.env.ASTRO_BLOCKS_PROJECT_ROOT = tempRoot;
+  await ensureDefaultFiles();
+  try {
+    await fn(tempRoot);
+  } finally {
+    if (previousRoot === undefined) delete process.env.ASTRO_BLOCKS_PROJECT_ROOT;
+    else process.env.ASTRO_BLOCKS_PROJECT_ROOT = previousRoot;
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+/** Minimal APIContext stub. cache disabled so handlers skip invalidation. */
+function ctx(request) {
+  return { request, cache: { enabled: false } };
+}
+
+/** Unauthenticated request, optional Accept-Language to drive locale resolution. */
+function unauthReq(url, method, { acceptLanguage } = {}) {
+  const headers = {};
+  if (acceptLanguage) headers['Accept-Language'] = acceptLanguage;
+  return new Request(url, { method, headers });
+}
+
+// ── Matched route requiring auth (routes/api/catchall.ts L67) ─────────────────
+
+test('401 on a matched auth route is localized to Spanish (Accept-Language: es)', async () => {
+  await withTempProject(async () => {
+    const res = await PUT(
+      ctx(unauthReq('http://localhost/cms/api/site', 'PUT', { acceptLanguage: 'es' })),
+    );
+    assert.equal(res.status, 401);
+    assert.equal(res.headers.get('content-type'), 'application/json');
+    const body = await res.json();
+    assert.equal(body.error, 'No autorizado.');
+  });
+});
+
+test('401 on a matched auth route falls back to English when no locale is requested', async () => {
+  await withTempProject(async () => {
+    const res = await PUT(ctx(unauthReq('http://localhost/cms/api/site', 'PUT')));
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.equal(body.error, 'Unauthorized.');
+  });
+});
+
+// ── Unmatched path, unauthenticated — info-hiding 401 (catchall.ts L57) ────────
+
+test('401 on an unmatched path (info-hiding) is localized, never a 404', async () => {
+  await withTempProject(async () => {
+    const res = await GET(
+      ctx(unauthReq('http://localhost/cms/api/does-not-exist', 'GET', { acceptLanguage: 'es' })),
+    );
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.equal(body.error, 'No autorizado.');
+  });
+});
+
+// ── R6: both 401 bodies are byte-identical (info-hiding stays an oracle-free gate) ──
+
+test('matched-route and unmatched-path 401 bodies are identical for the same locale', async () => {
+  await withTempProject(async () => {
+    const matched = await PUT(
+      ctx(unauthReq('http://localhost/cms/api/site', 'PUT', { acceptLanguage: 'es' })),
+    );
+    const unmatched = await GET(
+      ctx(unauthReq('http://localhost/cms/api/does-not-exist', 'GET', { acceptLanguage: 'es' })),
+    );
+    assert.equal(matched.status, 401);
+    assert.equal(unmatched.status, 401);
+    assert.deepEqual(await matched.json(), await unmatched.json());
+  });
+});


### PR DESCRIPTION
## What

Localizes the unauthenticated **401** body in the central CMS API dispatch (`routes/api/catchall.ts`),
making it consistent with its already-localized **403** and **404** siblings.

Both 401 sites in `dispatch()` returned a plain, non-localized `{ error: "Unauthorized" }` with no
`Content-Type`:

- the matched-route auth gate (route requires auth, no session), and
- the unmatched-path **info-hiding** gate (unauthenticated unknown path → 401, never 404).

Both now use `localizedJsonError(request, "errors.unauthorized", 401)` → locale-aware `{ error }`
body + `application/json` header. The `errors.unauthorized` key already exists (en: "Unauthorized.",
es: "No autorizado.").

## Why

Follow-up consistency improvement intentionally deferred by #59 (which kept the plain 401 to keep the
route-table refactor behavior-equivalent).

## Notes

- **Status unchanged (401)** — the 43 router-level authz tests (status-only asserts) stay green.
- **Info-hiding preserved** — both sites emit an identical localized body, so an anonymous caller still
  cannot tell "route exists" from "route does not exist".
- Minor observable change: the English body text is now `"Unauthorized."` (catalog value) and a
  `Content-Type: application/json` header is present.
- Inaugurates `specs/api-dispatch.md` (living spec of the 401/403/404 auth ladder).

## Test plan

- New `tests/catchall-401-localization.test.js` — drives the catchall verb exports unauthenticated and
  asserts the localized body (es/en), the `Content-Type`, and R6 body-stability (both 401s identical).
- Full suite: **1060/1060** · `tsc --noEmit` clean · `biome ci .` 0 errors.

Closes #60
