### PR TITLE
fix(redirects): reject backslash and protocol-relative redirect targets

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -113,6 +113,7 @@ astro.config  │                        register the `astro-blocks-runtime` Vit
 | **Handler contract** | `(id?, Request, context?) => Promise<Response>`, isolated in tests via `ASTRO_BLOCKS_PROJECT_ROOT` + `withTempProject`. (obs #881) |
 | **Bootstrap state** | A fresh instance with `users.length === 0`: the login screen is reachable unauthenticated and allows a full import/restore. Leaves bootstrap once users exist. (ADR-0015, obs #1857) |
 | **Catchall** | `src/routes/api/catchall.ts` — the single precompiled REST entry injected into the consumer; dispatches `/cms/api/*` through the route table. |
+| **Redirect** | An internal-only mapping from one site path to another; the target can never point off-origin. External targets are not a looser validation — they would be an explicit feature (#128). |
 | **Owner** | The first bootstrapped user; owner-only gates protect user management; the sole owner cannot be demoted or deleted; `passwordHash` is never exposed. (obs #878) |
 | **HTML sink** | A DOM property/method that parses a string as markup: `innerHTML`, `outerHTML`, `insertAdjacentHTML`. Any API-sourced value reaching a sink must be escaped by context first. (ADR-0022, #99) |
 | **Canonical escaper** | The single `escapeHtml` / `escapeAttr` pair in `utils/html-escape.ts` — `escapeHtml` for text content, `escapeAttr` for attribute values. The only HTML escaper allowed anywhere. (ADR-0011, ADR-0022) |

--- a/docs/changes/redirect-backslash-bypass/design.md
+++ b/docs/changes/redirect-backslash-bypass/design.md
@@ -1,0 +1,98 @@
+<!--
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+-->
+
+# Design — Reject backslash and protocol-relative redirect targets
+
+## 1. The validator change (`src/utils/redirects.ts`)
+
+One new check in `validateRedirectPathInput`, placed together with the existing absolute-URL
+rejection so every off-origin shape yields the same error:
+
+```ts
+const ABSOLUTE_URL_REGEX = /^https?:\/\//i;
+
+// ...inside validateRedirectPathInput, replacing the current ABSOLUTE_URL_REGEX line:
+
+// Backslashes and protocol-relative prefixes are off-origin in disguise: browsers
+// normalize "\" to "/", so "/\evil.com" and "//evil.com" both resolve to
+// https://evil.com. Redirect targets are internal-only — reject, never rewrite.
+if (ABSOLUTE_URL_REGEX.test(path) || path.includes('\\') || path.startsWith('//'))
+  return { errorKey: 'redirects.pathMustBeInternal', fieldKey };
+```
+
+Check order (empty → off-origin shapes → leading slash → query/fragment) is chosen so that every
+bypass grafia reports `pathMustBeInternal` — including `\\evil.com`, which today would die at
+`pathMustStartSlash` with a less truthful message.
+
+No change to `normalizePathname` (`slug.ts` stays generic, pages keep their collapse semantics)
+and no change to `normalizeRedirectPath`.
+
+## 2. Why the validator alone closes the stored data hole
+
+All three flows pass through `validateRedirectPathInput`:
+
+| Flow | Path |
+|---|---|
+| API write | `handlers/redirects.ts:27-34` — validates raw input before normalize+save |
+| Restore / import / **read** | `data.ts:normalizeRedirect` (:136-137) — validates each stored entry, `loadRedirects` (:369-374) drops failures |
+| Serve | `page.astro:21` loads via `loadRedirects` → filtered entries never reach `Astro.redirect` |
+
+A malicious entry already persisted in `redirects.json` is therefore neutralized at read time with
+no migration. This is the single-choke-point decision from grilling: the invariant lives in one
+function; no emit-time guard.
+
+## 3. Tests (TDD — written first, red, then the fix)
+
+### `tests/redirects-utils.test.js` — new regression test
+
+`validateRedirectPathInput` returns `{ errorKey: 'redirects.pathMustBeInternal', ... }` for every
+vector, on both fields:
+
+- `/\evil.com` (the reported bypass)
+- `/\/evil.com`
+- `\\evil.com`
+- `//evil.com`
+- `///evil.com`
+
+And stays `null` for `/valid-path` (already pinned) — plus `/docs//intro` (interior `//` is not a
+protocol-relative shape; normalization still collapses it).
+
+### `tests/redirects-handlers.test.js`
+
+- **New test**: `POST` with `to: '/\\evil.com'` and `to: '//evil.com'` → 400 with the
+  `pathMustBeInternal` message; nothing persisted.
+- **New test (read-time filtering)**: write a `redirects.json` containing a `/\evil.com` entry
+  directly with `fs`, then `loadRedirects()` → entry absent.
+- **Deliberate update**: the CRUD test (:50) posts `to: '//new-path//'` expecting silent collapse
+  to `/new-path`. That input is now invalid by design — the test switches to `to: '/new-path//'`,
+  which keeps exercising trailing-slash normalization without the protocol-relative prefix.
+
+`normalizeRedirectPath('//docs///intro//') → '/docs/intro'` (utils test :18) stays untouched:
+the function is unchanged; only pre-validation tightened.
+
+## 4. Docs
+
+- **`docs/CONTEXT.md`** — one glossary line: *Redirect — an internal-only mapping from one site
+  path to another; the target can never point off-origin.*
+- **`docs/specs/redirects.md`** — created at Archive from `spec-delta.md`.
+
+## 5. Verification bar
+
+1. `npm run typecheck` + `npm test` green.
+2. Manual smoke in the playground: create a redirect with `to: /\evil.com` via the admin UI →
+   validation error shown; create a legit redirect → still works end-to-end.
+3. Direct check that a hand-edited malicious `redirects.json` entry no longer redirects (serve
+   returns 404 instead of off-site 301).
+
+No UI change → no README screenshots. `src/meta/features.json` reviewed at close per checklist.
+
+## 6. Commit sequence
+
+A single commit (test + fix land together, red→green within the commit):
+
+1. `fix(redirects): reject backslash and protocol-relative redirect targets`
+   — validator change, regression tests, handler-test update, `CONTEXT.md` glossary line.
+
+Release bump + CHANGELOG happen only at close, on the human's request, per policy.

--- a/docs/changes/redirect-backslash-bypass/proposal.md
+++ b/docs/changes/redirect-backslash-bypass/proposal.md
@@ -1,0 +1,63 @@
+<!--
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+-->
+
+# Proposal — Reject backslash and protocol-relative redirect targets
+
+_Issue: [#123](https://github.com/NauelG/astro-blocks/issues/123) (P1, security). Grilled 2026-07-15._
+
+## Problem
+
+Redirect targets are internal-only by policy (`redirects.pathMustBeInternal`), but the validator
+only rejects `^https?://`, a missing leading `/`, and `?`/`#`. Two bypass shapes survive:
+
+- **Backslash**: a `to` of `/\evil.com` passes `validateRedirectPathInput`
+  (`src/utils/redirects.ts:31-45`) and survives `normalizePathname`
+  (`src/utils/slug.ts:15-23`, collapses forward slashes only) intact. `page.astro:88-89` emits it
+  raw into `Astro.redirect`; browsers normalize `/\` to `//`, producing a **protocol-relative
+  off-site redirect**. Stored, persistent, and served to unauthenticated public visitors. Any
+  low-privilege CMS user (`auth: 'user'`, `src/api/route-table.ts:235`) can plant it.
+- **Leading double slash**: a raw `to` of `//evil.com` passes validation and is only neutralized
+  because `normalizePathname` happens to collapse it to `/evil.com` — a **silent rewrite** of an
+  attack-shaped input, dependent on a generic slug helper that redirects do not own.
+
+## Proposal
+
+Harden `validateRedirectPathInput` — the single choke point all three redirect paths flow through
+(API write via `handlers/redirects.ts`, restore/import and read via `data.ts:normalizeRedirect`,
+serve via `loadRedirects` → `page.astro`):
+
+1. **Reject any path containing `\`**, on both `from` and `to`. A backslash has no legitimate use
+   in an internal path; a `from` containing one is unmatchable dead data.
+2. **Reject any path starting with `//`** (protocol-relative shape), instead of relying on
+   `normalizePathname`'s collapse. The invariant "no stored redirect can resolve off-origin"
+   becomes self-contained in the validator.
+3. Both rejections reuse the existing **`redirects.pathMustBeInternal`** error key — semantically
+   exact, zero new i18n surface.
+
+Because `loadRedirects` runs every stored entry through `normalizeRedirect`, which calls this
+validator, **already-persisted malicious entries are filtered out at read time** — no migration,
+consistent with the repo's no-fallback policy.
+
+## Observable behaviour changes
+
+- Inputs containing `\` (anywhere) are rejected with a validation error; previously stored/emitted.
+- Inputs with a leading `//` (e.g. `//new-path//`) are rejected; previously silently collapsed to
+  `/new-path`. The existing handler CRUD test pins that old behaviour and is updated deliberately.
+- Stored entries with either shape disappear from reads (and thus from the admin list and serving).
+
+## Out of scope
+
+- **External redirect targets** — captured as an explicit future feature in
+  [#128](https://github.com/NauelG/astro-blocks/issues/128); this fix keeps the internal-only policy.
+- Defense-in-depth guard at the `page.astro` emit — rejected at grilling: dead code by
+  construction once the choke point rejects, and it would split ownership of the invariant.
+- Session revocation (#124) and the rest of the security backlog.
+
+## Consequences
+
+- First living spec for redirects: `docs/specs/redirects.md` (see `spec-delta.md`).
+- One new glossary line in `docs/CONTEXT.md` (Redirect — internal-only).
+- No ADR — cheap to reverse (reversal is #128's own cycle), explainable in a two-line code comment.
+- Release: no bump during development; at close, `patch` + `### Fixed` entry (security fix).

--- a/docs/changes/redirect-backslash-bypass/spec-delta.md
+++ b/docs/changes/redirect-backslash-bypass/spec-delta.md
@@ -1,0 +1,44 @@
+<!--
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+-->
+
+# Spec delta — Reject backslash and protocol-relative redirect targets
+
+## ADDED: Redirect target policy (`redirects.md`, new spec)
+
+First living spec for redirects. Requirements:
+
+> **R1 — Redirect targets are internal-only.** A redirect's `to` (and `from`) must be a
+> site-internal pathname: leading `/`, no scheme, no query, no fragment. Absolute URLs
+> (`http://`, `https://`) are rejected with `redirects.pathMustBeInternal`.
+>
+> **R2 — Off-origin shapes are rejected, never rewritten.** Any path containing `\` or starting
+> with `//` is rejected with `redirects.pathMustBeInternal`. Browsers normalize `\` to `/` and
+> resolve `//host` as protocol-relative, so these are external URLs in disguise; silently
+> normalizing them would mask attack-shaped input. (External targets, if ever wanted, are an
+> explicit feature — #128 — not a loosening of this rule.)
+>
+> **R3 — `validateRedirectPathInput` is the single choke point.** All redirect flows — API write
+> (`handlers/redirects.ts`), restore/import and read (`data.ts:normalizeRedirect`), and serve
+> (`loadRedirects` → `page.astro`) — validate through this one function. Entries that fail
+> validation are dropped at read time, so invalid persisted data never reaches `Astro.redirect`
+> and no data migration is ever needed. No duplicate guard exists at the emit site by design.
+>
+> **R4 — Regression coverage.** `tests/redirects-utils.test.js` pins the bypass vectors
+> (`/\evil.com`, `/\/evil.com`, `\\evil.com`, `//evil.com`, `///evil.com`) as rejected and
+> interior double slashes (`/docs//intro`) as accepted; `tests/redirects-handlers.test.js` pins
+> the API 400 and the read-time filtering of a hand-persisted malicious entry.
+
+## No other behavioural delta
+
+- `normalizePathname` / `normalizeRedirectPath` semantics are unchanged; only pre-validation
+  tightened.
+- Matching (`findRedirectByPath`), status codes, and the admin editor flow are untouched.
+
+## Consequence for Archive
+
+1. Create `docs/specs/redirects.md` from the ADDED section above.
+2. Add the glossary line to `docs/CONTEXT.md` if not already landed with the fix commit.
+3. Move `docs/changes/redirect-backslash-bypass/` → `docs/changes/archive/<date>-redirect-backslash-bypass/`.
+4. No ADR to leave in place — this change creates none.

--- a/docs/changes/redirect-backslash-bypass/tasks.md
+++ b/docs/changes/redirect-backslash-bypass/tasks.md
@@ -1,0 +1,59 @@
+<!--
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+-->
+
+# Tasks — Reject backslash and protocol-relative redirect targets
+
+Single vertical slice (one behaviour, one commit), executed with TDD discipline:
+red tests first, minimal fix, then docs. Commit only at T5.
+
+## T1 — Regression tests (red)
+
+- [x] **Files:** `tests/redirects-utils.test.js`, `tests/redirects-handlers.test.js`
+- New utils test: `validateRedirectPathInput` returns
+  `{ errorKey: 'redirects.pathMustBeInternal', fieldKey: <field> }` for `/\evil.com`,
+  `/\/evil.com`, `\\evil.com`, `//evil.com`, `///evil.com` — on both `from` and `to`; stays
+  `null` for `/docs//intro` (interior `//` remains legit input).
+- New handler test: `POST /cms/api/redirects` with `to: '/\\evil.com'` and with
+  `to: '//evil.com'` → 400, `redirects.json` untouched.
+- New read-filter test: hand-write `data/redirects.json` with a `/\evil.com` entry via `fs`,
+  then `loadRedirects()` → entry absent from the result.
+- Deliberate update: CRUD test input `to: '//new-path//'` → `to: '/new-path//'` (still pins
+  trailing-slash normalization; the protocol-relative prefix is now invalid by design).
+- **Verify:** `npm run build && npm test -- --test-name-pattern` shows the new tests **failing**
+  (except the CRUD update, which still passes) — the bypass is reproduced against current code.
+
+## T2 — Validator fix (green)
+
+- [x] **File:** `src/utils/redirects.ts`
+- In `validateRedirectPathInput`, replace the `ABSOLUTE_URL_REGEX` line with the combined
+  off-origin check (absolute URL ‖ contains `\` ‖ starts with `//`), returning
+  `redirects.pathMustBeInternal`, with the two-line browser-normalization comment from
+  `design.md` §1. Check order: empty → off-origin → leading slash → query/fragment.
+- No changes to `src/utils/slug.ts` or `normalizeRedirectPath`.
+- **Verify:** `npm run typecheck` green; `npm test` fully green (T1 tests included).
+
+## T3 — Glossary line
+
+- [x] **File:** `docs/CONTEXT.md`
+- Add to the glossary: *Redirect — an internal-only mapping from one site path to another;
+  the target can never point off-origin.*
+- **Verify:** the line reads as domain language (no implementation detail leaked).
+
+## T4 — End-to-end verification
+
+- [x] Playground smoke (`playgrounds/` basic): admin UI rejects `to: /\evil.com` with the
+  must-be-internal message; a legit redirect still round-trips (create → visit `from` → 301 to
+  `to`).
+- [x] Hand-edit the playground's `data/redirects.json` with a `/\evil.com` entry: visiting its
+  `from` yields 404, not an off-site redirect; the entry does not appear in the admin list.
+- **Verify:** both checks observed; `npm run check` (if defined) / `npm run typecheck` +
+  `npm test` green.
+
+## T5 — Commit
+
+- [x] Single commit: `fix(redirects): reject backslash and protocol-relative redirect targets`
+  (T1 + T2 + T3), body summarizing the bypass and the internal-only policy, footer
+  `Reviewed-by:` per repo policy. No version bump / CHANGELOG (only at close, on request).
+- **Verify:** `git show --stat` touches only the four files above + this change dir.

--- a/src/utils/redirects.ts
+++ b/src/utils/redirects.ts
@@ -36,7 +36,11 @@ export function validateRedirectPathInput(
   const fieldKey = fieldLabelKey(field);
 
   if (!path) return { errorKey: 'redirects.pathRequired', fieldKey };
-  if (ABSOLUTE_URL_REGEX.test(path)) return { errorKey: 'redirects.pathMustBeInternal', fieldKey };
+  // Backslashes and protocol-relative prefixes are off-origin in disguise: browsers
+  // normalize "\" to "/", so "/\evil.com" and "//evil.com" both resolve to
+  // https://evil.com. Redirect targets are internal-only — reject, never rewrite.
+  if (ABSOLUTE_URL_REGEX.test(path) || path.includes('\\') || path.startsWith('//'))
+    return { errorKey: 'redirects.pathMustBeInternal', fieldKey };
   if (!path.startsWith('/')) return { errorKey: 'redirects.pathMustStartSlash', fieldKey };
   if (path.includes('?') || path.includes('#'))
     return { errorKey: 'redirects.pathNoQueryFragment', fieldKey };

--- a/tests/redirects-handlers.test.js
+++ b/tests/redirects-handlers.test.js
@@ -55,7 +55,7 @@ test('redirect handlers support CRUD and canonical path normalization', async ()
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           from: '/old-path/',
-          to: '//new-path//',
+          to: '/new-path//',
           statusCode: 301,
           enabled: true,
         }),
@@ -152,5 +152,45 @@ test('redirect handlers validate input and avoid duplicate origins', async () =>
 
     assert.equal(withQuery.status, 400);
     assert.match((await withQuery.json()).error, /query|fragment/i);
+  });
+});
+
+test('redirect handlers reject off-origin bypass shapes and persist nothing', async () => {
+  await withTempProject(async () => {
+    for (const to of ['/\\evil.com', '//evil.com']) {
+      const response = await handlePostRedirects(
+        new Request('http://localhost/cms/api/redirects', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ from: '/old', to }),
+        }),
+      );
+
+      assert.equal(response.status, 400);
+      assert.match((await response.json()).error, /internal/i);
+    }
+
+    const afterAttempts = await loadRedirects();
+    assert.equal(afterAttempts.redirects.length, 0);
+  });
+});
+
+test('loadRedirects drops persisted entries with off-origin targets', async () => {
+  await withTempProject(async (tempRoot) => {
+    const redirectsPath = path.join(tempRoot, 'data', 'redirects.json');
+    await fs.writeFile(
+      redirectsPath,
+      JSON.stringify({
+        redirects: [
+          { id: 'evil', from: '/promo', to: '/\\evil.com', statusCode: 301, enabled: true },
+          { id: 'good', from: '/old', to: '/new', statusCode: 301, enabled: true },
+        ],
+      }),
+      'utf-8',
+    );
+
+    const data = await loadRedirects();
+    assert.equal(data.redirects.length, 1);
+    assert.equal(data.redirects[0].id, 'good');
   });
 });

--- a/tests/redirects-utils.test.js
+++ b/tests/redirects-utils.test.js
@@ -54,6 +54,27 @@ test('validateRedirectPathInput rejects external urls, query and hash', () => {
   assert.equal(validateRedirectPathInput('/valid-path', 'from'), null);
 });
 
+test('validateRedirectPathInput rejects backslash and protocol-relative bypass shapes', () => {
+  // Browsers normalize "\" to "/" and resolve "//host" as protocol-relative,
+  // so every one of these would escape the internal-only policy if stored.
+  const vectors = ['/\\evil.com', '/\\/evil.com', '\\\\evil.com', '//evil.com', '///evil.com'];
+
+  for (const vector of vectors) {
+    assert.deepEqual(validateRedirectPathInput(vector, 'from'), {
+      errorKey: 'redirects.pathMustBeInternal',
+      fieldKey: 'redirects.labelFrom',
+    });
+    assert.deepEqual(validateRedirectPathInput(vector, 'to'), {
+      errorKey: 'redirects.pathMustBeInternal',
+      fieldKey: 'redirects.labelTo',
+    });
+  }
+
+  // Interior double slashes are not protocol-relative; normalization still collapses them.
+  assert.equal(validateRedirectPathInput('/docs//intro', 'from'), null);
+  assert.equal(validateRedirectPathInput('/docs//intro', 'to'), null);
+});
+
 test('findRedirectByPath only returns enabled exact matches', () => {
   const redirects = [
     { id: '1', from: '/old', to: '/new', statusCode: 301, enabled: true },


### PR DESCRIPTION
Closes #123.

## Summary

`validateRedirectPathInput` only rejected `^https?://`, a missing leading `/` and `?`/`#`, so a stored `to` of `/\evil.com` survived validation and normalization (`normalizePathname` collapses forward slashes only) and was emitted raw into `Astro.redirect`. Browsers normalize `\` to `/`, turning it into a protocol-relative **off-site redirect served to unauthenticated public visitors**, plantable by any low-privilege CMS user.

## Fix

Harden the validator — the single choke point for API writes, restore/import and reads (`loadRedirects` → `normalizeRedirect`) — to reject any path containing `\` or starting with `//`, reusing the existing `redirects.pathMustBeInternal` error (zero new i18n surface). Redirect targets are internal-only, and off-origin shapes are **rejected, never rewritten**.

- Already-persisted malicious entries are dropped at read time — no migration needed.
- Deliberate behaviour change: a leading `//` (previously silently collapsed to `/`) is now a validation error; the handler CRUD test pinning that collapse was updated accordingly.
- No change to `slug.ts` / `normalizePathname` (pages keep their collapse semantics) and no duplicate guard at the emit site.
- External redirect targets remain out of scope — captured as an explicit future feature in #128.

Change artifacts (grilling → proposal → design → tasks) live in `docs/changes/redirect-backslash-bypass/`; the `spec-delta.md` becomes `docs/specs/redirects.md` at Archive after merge.

## Tests

- `tests/redirects-utils.test.js`: bypass vectors `/\evil.com`, `/\/evil.com`, `\\evil.com`, `//evil.com`, `///evil.com` rejected on both fields; interior `//` (`/docs//intro`) still accepted.
- `tests/redirects-handlers.test.js`: POST with off-origin shapes → 400 with nothing persisted; `loadRedirects` drops a hand-persisted malicious entry.
- Full suite green (1250/1250), typecheck clean, `biome ci` green.
- Playground smoke verified end-to-end: malicious payloads → 400, legit redirect → 301, injected malicious JSON entry → 404 and absent from the admin list.