### PR TITLE
fix(media): drain variant jobs before teardown; guard package-root data/ leak

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -285,9 +285,13 @@ create the component with its `schema` and add it to the `blocks` array. (See AD
 
 ### Data store & testing
 - **Concurrent writes corrupt the JSON store** — always go through `writeJson` (atomic) + `withFileLock`. (ADR-0008, obs #805)
-- **Fire-and-forget async in handlers can outlive the test's env scope**: `handleUpload` fires
-  `generateAndPersistVariants` un-awaited; tests must **drain pending variant jobs** before `withTempProject`
-  restores `ASTRO_BLOCKS_PROJECT_ROOT`, or stray files land at repo root (SVG is the fastest to trip it). (obs #836)
+- **Fire-and-forget async in handlers can outlive the test's env scope**: `handleUpload`/`handleReplaceUpload`
+  spawn variant generation un-awaited via `spawnVariantGeneration`, which resolves the store path *at write time* —
+  a job that outlives the test writes to `process.cwd()/data` once `withTempProject` has unset
+  `ASTRO_BLOCKS_PROJECT_ROOT`. Tests that upload/replace **must `await drainVariantJobs()`** (from
+  `utils/variant-generator`) in `withTempProject`'s `finally`, *before* the env restore + temp-dir removal.
+  `scripts/check-root-data-leak.mjs` (chained in `npm test`) fails the suite if a package-root `data/` ever
+  appears — a `.gitignore` rule is not self-enforcing. (obs #836, #96)
 - **Delete/status-code inconsistency across domains**: `handleDeleteMenu` → `204`; `handleDeleteLanguage` → `200`
   with a JSON body. Don't assume a uniform delete contract. (obs #879)
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "check": "biome ci .",
-    "test": "npm run build && node --test tests/*.test.js",
+    "test": "npm run build && node --test tests/*.test.js && node scripts/check-root-data-leak.mjs",
     "coverage": "node scripts/coverage.mjs",
     "coverage:badge": "node scripts/coverage-badge.mjs",
     "prepare:playground": "npm run build && node scripts/install-playground-package.mjs",

--- a/scripts/check-root-data-leak.mjs
+++ b/scripts/check-root-data-leak.mjs
@@ -1,0 +1,45 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * Guard: the package root must never contain a `data/` directory.
+ *
+ * `.gitignore` refuses to track a package-root `data/`, but nothing stops the
+ * write itself — a test that leaks a write to `process.cwd()/data` passes green
+ * while polluting the repo (see #96). This script makes that leak loud: it runs
+ * after the suite and fails if `data/` exists at the package root.
+ *
+ * A rule enforced only by `.gitignore` is a rule nothing enforces.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const packageRoot = path.resolve(import.meta.dirname, '..');
+const dataDir = path.join(packageRoot, 'data');
+
+if (!fs.existsSync(dataDir)) {
+  process.exit(0);
+}
+
+const entries = fs.readdirSync(dataDir, { withFileTypes: true });
+const listing = entries.map((e) => (e.isDirectory() ? `${e.name}/` : e.name)).join(', ');
+
+console.error(
+  [
+    '',
+    `✖ Package-root data/ leak detected: ${dataDir}`,
+    `  Contents: ${listing || '(empty)'}`,
+    '',
+    '  A test leaked a write to process.cwd()/data — the package root must never',
+    '  contain data/ (it is always consumer/playground-scoped). This usually means',
+    '  a fire-and-forget job outlived its test and wrote after teardown (#96).',
+    '',
+    '  Clean it and re-run:  rm -rf data',
+    '',
+  ].join('\n'),
+);
+
+process.exit(1);

--- a/src/api/handlers/media.ts
+++ b/src/api/handlers/media.ts
@@ -8,7 +8,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { imageSize } from 'image-size';
 import { getUploadsDir, resolveUploadPath } from '../../utils/paths.js';
-import { generateAndPersistVariants } from '../../utils/variant-generator.js';
+import { spawnVariantGeneration } from '../../utils/variant-generator.js';
 import { DEFAULT_ALLOWED_FILE_TYPES, lookupByMime } from '../../utils/file-catalog.js';
 import { evaluateUpload } from '../../utils/upload-gate.js';
 import type { FileCategory, MediaEntry } from '../../types/index.js';
@@ -397,7 +397,7 @@ export async function handleUpload(request: Request): Promise<Response> {
 
   // Build response first, then fire-and-forget variant generation (after response returns)
   const res = Response.json({ url, entry });
-  void generateAndPersistVariants(entry).catch(() => {});
+  spawnVariantGeneration(entry);
   return res;
 }
 
@@ -667,6 +667,6 @@ export async function handleReplaceUpload(request: Request, id: string): Promise
 
   // Build response, then fire-and-forget variant regen (same as handleUpload)
   const res = Response.json({ entry: updated });
-  void generateAndPersistVariants(updated).catch(() => {});
+  spawnVariantGeneration(updated);
   return res;
 }

--- a/src/utils/variant-generator.ts
+++ b/src/utils/variant-generator.ts
@@ -92,3 +92,32 @@ export async function generateAndPersistVariants(entry: MediaEntry): Promise<voi
     await data.markMediaVariantsFailed(entry.id);
   }
 }
+
+// In-flight variant jobs spawned fire-and-forget from the media handlers. The
+// job resolves the store path lazily at write time, so one that outlives its
+// caller writes to whatever process.cwd() resolves to then (see #96). Tracking
+// the promises lets a test drain them before it tears down the temp project.
+const pendingVariantJobs = new Set<Promise<void>>();
+
+/**
+ * Spawn variant generation as fire-and-forget (production behaviour) while
+ * registering the promise so tests can await completion via drainVariantJobs.
+ * Never throws; the job's own error handling marks the entry failed.
+ */
+export function spawnVariantGeneration(entry: MediaEntry): void {
+  const job = generateAndPersistVariants(entry).catch(() => {});
+  pendingVariantJobs.add(job);
+  void job.finally(() => pendingVariantJobs.delete(job));
+}
+
+/**
+ * Await every variant job spawned so far. Loops because draining is only
+ * meaningful before teardown, and a settling job could still be registered.
+ * Tests call this in withTempProject's teardown, before the temp root is
+ * removed and ASTRO_BLOCKS_PROJECT_ROOT is unset.
+ */
+export async function drainVariantJobs(): Promise<void> {
+  while (pendingVariantJobs.size > 0) {
+    await Promise.all([...pendingVariantJobs]);
+  }
+}

--- a/tests/allowed-file-types.test.js
+++ b/tests/allowed-file-types.test.js
@@ -17,6 +17,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { DEFAULT_ALLOWED_FILE_TYPES, intersectAccept } from '../dist/utils/file-catalog.js';
+import { drainVariantJobs } from '../dist/utils/variant-generator.js';
 
 // ─── R1.1-A: DEFAULT_ALLOWED_FILE_TYPES export is correct ────────────────────
 
@@ -114,6 +115,8 @@ test('R1.5-A: getAllowedFileTypes falls back to DEFAULT_ALLOWED_FILE_TYPES when 
     const res = await handleUpload(req);
     assert.equal(res.status, 200, 'image/jpeg should be accepted from default fallback allowlist');
   } finally {
+    // Drain fire-and-forget variant jobs before restoring the env var (#96).
+    await drainVariantJobs();
     if (previousRoot === undefined) delete process.env.ASTRO_BLOCKS_PROJECT_ROOT;
     else process.env.ASTRO_BLOCKS_PROJECT_ROOT = previousRoot;
     await rm(tempRoot, { recursive: true, force: true });

--- a/tests/media-alt-dimensions.test.js
+++ b/tests/media-alt-dimensions.test.js
@@ -18,6 +18,7 @@ import path from 'node:path';
 
 import { ensureDefaultFiles, loadMedia, saveUsers } from '../dist/api/data.js';
 import { handleUpload, handleUpdateMediaAlt } from '../dist/api/handlers.js';
+import { drainVariantJobs } from '../dist/utils/variant-generator.js';
 
 // Minimal JWT for auth tests
 import { SignJWT } from 'jose';
@@ -46,21 +47,6 @@ async function makeAuthToken() {
     .sign(JWT_SECRET);
 }
 
-/**
- * Poll loadMedia() until no entry has status:'processing'.
- * Drains fire-and-forget generateAndPersistVariants calls from handleUpload
- * before ASTRO_BLOCKS_PROJECT_ROOT is restored, preventing writes to repo root.
- */
-async function drainVariantJobs(maxWaitMs = 5000) {
-  const deadline = Date.now() + maxWaitMs;
-  while (Date.now() < deadline) {
-    const media = await loadMedia();
-    const pending = media.uploads.some((u) => u.status === 'processing');
-    if (!pending) return;
-    await new Promise((r) => setTimeout(r, 20));
-  }
-}
-
 async function withTempProject(fn) {
   const previousRoot = process.env.ASTRO_BLOCKS_PROJECT_ROOT;
   const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'astro-blocks-alt-dims-'));
@@ -68,9 +54,10 @@ async function withTempProject(fn) {
   await ensureDefaultFiles();
   try {
     await fn(tempRoot);
-    // Drain any fire-and-forget variant jobs before restoring the env var.
-    await drainVariantJobs();
   } finally {
+    // Drain fire-and-forget variant jobs before restoring the env var, so a job
+    // that outlives fn writes to the temp root (still active here) not cwd (#96).
+    await drainVariantJobs();
     if (previousRoot === undefined) {
       delete process.env.ASTRO_BLOCKS_PROJECT_ROOT;
     } else {

--- a/tests/media-handlers.test.js
+++ b/tests/media-handlers.test.js
@@ -27,26 +27,9 @@ import {
   handleReplaceUpload,
 } from '../dist/api/handlers.js';
 import { replaceMediaEntryBytes } from '../dist/api/data.js';
-import { generateAndPersistVariants } from '../dist/utils/variant-generator.js';
+import { generateAndPersistVariants, drainVariantJobs } from '../dist/utils/variant-generator.js';
 import { toImageValue } from '../dist/utils/image-value.js';
 import { validateBlockPropsAgainstSchema } from '../dist/utils/block-validation.js';
-
-/**
- * Poll loadMedia() until no entry has status:'processing'.
- * This drains any fire-and-forget generateAndPersistVariants calls that
- * handleUpload launches BEFORE we restore ASTRO_BLOCKS_PROJECT_ROOT — which
- * would otherwise cause the async write to land at process.cwd()/data instead
- * of the temp dir.
- */
-async function drainVariantJobs(maxWaitMs = 5000) {
-  const deadline = Date.now() + maxWaitMs;
-  while (Date.now() < deadline) {
-    const media = await loadMedia();
-    const pending = media.uploads.some((u) => u.status === 'processing');
-    if (!pending) return;
-    await new Promise((r) => setTimeout(r, 20));
-  }
-}
 
 async function withTempProject(fn) {
   const previousRoot = process.env.ASTRO_BLOCKS_PROJECT_ROOT;
@@ -57,11 +40,11 @@ async function withTempProject(fn) {
 
   try {
     await fn(tempRoot);
-    // Drain any fire-and-forget variant jobs launched by handleUpload before
-    // we restore the env var. Without this, those async writes race against the
-    // finally block and fall back to process.cwd()/data (repo root).
-    await drainVariantJobs();
   } finally {
+    // Drain fire-and-forget variant jobs launched by handleUpload before we
+    // restore the env var. Without this, those async writes race the teardown
+    // and fall back to process.cwd()/data (repo root) — see #96.
+    await drainVariantJobs();
     if (previousRoot === undefined) {
       delete process.env.ASTRO_BLOCKS_PROJECT_ROOT;
     } else {

--- a/tests/media-replace.test.js
+++ b/tests/media-replace.test.js
@@ -24,6 +24,7 @@ import {
   markMediaVariantsReady,
 } from '../dist/api/data.js';
 import { handleReplaceUpload } from '../dist/api/handlers.js';
+import { drainVariantJobs } from '../dist/utils/variant-generator.js';
 import { getMediaVariants } from '../dist/utils/getMediaVariants.js';
 
 // ─── Auth helpers ─────────────────────────────────────────────────────────────
@@ -64,6 +65,9 @@ async function withTempProject(fn) {
   try {
     await fn(tempRoot);
   } finally {
+    // Drain fire-and-forget variant jobs before restoring the env var, so a job
+    // that outlives fn writes to the temp root (still active here) not cwd (#96).
+    await drainVariantJobs();
     if (previousRoot === undefined) {
       delete process.env.ASTRO_BLOCKS_PROJECT_ROOT;
     } else {

--- a/tests/media-upload-limits.test.js
+++ b/tests/media-upload-limits.test.js
@@ -24,6 +24,7 @@ import path from 'node:path';
 
 import { ensureDefaultFiles } from '../dist/api/data.js';
 import { handleUpload, __setAllowedFileTypesForTest } from '../dist/api/handlers.js';
+import { drainVariantJobs } from '../dist/utils/variant-generator.js';
 
 const MB = 1024 * 1024;
 
@@ -42,6 +43,8 @@ async function withTempProject(allowed, env, fn) {
   try {
     await fn(tempRoot);
   } finally {
+    // Drain fire-and-forget variant jobs before restoring the env var (#96).
+    await drainVariantJobs();
     __setAllowedFileTypesForTest(null);
     if (prevRoot === undefined) delete process.env.ASTRO_BLOCKS_PROJECT_ROOT;
     else process.env.ASTRO_BLOCKS_PROJECT_ROOT = prevRoot;

--- a/tests/media-video-upload.test.js
+++ b/tests/media-video-upload.test.js
@@ -24,6 +24,7 @@ import path from 'node:path';
 
 import { ensureDefaultFiles, loadMedia } from '../dist/api/data.js';
 import { handleUpload, __setAllowedFileTypesForTest } from '../dist/api/handlers.js';
+import { drainVariantJobs } from '../dist/utils/variant-generator.js';
 
 /** Minimal MP4 header: a real `ftyp` box. The handler trusts Content-Type and never sniffs, but a
  *  test that ships plausible bytes is a test that keeps being honest if that ever changes. */
@@ -31,15 +32,6 @@ const MP4_BYTES = new Uint8Array([
   0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00,
   0x69, 0x73, 0x6f, 0x6d, 0x69, 0x73, 0x6f, 0x32, 0x61, 0x76, 0x63, 0x31, 0x6d, 0x70, 0x34, 0x31,
 ]);
-
-async function drainVariantJobs(maxWaitMs = 5000) {
-  const deadline = Date.now() + maxWaitMs;
-  while (Date.now() < deadline) {
-    const media = await loadMedia();
-    if (!media.uploads.some((u) => u.status === 'processing')) return;
-    await new Promise((r) => setTimeout(r, 20));
-  }
-}
 
 async function withTempProject(allowed, fn) {
   const previousRoot = process.env.ASTRO_BLOCKS_PROJECT_ROOT;
@@ -51,8 +43,9 @@ async function withTempProject(allowed, fn) {
 
   try {
     await fn(tempRoot);
-    await drainVariantJobs();
   } finally {
+    // Drain fire-and-forget variant jobs before restoring the env var (#96).
+    await drainVariantJobs();
     __setAllowedFileTypesForTest(null);
     if (previousRoot === undefined) delete process.env.ASTRO_BLOCKS_PROJECT_ROOT;
     else process.env.ASTRO_BLOCKS_PROJECT_ROOT = previousRoot;


### PR DESCRIPTION
Closes #96.

## Problem

`handleUpload` / `handleReplaceUpload` spawn `generateAndPersistVariants` fire-and-forget. The job resolves the store path **lazily at write time** (`getProjectRoot()` → `ASTRO_BLOCKS_PROJECT_ROOT || process.cwd()`). A job that outlives its test finishes *after* `withTempProject` has unset the env var, so its final registry write falls back to `process.cwd()/data` — leaking `data/media.json` into the repo root. `.gitignore` refuses to track it, but nothing stops the write, so the suite goes green while polluting the tree.

Reproduced deterministically: `rm -rf data && node --test tests/media-replace.test.js` left a `data/media.json` with a `doc.pdf` entry written after teardown.

## Scope decision (B + guard, not A)

`ASTRO_BLOCKS_PROJECT_ROOT` is **process-global** — set once at `astro:config:setup` and never unset in a running server, so `cwd == projectRoot` always holds in production. The "wrong root" only occurs when something unsets the env mid-flight, which today is exclusively the test harness. Binding the root at spawn (fix A) would be speculative generality with no multi-tenant on the roadmap. So this fixes what actually bites — the test leak and its latent non-determinism — and enforces the invariant, without threading a root through the media data API.

## Fix

- **Drainable fire-and-forget.** `spawnVariantGeneration` registers each job's promise; `drainVariantJobs` awaits them. The two handlers call `spawnVariantGeneration`; production stays fire-and-forget.
- **Deterministic drain in teardown.** The 6 test files that upload/replace now `await drainVariantJobs()` as the first line of `withTempProject`'s `finally`, before the env restore and temp-dir removal — so the job's write lands in the temp root. This **replaces three local poll-until-not-`processing` helpers** (5s timeout, non-deterministic) with one deterministic seam.
- **Guard.** `scripts/check-root-data-leak.mjs`, chained into `npm test`, fails the suite if a package-root `data/` exists after the run. A rule enforced only by `.gitignore` is a rule nothing enforces. Verified **red** against the leak, **green** after the drain.
- Recorded the gotcha in `docs/CONTEXT.md` (updates the existing obs #836 entry).

## Verification

- `npm test` → 1271 passing + guard green
- `media-replace` alone → no `data/` leak (was leaking `doc.pdf`)
- Touched files ×3 runs → stable, `data/` clean each time
- `typecheck` OK · no new lint warnings

## Out of scope

Fix A (bind root at spawn) — latent, masked by the process-global env model; not pursued (see scope note). No `spawnVariantGeneration` fire-and-forget site remains elsewhere in `src/`.