### PR TITLE
docs(release): changelog for 3.6.0 and the consumer config surface

### DIFF
--- a/AGENTS.consumer.md
+++ b/AGENTS.consumer.md
@@ -141,6 +141,104 @@ i18n?: {
 }
 ```
 
+### `allowedFileTypes`
+
+Which file types the media upload endpoint accepts.
+
+```ts
+allowedFileTypes?: string[]
+// default: ['image/jpeg', 'image/png', 'image/webp', 'image/svg+xml', 'image/gif', 'application/pdf']
+```
+
+**This SELECTS from a catalog; it does not invent types.** AstroBlocks derives the stored file
+extension from the validated MIME type (a security requirement — an SVG uploaded as `foo.jpg` and
+served inline is stored XSS), so it can only accept types it has a catalog row for.
+
+The catalog:
+
+| MIME | Stored as | Category | Enabled by default |
+|---|---|---|---|
+| `image/jpeg` | `.jpg` | image | ✅ |
+| `image/png` | `.png` | image | ✅ |
+| `image/webp` | `.webp` | image | ✅ |
+| `image/gif` | `.gif` | image | ✅ |
+| `image/svg+xml` | `.svg` | image | ✅ (served as a download) |
+| `image/avif` | `.avif` | image | — |
+| `application/pdf` | `.pdf` | document | ✅ |
+| `video/mp4` | `.mp4` | video | — |
+| `video/webm` | `.webm` | video | — |
+| `audio/mpeg` | `.mp3` | audio | — |
+
+**A MIME type with no catalog row fails the build**, naming it and listing what is supported. It is
+never silently ignored.
+
+Video and audio are in the catalog and **off by default**. To enable video:
+
+```ts
+allowedFileTypes: [
+  'image/jpeg', 'image/png', 'image/webp', 'image/svg+xml', 'image/gif',
+  'application/pdf',
+  'video/mp4',
+]
+```
+
+Once enabled, video and audio uploads are streamed to disk rather than buffered, and served with
+HTTP Range support so the browser can seek (Safari refuses to play a media source that does not
+answer a ranged request). They are **passthrough**: no dimensions, duration, poster frame or
+transcoding.
+
+A hard security denylist (HTML, JavaScript, executables, shell scripts) is **always enforced** and
+cannot be re-enabled by any setting.
+
+### `customFileTypes`
+
+Registers a file type the catalog does not cover.
+
+```ts
+customFileTypes?: Array<{ mime: string; ext: string; category: 'image' | 'video' | 'audio' | 'document' }>
+// default: []
+```
+
+```ts
+astroBlocks({
+  customFileTypes: [{ mime: 'application/zip', ext: '.zip', category: 'document' }],
+  allowedFileTypes: [...defaults, 'application/zip'],
+})
+```
+
+You supply the MIME, the extension and the category — **and nothing else**. Every registered type is
+served as `application/octet-stream` with `Content-Disposition: attachment`, always. You cannot make
+one render inline, and that is deliberate: a format AstroBlocks has never audited must not be able to
+execute in the CMS's own origin.
+
+The build fails if a registration is on the security denylist, shadows a builtin's MIME, or **borrows
+a builtin's extension** (files are served by extension, so it would be served under the builtin's
+rules).
+
+### `maxUploadBytes`
+
+Per-category upload ceiling, in bytes.
+
+```ts
+maxUploadBytes?: Partial<Record<'image' | 'video' | 'audio' | 'document', number>>
+// defaults: image 5 MB, document 10 MB, audio 20 MB, video 200 MB
+```
+
+There is also an `ASTRO_BLOCKS_MAX_UPLOAD_BYTES` **environment variable**: a single global limit
+applied to every category, read at runtime, so it takes effect **without a rebuild** — the only
+upload knob that does.
+
+**Most specific wins:**
+
+```
+limit(category) = maxUploadBytes[category]          // build-time, per category
+               ?? ASTRO_BLOCKS_MAX_UPLOAD_BYTES     // runtime, global
+               ?? the built-in default for that category
+```
+
+Set neither and images stay at 5 MB while video gets 200 MB. Set only the environment variable and
+that one number applies to everything.
+
 ---
 
 ## Block Development
@@ -203,7 +301,7 @@ Field types available in `items`:
 | `image` | Image with upload | Returns an `ImageFieldValue` object (`{ url, alt?, caption?, width?, height? }`); legacy bare strings are coerced. Render with `<BlockImage>` |
 | `link` | URL or path | Text input for href values |
 | `select` | Dropdown selection | Requires `options: string[]` |
-| `file` | Non-image file upload (PDF, etc.) | Returns a `FileFieldValue` object (`{ url, filename?, mimeType?, download? }`). Optional `accept?: string[]` (MIME subset) and `download?: boolean` meta. Use `fileDownloadUrl(value)` for server-enforced download. Import helpers from `./getFileValue` |
+| `file` | Non-image file upload (PDF, video, audio, …) | Returns a `FileFieldValue` object (`{ url, filename?, mimeType?, download? }`). Optional `accept?: string[]` (MIME subset of `allowedFileTypes`) and `download?: boolean` meta. Use `fileDownloadUrl(value)` for server-enforced download — **omit it for video/audio**, or the browser downloads the file instead of playing it. Import helpers from `./getFileValue` |
 | `array` | List of items | Requires `item` definition; supports sortable, minItems, maxItems |
 
 **Array field example:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,60 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [3.6.0] - 2026-07-14
+
+### Title
+
+Video and audio uploads, on a supported-file-type catalog
+
+### Fixed
+
+- **`allowedFileTypes` never reached the server.** The plugin passed the allowlist to the runtime
+  through a `vite.define` bridge that emitted an array literal, while the server guarded with
+  `typeof raw === 'string'` before parsing — so the guard rejected it and silently fell back to the
+  shipped defaults. **Any `allowedFileTypes` configuration was ignored, in every released version.**
+  This is what caused `type: 'file'` to reject an MP4 with `415 Unsupported Media Type` even with
+  `video/mp4` in the allowlist: the upload was refused by the allowlist gate, which never saw your
+  config.
+- **AVIF variants were served as `application/octet-stream`.** The responsive-image pipeline writes
+  `.avif` variants, and the serving route had no `.avif` entry in its extension map. They are now
+  served as `image/avif`.
+- **Uploads are authorised before the request body is read.** The size limit used to be checked
+  *after* the whole file had been buffered into memory, so a `413` rejected what the server had
+  already swallowed.
+
+### Added
+
+- **Video and audio uploads.** `video/mp4`, `video/webm` and `audio/mpeg` are supported file types.
+  They are **not enabled by default** — add them to `allowedFileTypes` to opt in.
+- **HTTP Range support on `/uploads/*`.** Responses advertise `Accept-Ranges`, answer a satisfiable
+  `Range` with `206 Partial Content`, and an unsatisfiable one with `416`. Without this, Safari
+  refuses to play a video at all — it requests the first two bytes of a media source and discards any
+  source that does not answer. Files are now streamed from disk rather than read whole into memory,
+  for every file type.
+- **`customFileTypes`** — register a file type the catalog does not cover:
+  `customFileTypes: [{ mime: 'application/zip', ext: '.zip', category: 'document' }]`. You supply the
+  MIME, the extension and the category and nothing else: every registered type is served as
+  `application/octet-stream` with `Content-Disposition: attachment`, always. The security denylist
+  still applies, and a registration may not borrow a builtin's extension.
+- **`maxUploadBytes`** — per-category upload ceilings (image 5 MB, document 10 MB, audio 20 MB, video
+  200 MB by default). `ASTRO_BLOCKS_MAX_UPLOAD_BYTES` remains a global runtime limit; the most
+  specific setting wins.
+
+### Changed
+
+- **`allowedFileTypes` now selects from a catalog of supported types.** The extension a file is stored
+  under is derived from its validated MIME type — a security requirement — so AstroBlocks can only
+  accept types it has an extension for. **A MIME type with no catalog row now fails the build**,
+  naming it and listing what is supported, instead of being silently ignored and rejecting every
+  upload of that type at runtime with a `415`.
+- Video, audio and document uploads are **streamed to disk** instead of buffered in memory. Images
+  still buffer, because the image pipeline needs the bytes resident.
+- `fileCategory` on a media entry widens to `'image' | 'video' | 'audio' | 'document'`, and the media
+  library and block picker render a category icon for each. Existing entries are unaffected.
+- Video and audio are **passthrough**: no dimensions, duration, poster frame or transcoding, and no
+  new native dependency.
+
 ## [3.5.4] - 2026-07-14
 
 ### Title


### PR DESCRIPTION
Prep for the 3.6.0 release. No source changes.

- **`CHANGELOG.md`** — the 3.6.0 entry. It leads with the fix that is least expected: **`allowedFileTypes` never reached the server in any released version.** Anyone who configured it has been running on the shipped defaults without knowing, and that is what refused the MP4.
- **`AGENTS.consumer.md`** — the release skill blocks a release when the public config surface changed and this file was not updated. It changed: `allowedFileTypes` now *selects from a catalog* (an unknown MIME fails the build), and `customFileTypes` / `maxUploadBytes` are new. The file did not document `allowedFileTypes` at all before this.

Verified with `node scripts/extract-changelog-entry.mjs --tag v3.6.0` — the entry parses and the `### Title` resolves.

The version bump and tag are **not** in this PR: `npm version minor` does both (plus screenshots and the README badge) once this is on `main`.