### PR TITLE
chore(release): 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [4.0.1] - 2026-07-20
+
+### Title
+
+A concurrent write can no longer discard a session revocation
+
+### Fixed
+
+- **Every mutation of `users.json` is now serialized behind a single seam.** Four code paths wrote the user store and two of them took no lock — and because each write persists the **whole list**, two overlapping requests overwrote each other across every record, not just the one they meant to change. What that could silently discard included the `tokenVersion` increment, which **is** a session revocation: an operator changed a compromised password, the API answered `200` and the admin reported success, while the token they believed they had killed stayed valid for the rest of its 7-day lifetime — with no error and no log line. User creation, deletion and role changes could be lost the same way. The last-owner guards and the email-uniqueness check are now re-validated against the freshly re-read list rather than a stale one, so they hold under concurrency too. Password hashing moved out of the critical section, so the two paths that already held the lock now hold it for less time than before. (#135, ADR-0030)
+
 ## [4.0.0] - 2026-07-19
 
 ### Title

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Licensed under the Business Source License 1.1
 </p>
 
 <p align="center">
-  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-4.0.0-blue" alt="version" /></a>
+  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-4.0.1-blue" alt="version" /></a>
   <img src="https://img.shields.io/badge/coverage-93.17%25-brightgreen" alt="coverage" />
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/v/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/dm/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm downloads" /></a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@astroblocks/astro-blocks",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@astroblocks/astro-blocks",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "BUSL-1.1",
       "workspaces": [
         "playgrounds/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astroblocks/astro-blocks",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Block-based content CMS integration for Astro with admin panel, page builder, menus, SEO and cache invalidation.",
   "homepage": "https://github.com/NauelG/astro-blocks#readme",
   "repository": {


### PR DESCRIPTION
## What & why

Release of the #135 fix, already merged to `main` (`8c69d98`, `6b4e08f`, `b235206`) but not yet on npm — `latest` still serves `4.0.0`, which contains the race.

**`patch`**: no API change, no config change, no contract change. Consumers upgrade with no action required.

## Scope

- [x] **Generic improvement** to the integration — not consumer site logic.
- Scope(s) touched: build/packaging · docs

## Checklist

- [x] **Conventional Commits**.
- [x] Branch is short-lived; diff is version bump + changelog entry only.
- [x] Quality gates pass locally:
  - [x] `npm test` — 1291/1291
  - [x] `npm run typecheck`
  - [x] `npm run features:validate`
  - [x] `npm run secrets` — no leaks
- [x] **CHANGELOG.md** updated — `### Fixed`, Keep a Changelog format with a `### Title`.
- [x] **`AGENTS.consumer.md` synced** — n/a, nothing in the public surface changed.
- [x] **README version badge** bumped to `4.0.1`.
- [x] `package-lock.json` bumped alongside `package.json` — the two disagreeing is what nearly shipped in `3.8.0`.
- [x] No closed ADR reopened.
- [x] No credentials, `.env` or `dist/` committed.

## Notes for reviewers

**The changelog entry leads with the consequence, not the mechanism.** "Serialized the user store behind a single seam" is what changed; "a password change could report success while leaving the revoked token alive for seven more days" is why anyone should read further and upgrade. A consumer scanning a patch release decides in one line whether it concerns them, and the mechanism does not help them decide.

**Why this deserves a prompt release rather than waiting to batch.** The defect is a lost session revocation with no error, no log line and nothing visible in the admin — an operator has no way to discover it happened. `4.0.0` is currently `latest`, so every new install gets the race.