### PR TITLE
fix(data): route restore's media write through the media mutex

### DIFF
--- a/docs/adr/0008-json-file-store-atomic-write-mutex.md
+++ b/docs/adr/0008-json-file-store-atomic-write-mutex.md
@@ -15,6 +15,12 @@ Licensed under the Business Source License 1.1
 > calls the exported, unlocked `data.saveMedia()` during restore, holding only `withUsersLock` — a
 > different key. That is a lost-update window against a concurrent upload. The comment at
 > `src/api/backup.ts:577-586` asserts the opposite of what line 651 does. Tracked in **#100**.
+>
+> **Update (2026-07-15) — #100 closed.** The escape hatch is gone. `saveMedia` is now module-private
+> (raw unlocked write, callable only from inside an already-held media lock), and the restore path
+> writes through the new exported `data.replaceMedia`, which takes `withFileLock(mediaLockKey())`.
+> No unlocked whole-registry write is reachable from outside `data.ts`. Regression: `CONC-03` in
+> `tests/media-concurrency.test.js` (replace interleaved with concurrent appends loses no update).
 
 ## Context
 

--- a/src/api/backup.ts
+++ b/src/api/backup.ts
@@ -581,9 +581,10 @@ export interface ApplyImportResult {
  *   `_runImportPipelineCore`'s bootstrapMode branch), and handleLogin's
  *   first-user path acquires the same lock — so users.json IS
  *   lock-protected, via withUsersLock rather than withFileLock directly.
- * - For the media unit: replaces public/uploads tree, then calls
- *   reconcileMedia (media writes go through withFileLock(mediaLockKey())
- *   inside data.ts — a separate mutex from withUsersLock).
+ * - For the media unit: writes the registry via data.replaceMedia (which takes
+ *   withFileLock(mediaLockKey()) — a separate mutex from withUsersLock — so the
+ *   whole-registry overwrite cannot lose a concurrent upload's append, per
+ *   ADR-0008), then replaces the public/uploads tree.
  * - Calls handleInvalidateCache equivalent (invalidates global cache via context.cache).
  * - Returns { usersReplaced } based on whether users unit was in selectedUnits.
  *
@@ -648,7 +649,7 @@ export async function applyImport(
         case 'media': {
           // Save media registry
           const raw = await fs.readFile(path.join(stagingDir, 'data', 'media.json'), 'utf-8');
-          await data.saveMedia(JSON.parse(raw));
+          await data.replaceMedia(JSON.parse(raw));
 
           // Replace public/uploads tree atomically:
           // 1. Copy staging uploads into a temp sibling dir (minimises destructive window).

--- a/src/api/data.ts
+++ b/src/api/data.ts
@@ -642,8 +642,22 @@ export async function updateMediaEntryAlt(id: string, alt: string): Promise<Medi
   });
 }
 
-export async function saveMedia(data: MediaData): Promise<void> {
+// Raw, UNLOCKED whole-registry write. Module-private on purpose: it must only be
+// called from inside an already-held withFileLock(mediaLockKey()) — every media
+// mutation in this module does exactly that. External callers that need a wholesale write
+// (restore/import, test fixtures) must use the locked replaceMedia seam instead,
+// so no caller can bypass the media mutex by forgetting to lock (ADR-0008, #100).
+async function saveMedia(data: MediaData): Promise<void> {
   await writeJson(getDataPath('media.json'), data);
+}
+
+// Locked whole-registry replace: the wholesale counterpart to the surgical
+// append/remove/update mutations. Serializes against every other media writer
+// through the shared media mutex, so a concurrent append cannot lose this write.
+export async function replaceMedia(data: MediaData): Promise<void> {
+  await withFileLock(mediaLockKey(), async () => {
+    await saveMedia(data);
+  });
 }
 
 // All media mutations share ONE lock keyed by the resolved media.json path so

--- a/tests/get-media-variants.test.js
+++ b/tests/get-media-variants.test.js
@@ -9,7 +9,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { ensureDefaultFiles, saveMedia } from '../dist/api/data.js';
+import { ensureDefaultFiles, replaceMedia } from '../dist/api/data.js';
 import { getMediaVariants } from '../dist/utils/getMediaVariants.js';
 
 async function withTempProject(fn) {
@@ -45,7 +45,7 @@ test('cache hit — single loadMedia call when mtime unchanged', async () => {
       status: 'ready',
       variants: [{ format: 'webp', width: 480, url: '/uploads/2026/06/img-480.webp' }],
     };
-    await saveMedia({ uploads: [entry] });
+    await replaceMedia({ uploads: [entry] });
 
     // First call — should populate cache
     const result1 = await getMediaVariants(entry.url);
@@ -74,7 +74,7 @@ test('cache invalidation — re-reads after mtime changes', async () => {
       status: 'processing',
       variants: [],
     };
-    await saveMedia({ uploads: [entry1] });
+    await replaceMedia({ uploads: [entry1] });
 
     const result1 = await getMediaVariants(url);
     assert.equal(result1.status, 'processing');
@@ -87,12 +87,12 @@ test('cache invalidation — re-reads after mtime changes', async () => {
       status: 'ready',
       variants: [{ format: 'webp', width: 480, url: '/uploads/2026/06/img2-480.webp' }],
     };
-    await saveMedia({ uploads: [entry2] });
+    await replaceMedia({ uploads: [entry2] });
 
     // Next call should see the updated status
     const result2 = await getMediaVariants(url);
     // Status should reflect the new registry (processing or ready depending on cache)
-    // Since mtime changed (saveMedia writes a new file), cache should be invalidated
+    // Since mtime changed (replaceMedia writes a new file), cache should be invalidated
     assert.equal(result2.status, 'ready', 'should read updated status after mtime change');
     assert.equal(result2.variants.length, 1, 'should have updated variants');
   });
@@ -123,7 +123,7 @@ test('URL not in registry → returns status:none', async () => {
       status: 'ready',
       variants: [],
     };
-    await saveMedia({ uploads: [entry] });
+    await replaceMedia({ uploads: [entry] });
 
     const result = await getMediaVariants('/uploads/2026/06/nonexistent.jpg');
     assert.equal(result.status, 'none', 'unknown URL should return status:none');
@@ -167,7 +167,7 @@ test('ready entry with variants — returns full result', async () => {
       { format: 'webp', width: 480, url: '/uploads/2026/06/full-480.webp' },
       { format: 'avif', width: 480, url: '/uploads/2026/06/full-480.avif' },
     ];
-    await saveMedia({
+    await replaceMedia({
       uploads: [
         {
           id: 'full-1',

--- a/tests/media-concurrency.test.js
+++ b/tests/media-concurrency.test.js
@@ -14,6 +14,7 @@ import {
   appendMediaEntry,
   removeMediaEntryByUrl,
   reconcileMedia,
+  replaceMedia,
   generateId,
 } from '../dist/api/data.js';
 
@@ -120,6 +121,47 @@ test('CONC-02: concurrent appends + delete + reconcile keep file valid, no dup/o
     // No orphaned entry: every remaining entry must have a known id from our set.
     const knownIds = new Set(entries.map((e) => e.id));
     for (const id of ids) {
+      assert.ok(knownIds.has(id), `unexpected/orphaned id ${id}`);
+    }
+  });
+});
+
+// CONC-03: a whole-registry replaceMedia (restore/import path) interleaved with
+// concurrent appends must serialize through the media mutex. Under the lock the
+// replace-set is written atomically, so every replace entry survives regardless
+// of interleaving: an append that runs after replace only adds, one that runs
+// before is overwritten by replace. An unlocked replace loses updates — an append
+// that read the pre-replace state writes back over it and wipes the entire set.
+test('CONC-03: replaceMedia interleaved with concurrent appends never loses the replace-set', async () => {
+  await withTempProject(async () => {
+    const N = 10;
+    const replaceSet = Array.from({ length: N }, (_, i) => makeEntry(1000 + i));
+    const appended = Array.from({ length: N }, (_, i) => makeEntry(i));
+
+    const ops = [
+      replaceMedia({ uploads: replaceSet }),
+      ...appended.map((entry) => appendMediaEntry(entry)),
+    ];
+
+    await Promise.all(ops);
+
+    const { loadMedia } = await import('../dist/api/data.js');
+    const parsed = await loadMedia();
+
+    // File must remain valid (loadMedia would throw on parse failure).
+    const finalIds = new Set(parsed.uploads.map((e) => e.id));
+
+    // Invariant: every replace-set entry must survive any serialization.
+    for (const entry of replaceSet) {
+      assert.ok(
+        finalIds.has(entry.id),
+        `replace-set entry ${entry.id} must survive interleaved appends`,
+      );
+    }
+
+    // No corruption: every surviving entry belongs to replace-set or append-set.
+    const knownIds = new Set([...replaceSet, ...appended].map((e) => e.id));
+    for (const id of finalIds) {
       assert.ok(knownIds.has(id), `unexpected/orphaned id ${id}`);
     }
   });

--- a/tests/media-handlers.test.js
+++ b/tests/media-handlers.test.js
@@ -419,7 +419,7 @@ test('SEC-03: filename with special characters is sanitized in stored path', asy
 
 test('T1.2: legacy entry (no status/variants) loads without error', async () => {
   await withTempProject(async () => {
-    const { saveMedia, loadMedia: reloadMedia } = await import('../dist/api/data.js');
+    const { replaceMedia, loadMedia: reloadMedia } = await import('../dist/api/data.js');
     const legacyEntry = {
       id: 'legacy-1',
       url: '/uploads/2026/01/legacy.jpg',
@@ -428,7 +428,7 @@ test('T1.2: legacy entry (no status/variants) loads without error', async () => 
       mimeType: 'image/jpeg',
       createdAt: '2026-01-01T00:00:00.000Z',
     };
-    await saveMedia({ uploads: [legacyEntry] });
+    await replaceMedia({ uploads: [legacyEntry] });
     const loaded = await reloadMedia();
     assert.equal(loaded.uploads.length, 1);
     const entry = loaded.uploads[0];
@@ -440,7 +440,7 @@ test('T1.2: legacy entry (no status/variants) loads without error', async () => 
 
 test('T1.2: invalid status coerced to undefined', async () => {
   await withTempProject(async () => {
-    const { saveMedia, loadMedia: reloadMedia } = await import('../dist/api/data.js');
+    const { replaceMedia, loadMedia: reloadMedia } = await import('../dist/api/data.js');
     const invalidEntry = {
       id: 'bad-status',
       url: '/uploads/2026/01/bad.jpg',

--- a/tests/media-list.test.js
+++ b/tests/media-list.test.js
@@ -13,7 +13,7 @@ import {
   saveUsers,
   ensureDefaultFiles,
   loadMedia,
-  saveMedia,
+  replaceMedia,
   appendMediaEntry,
   generateId,
 } from '../dist/api/data.js';
@@ -130,7 +130,7 @@ test('T14-07: GET /cms/api/media prunes registry entries whose files are missing
         },
       ],
     };
-    await saveMedia(existingMedia);
+    await replaceMedia(existingMedia);
 
     const token = await makeAuthToken();
     const req = new Request('http://localhost/cms/api/media', {
@@ -169,7 +169,7 @@ test('T-15: loadMedia — old entry without alt/width/height loads cleanly (SC-3
       createdAt: now,
       // no alt, no width, no height
     };
-    await saveMedia({ uploads: [oldEntry] });
+    await replaceMedia({ uploads: [oldEntry] });
 
     const media = await loadMedia();
     assert.equal(media.uploads.length, 1, 'old entry should not be dropped');
@@ -187,7 +187,7 @@ test('FIX-C: loadMedia drops a stored width:0 / height:0 (must match projection 
   await withTempProject(async () => {
     const now = new Date().toISOString();
     // Write malformed-but-tolerated entries directly to disk
-    await saveMedia({
+    await replaceMedia({
       uploads: [
         {
           id: 'zero-w',
@@ -261,7 +261,7 @@ test('T-16: loadMedia — new entry with alt/width/height loads cleanly (SC-3.2)
       width: 1024,
       height: 768,
     };
-    await saveMedia({ uploads: [newEntry] });
+    await replaceMedia({ uploads: [newEntry] });
 
     const media = await loadMedia();
     assert.equal(media.uploads.length, 1, 'new entry should load cleanly');
@@ -308,7 +308,7 @@ test('ML-R1-default: default params — 30 entries returns page:1, limit:24, tot
       const entry = await createRealEntry(tempRoot, subdir, filename);
       entries.push(entry);
     }
-    await saveMedia({ uploads: entries });
+    await replaceMedia({ uploads: entries });
 
     const token = await makeAuthToken();
     const req = new Request('http://localhost/cms/api/media', {
@@ -333,7 +333,7 @@ test('ML-R1-limit-clamp-low: limit=0 clamped to 1', async () => {
       const entry = await createRealEntry(tempRoot, '2026/06', `file-${i}.jpg`);
       entries.push(entry);
     }
-    await saveMedia({ uploads: entries });
+    await replaceMedia({ uploads: entries });
 
     const token = await makeAuthToken();
     const req = new Request('http://localhost/cms/api/media?limit=0', {
@@ -356,7 +356,7 @@ test('ML-R1-limit-clamp-high: limit=500 clamped to 100', async () => {
       const entry = await createRealEntry(tempRoot, '2026/06', `file-${i}.jpg`);
       entries.push(entry);
     }
-    await saveMedia({ uploads: entries });
+    await replaceMedia({ uploads: entries });
 
     const token = await makeAuthToken();
     const req = new Request('http://localhost/cms/api/media?limit=500', {
@@ -378,7 +378,7 @@ test('ML-R1-nan-defaults: NaN page and limit → defaults applied', async () => 
       const entry = await createRealEntry(tempRoot, '2026/06', `file-${i}.jpg`);
       entries.push(entry);
     }
-    await saveMedia({ uploads: entries });
+    await replaceMedia({ uploads: entries });
 
     const token = await makeAuthToken();
     const req = new Request('http://localhost/cms/api/media?page=abc&limit=xyz', {
@@ -399,7 +399,7 @@ test('ML-R4-filter-ci: q=banner matches both banner entries case-insensitively',
     const heroBanner = await createRealEntry(tempRoot, subdir, 'hero-Banner.jpg');
     const bannerSmall = await createRealEntry(tempRoot, subdir, 'banner-small.png', 'image/png');
     const profile = await createRealEntry(tempRoot, subdir, 'profile.jpg');
-    await saveMedia({ uploads: [heroBanner, bannerSmall, profile] });
+    await replaceMedia({ uploads: [heroBanner, bannerSmall, profile] });
 
     const token = await makeAuthToken();
     const req = new Request('http://localhost/cms/api/media?q=banner', {
@@ -425,7 +425,7 @@ test('ML-R4-empty-q: q= (empty string) returns all entries', async () => {
       const entry = await createRealEntry(tempRoot, '2026/06', `img-${i}.jpg`);
       entries.push(entry);
     }
-    await saveMedia({ uploads: entries });
+    await replaceMedia({ uploads: entries });
 
     const token = await makeAuthToken();
     const req = new Request('http://localhost/cms/api/media?q=', {
@@ -442,7 +442,7 @@ test('ML-R4-empty-q: q= (empty string) returns all entries', async () => {
 test('ML-R4-zero-matches: q=xyz returns empty uploads and total:0', async () => {
   await withTempProject(async (tempRoot) => {
     const entry = await createRealEntry(tempRoot, '2026/06', 'photo.jpg');
-    await saveMedia({ uploads: [entry] });
+    await replaceMedia({ uploads: [entry] });
 
     const token = await makeAuthToken();
     const req = new Request('http://localhost/cms/api/media?q=xyz', {
@@ -465,7 +465,7 @@ test('ML-R5-out-of-range-page: page beyond last returns empty uploads + correct 
       const entry = await createRealEntry(tempRoot, '2026/06', `file-${i}.jpg`);
       entries.push(entry);
     }
-    await saveMedia({ uploads: entries });
+    await replaceMedia({ uploads: entries });
 
     const token = await makeAuthToken();
     const req = new Request('http://localhost/cms/api/media?page=5&limit=5', {
@@ -552,7 +552,7 @@ test('ML-R2-pipeline-order: orphan entries excluded before filter+count', async 
     // Add a non-matching real entry
     const nonMatchEntry = await createRealEntry(tempRoot, subdir, 'landscape.jpg');
 
-    await saveMedia({ uploads: [...realEntries, ...orphanEntries, nonMatchEntry] });
+    await replaceMedia({ uploads: [...realEntries, ...orphanEntries, nonMatchEntry] });
 
     const token = await makeAuthToken();
     const req = new Request('http://localhost/cms/api/media?q=photo', {
@@ -602,7 +602,7 @@ test('P4-reconcile-count-slice: missing-file entry excluded from total AND from 
       mimeType: 'image/jpeg',
       createdAt: new Date(base + 99 * 1000).toISOString(), // newest
     };
-    await saveMedia({ uploads: [...real, orphan] });
+    await replaceMedia({ uploads: [...real, orphan] });
 
     const token = await makeAuthToken();
     // limit=2 so the slice is a strict subset — proves reconcile ran before slice
@@ -640,7 +640,7 @@ test('P4-q-filters-reconciled-set: q filters AFTER reconcile (orphan match exclu
     };
     // plus a non-matching real entry
     const other = await createRealEntry(tempRoot, subdir, 'banner.jpg');
-    await saveMedia({ uploads: [realA, realB, orphanLogo, other] });
+    await replaceMedia({ uploads: [realA, realB, orphanLogo, other] });
 
     const token = await makeAuthToken();
     const req = new Request('http://localhost/cms/api/media?q=logo', {


### PR DESCRIPTION
Closes #100.

## Problem

The import/restore path (`applyImport`, `src/api/backup.ts`, `case 'media'`) wrote `media.json` via the exported, **unlocked** `data.saveMedia()` while holding only `withUsersLock` — a different key from the media mutex. That left a **lost-update window** against a concurrent upload's locked `appendMediaEntry`: the atomic `writeJson` prevents byte-level corruption, but the whole-registry overwrite can clobber a concurrent append. This is exactly the class of race ADR-0008's mutex exists to close. The comment at `applyImport` also claimed the opposite of what the code did.

## Fix — close the class, not just the site

- `saveMedia` is now **module-private**: a raw, unlocked whole-registry write, callable only from inside an already-held `withFileLock(mediaLockKey())`. Every media mutation in `data.ts` already does exactly that.
- New exported **`replaceMedia(data)`** takes `withFileLock(mediaLockKey())` and is the only wholesale-write seam reachable from outside `data.ts`. The restore path and the test fixtures use it, so no caller can bypass the media mutex by forgetting to lock.
- Corrected the misleading `applyImport` comment and added a dated closure note to ADR-0008.

Naive "make `saveMedia` itself locked" was rejected: `withFileLock` is non-reentrant, so the 7 internal callers (which already hold the lock) would deadlock. Splitting into a private unlocked primitive + a public locked seam avoids that.

## Test

`CONC-03` in `tests/media-concurrency.test.js` interleaves `replaceMedia` with N concurrent appends and asserts the replace-set survives every serialization. It was verified **red** on an unlocked `replaceMedia` (lost update) and **green** once locked, stable across repeated runs.

- `npm test` → 1271 passing
- `npm run typecheck` / `npm run build` → OK

## Scope

Out of scope: #96 (async variant job) — untouched; this fix narrows its blast radius and that is noted on #96. No `spec-delta`: media concurrency behavior lives in ADR-0008, not a living spec.