### PR TITLE
docs(adr): accept ADR-0007..0020 after verifying each against the code

### DIFF
--- a/docs/adr/0007-token-in-header-auth-no-csrf.md
+++ b/docs/adr/0007-token-in-header-auth-no-csrf.md
@@ -5,7 +5,7 @@ Licensed under the Business Source License 1.1
 
 # 0007 — Token-in-header JWT auth model (no CSRF surface)
 
-- **Status:** Draft — proposed (triaged from engram memory, awaiting review)
+- **Status:** Accepted — verified against the code on 2026-07-14
 - **Date:** 2026-06-30
 - **Source:** engram observation #1865
 

--- a/docs/adr/0008-json-file-store-atomic-write-mutex.md
+++ b/docs/adr/0008-json-file-store-atomic-write-mutex.md
@@ -5,9 +5,16 @@ Licensed under the Business Source License 1.1
 
 # 0008 — JSON file store: atomic write + per-file mutex
 
-- **Status:** Draft — proposed (triaged from engram memory, awaiting review)
+- **Status:** Accepted — verified against the code on 2026-07-14
 - **Date:** 2026-06-13
 - **Source:** engram observation #805
+
+> **Compliance note (2026-07-14).** Verified against the code. Atomic `writeJson` and the media
+> mutex are implemented — and lock coverage is in fact *wider* than this ADR claims (alt update, byte
+> replace and variant markers are locked too). **One write escapes the seam:** `src/api/backup.ts:651`
+> calls the exported, unlocked `data.saveMedia()` during restore, holding only `withUsersLock` — a
+> different key. That is a lost-update window against a concurrent upload. The comment at
+> `src/api/backup.ts:577-586` asserts the opposite of what line 651 does. Tracked in **#100**.
 
 ## Context
 

--- a/docs/adr/0009-runtime-registry-resolution.md
+++ b/docs/adr/0009-runtime-registry-resolution.md
@@ -5,9 +5,18 @@ Licensed under the Business Source License 1.1
 
 # 0009 — Runtime registry resolution for injected & precompiled routes
 
-- **Status:** Draft — proposed (triaged from engram memory, awaiting review)
+- **Status:** Accepted — verified against the code on 2026-07-14
 - **Date:** 2026-04-21
 - **Source:** engram observations #139, #1907
+
+> **Compliance note (2026-07-14).** Verified against the code. For the **global-blocks registry** the
+> decision is fully implemented: Vite alias for pages, `import.meta.env` bake for the precompiled API
+> route, no swallowing catch on the page side. **The schema map got only the fragile half:**
+> `generateRuntime()` emits `schema-map.mjs` too (`src/plugin/index.ts:177-181`), but it is never baked —
+> `src/api/handlers/schema-loading.ts:19-34` resolves it from disk only, behind a swallowing
+> `catch { return { error: ... } }`. That is the exact deployment failure mode this ADR exists to
+> eliminate, reproduced one layer over. Page-save validation and global-block PUT depend on it.
+> Tracked in **#101**.
 
 ## Context
 

--- a/docs/adr/0010-ssr-adapter-config-guard.md
+++ b/docs/adr/0010-ssr-adapter-config-guard.md
@@ -5,7 +5,7 @@ Licensed under the Business Source License 1.1
 
 # 0010 — SSR adapter required via config-time guard, not peerDependency
 
-- **Status:** Draft — proposed (triaged from engram memory, awaiting review)
+- **Status:** Accepted — verified against the code on 2026-07-14
 - **Date:** 2026-07-06
 - **Source:** engram observations #1950, #1949
 

--- a/docs/adr/0011-canonical-html-escaper.md
+++ b/docs/adr/0011-canonical-html-escaper.md
@@ -5,9 +5,19 @@ Licensed under the Business Source License 1.1
 
 # 0011 — Single canonical context-aware HTML escaper
 
-- **Status:** Draft — proposed (triaged from engram memory, awaiting review)
+- **Status:** Accepted — verified against the code on 2026-07-14
 - **Date:** 2026-07-07
 - **Source:** engram observations #1980, #1984
+
+> **Compliance note (2026-07-14).** Verified against the code. The *one implementation* rule holds:
+> `src/utils/html-escape.ts` is the only escaper in the repo, and all six `src/routes/admin/client/*.ts`
+> modules import from it. **But two admin pages use no escaper at all** —
+> `src/routes/admin/languages.astro:255-264` and `src/routes/admin/users.astro:226-233` build
+> `innerHTML` by concatenating API data into both text and attribute contexts. That is a stored XSS
+> (owner-privileged to plant; see the issue for the severity reasoning). CI misses it twice over: the
+> guard test (`tests/html-escape-attr-guard.test.js:44-51`) only covers `client/*.ts`, and `biome.json`
+> excludes `**/*.astro`. Note also that `src/utils/html-escape.ts:9` claims to be canonical "for the
+> whole codebase" — a claim the code does not currently earn. Tracked in **#99**.
 
 ## Context
 

--- a/docs/adr/0012-handlers-decomposition-nodenext-shim.md
+++ b/docs/adr/0012-handlers-decomposition-nodenext-shim.md
@@ -5,7 +5,7 @@ Licensed under the Business Source License 1.1
 
 # 0012 — Decompose api/handlers.ts behind a NodeNext re-export shim
 
-- **Status:** Draft — proposed (triaged from engram memory, awaiting review)
+- **Status:** Accepted — verified against the code on 2026-07-14
 - **Date:** 2026-07-07
 - **Source:** engram observation(s) #1996, #2001
 

--- a/docs/adr/0013-biome-ci-gate.md
+++ b/docs/adr/0013-biome-ci-gate.md
@@ -5,9 +5,18 @@ Licensed under the Business Source License 1.1
 
 # 0013 — Adopt Biome as a CI gate separate from tests
 
-- **Status:** Draft — proposed (triaged from engram memory, awaiting review)
+- **Status:** Accepted — verified against the code on 2026-07-14
 - **Date:** 2026-07-07
 - **Source:** engram observation(s) #1959, #2004, #1978
+
+> **Compliance note (2026-07-14).** Verified against the code. The decision holds: `npm run check`
+> (`biome ci .`) is its own CI step in job `validate`, independent of `npm test`, and `e2e` needs
+> `validate`. **But the gate is narrower than "`biome ci .`" reads.** `biome.json` `files.includes` is an
+> allowlist (`src/`, `scripts/`, `tests/`, `e2e/`), so root configs, `playgrounds/` and `docs/` are out
+> of scope; `!**/*.astro` leaves the several hundred lines of inline TypeScript in the admin `.astro`
+> pages entirely unlinted — which is where the XSS in **#99** lives; and `!src/styles/**` excludes
+> `cms-admin.css` (**#95**). None of this falsifies the Decision — it is about *where the gate runs*,
+> not what it covers — but a reader will over-estimate the coverage.
 
 ## Context
 

--- a/docs/adr/0014-coverage-c8.md
+++ b/docs/adr/0014-coverage-c8.md
@@ -5,7 +5,7 @@ Licensed under the Business Source License 1.1
 
 # 0014 — Test coverage via c8; browser-only controllers excluded
 
-- **Status:** Draft — proposed (triaged from engram memory, awaiting review)
+- **Status:** Accepted — verified against the code on 2026-07-14
 - **Date:** 2026-06-15
 - **Source:** engram observation(s) #881, #885
 

--- a/docs/adr/0015-bootstrap-import-full-restore.md
+++ b/docs/adr/0015-bootstrap-import-full-restore.md
@@ -5,7 +5,7 @@ Licensed under the Business Source License 1.1
 
 # 0015 — Bootstrap import = full restore, gated only by zero-users
 
-- **Status:** Draft — proposed (triaged from engram memory, awaiting review)
+- **Status:** Accepted — verified against the code on 2026-07-14
 - **Date:** 2026-06-30
 - **Source:** engram observation(s) #1857, #1889
 

--- a/docs/adr/0016-image-field-value-model.md
+++ b/docs/adr/0016-image-field-value-model.md
@@ -5,7 +5,7 @@ Licensed under the Business Source License 1.1
 
 # 0016 — Image field value is a structured object (alt, dimensions, caption)
 
-- **Status:** Draft — proposed (triaged from engram memory, awaiting review)
+- **Status:** Accepted — verified against the code on 2026-07-14
 - **Date:** 2026-06-13
 - **Source:** engram observation(s) #807, #809, #849
 

--- a/docs/adr/0017-responsive-images-variant-generation.md
+++ b/docs/adr/0017-responsive-images-variant-generation.md
@@ -5,7 +5,7 @@ Licensed under the Business Source License 1.1
 
 # 0017 — Responsive images via sharp on-upload variant generation
 
-- **Status:** Draft — proposed (triaged from engram memory, awaiting review)
+- **Status:** Accepted — verified against the code on 2026-07-14
 - **Date:** 2026-06-14
 - **Source:** engram observation #827
 

--- a/docs/adr/0018-non-image-file-uploads.md
+++ b/docs/adr/0018-non-image-file-uploads.md
@@ -5,9 +5,18 @@ Licensed under the Business Source License 1.1
 
 # 0018 — Non-image file uploads: 'file' prop type + server-side denylist
 
-- **Status:** Draft — proposed (triaged from engram memory, awaiting review)
+- **Status:** Accepted — verified against the code on 2026-07-14
 - **Date:** 2026-06-29
 - **Source:** engram observation(s) #1833, #800
+
+> **Compliance note (2026-07-14).** Verified against the code. Everything load-bearing for security is
+> enforced server-side: the hard denylist runs **before** the allowlist (`src/utils/upload-gate.ts:100-119`,
+> `src/api/handlers/media.ts:110-118`), the stored extension is derived from the MIME map and never from
+> user input, and path containment is separator-safe. **But this ADR describes `intersectAccept()` as
+> computing the "effective allowlist", and that never reaches the server.** Its only call site is
+> `src/routes/admin/client/block-form.ts:996` — the media picker's browser-side filter. The upload
+> endpoint enforces the *global* allowlist only. Per-component `accept` is a UI affordance, not a
+> server-enforced constraint. Tracked in **#102**.
 
 ## Context
 

--- a/docs/adr/0019-media-lifecycle-delete-replace.md
+++ b/docs/adr/0019-media-lifecycle-delete-replace.md
@@ -5,9 +5,18 @@ Licensed under the Business Source License 1.1
 
 # 0019 — Media lifecycle: warn-and-allow delete, same-MIME keep-URL replace
 
-- **Status:** Draft — proposed (triaged from engram memory, awaiting review)
+- **Status:** Accepted — verified against the code on 2026-07-14
 - **Date:** 2026-06-14
 - **Source:** engram observation #857
+
+> **Compliance note (2026-07-14).** Verified against the code. Warn-and-allow delete, the 415 on MIME
+> mismatch, the keep-URL byte overwrite and `Cache-Control: no-cache` are all implemented and enforced.
+> **Two gaps.** (1) The usage scan does not cover a legacy plain-string `seo.image`:
+> `src/api/data.ts:497-508` guards on `typeof … === 'object'`, so such a page is never matched and the
+> delete confirms "used in 0 places" — a warn-and-allow design makes the warning *the* safety
+> mechanism, so a blind spot there is worse than no scan (**#103**). (2) Replace fires
+> `void generateAndPersistVariants(...)` without awaiting (`src/api/handlers/media.ts:437`), so the
+> promised `processing → ready` cycle is best-effort; there is no stuck-`processing` repair (**#96**).
 
 ## Context
 

--- a/docs/adr/0020-media-server-side-search-pagination.md
+++ b/docs/adr/0020-media-server-side-search-pagination.md
@@ -5,9 +5,20 @@ Licensed under the Business Source License 1.1
 
 # 0020 — Media library: server-side search + pagination
 
-- **Status:** Draft — proposed (triaged from engram memory, awaiting review)
+- **Status:** Accepted — verified against the code on 2026-07-14
 - **Date:** 2026-06-14
 - **Source:** engram observation #838
+
+> **Compliance note (2026-07-14).** Verified against the code. The **handler** is a line-for-line match
+> with this decision (`src/api/handlers/media.ts:240-265`), search and pagination really are
+> server-side, and the shared `fetchMedia()` utility the ADR could not verify does exist and is used by
+> both the grid and the picker. **The drift is at the consumer edges.** (1) The SSR first paint
+> (`src/routes/admin/media.astro:32-33`) renders the *entire* registry with no sort, filter or slice —
+> exactly what this ADR's Context rejects — and in a different order than the client re-render.
+> (2) The picker's `accept` filter runs client-side **after** the server's slice
+> (`src/routes/admin/client/block-form.ts:499-503`), so file-mode counts and paging are wrong. That is
+> the "each consumer re-implementing filtering client-side" this ADR set out to prevent. Tracked in
+> **#104**.
 
 ## Context
 


### PR DESCRIPTION
## What & why

All 14 ADRs (0007–0020) sat at **`Draft — proposed (triaged from engram memory, awaiting review)`**. They were produced by a knowledge triage and never went through an accept step. So rules the codebase *already enforces today* — the Biome CI gate, the atomic-write + mutex store, the handlers shim — were documented as non-binding drafts.

That is not a cosmetic problem. **An ADR that describes reality while calling itself a draft lies to its reader**, human or agent: it says "this is still open for discussion" when it is in fact law of the repo.

Each ADR was verified against the current code by an independent adversarial pass whose brief was to **falsify** it, not confirm it.

## Result

**8 fully implemented → `Accepted`, no notes**

`0007` token-in-header auth · `0010` SSR adapter guard · `0012` handlers shim · `0014` c8 coverage · `0015` bootstrap import · `0016` `ImageFieldValue` · `0017` sharp variants · `0013` Biome gate

Worth calling out: **ADR-0015 is ahead of its own text** — the login-vs-bootstrap hardening it lists as "deferred" is already implemented (`src/api/handlers/auth.ts:32-35`).

**6 hold as decisions, but the code violates them somewhere → `Accepted` + a Compliance note naming the violating `file:line` and its tracking issue**

| ADR | The gap | Issue |
|---|---|---|
| **0011** canonical escaper | The *one-implementation* rule holds — but `languages.astro:255-264` and `users.astro:226-233` use **no escaper at all**. Stored XSS (owner-privileged to plant). | **#99** |
| **0008** atomic write + mutex | `backup.ts:651` calls the exported, unlocked `saveMedia()` during restore. Lost-update window. The comment at `backup.ts:577-586` asserts the opposite. | **#100** |
| **0009** registry resolution | The schema map got only the fragile half: disk-only, no bake, swallowing `catch`. The exact failure mode this ADR exists to eliminate, one layer over. | **#101** |
| **0018** file uploads | The security-critical parts *are* enforced server-side. But `intersectAccept()` never reaches the server — per-component `accept` is a UI affordance the ADR describes as a constraint. | **#102** |
| **0019** media lifecycle | The usage scan misses a legacy string `seo.image`, so delete confirms "used in 0 places" when it is used. In a warn-and-allow design the warning **is** the safety mechanism. | **#103** |
| **0020** search + pagination | The handler is a line-for-line match. But the SSR first paint dumps the whole registry, and the picker filters client-side *after* the server's slice. | **#104** |

`0013` also carries a note: the gate is real, but `biome.json`'s allowlist plus `!**/*.astro` make `biome ci .` narrower than it reads — and the excluded `.astro` inline scripts are **exactly where the XSS in #99 lives**.

## Why `Accepted` rather than leaving the six as drafts

An implementation gap is a **bug**, not a reason to leave the decision in draft. Keeping them as drafts was the worst of both worlds: the rule was neither enforced *nor* documented as binding. Accepting the decision and tracking the violation is what makes the gap actionable.

## Checklist

- [x] **Conventional Commits** — body explains WHY.
- [x] Docs only. No code, no `dist/` impact, no behaviour change.
- [x] **No ADR prose rewritten.** The `Contexto` / `Decisión` / `Consecuencias` of every ADR is byte-untouched — the 8 clean ADRs show `1 insertion / 1 deletion` (the Status line, nothing else). An ADR is immutable; its **status** is lifecycle metadata, which is precisely what Nygard's `Proposed → Accepted` transition exists for. If a *decision* ever changes, it gets a new ADR that supersedes the old one — per `AGENTS.md`.
- [ ] CHANGELOG — not applicable (no user-facing change).

## Notes for reviewers

The six Compliance notes are placed **before** `## Context`, deliberately: a reader must learn that the code does not fully honour the decision *before* they read and trust the decision.

Depends on nothing; **#98** (archive + accept ADR-0021) is independent and can merge in either order.
