### PR TITLE
chore(release): 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [4.0.2] - 2026-07-20
+
+### Title
+
+Select dropdowns are no longer cut off inside modals
+
+### Fixed
+
+- **The select dropdown escapes the modal that was clipping it.** Opening a select inside a modal — creating a redirect, editing a user — cut the options panel off at the edge of the modal body, added a scrollbar and made the dialog taller than its content. The panel was positioned absolutely, so the nearest scrolling ancestor both clipped it and counted it towards its own scrollable height. It is now positioned against the viewport and measured from its trigger, so no ancestor can clip it. If it does not fit below the field it opens upwards, and if it fits on neither side it shortens rather than covering the field being edited. (#138)
+
 ## [4.0.1] - 2026-07-20
 
 ### Title

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Licensed under the Business Source License 1.1
 </p>
 
 <p align="center">
-  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-4.0.1-blue" alt="version" /></a>
+  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-4.0.2-blue" alt="version" /></a>
   <img src="https://img.shields.io/badge/coverage-93.17%25-brightgreen" alt="coverage" />
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/v/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/dm/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm downloads" /></a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@astroblocks/astro-blocks",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@astroblocks/astro-blocks",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "BUSL-1.1",
       "workspaces": [
         "playgrounds/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astroblocks/astro-blocks",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Block-based content CMS integration for Astro with admin panel, page builder, menus, SEO and cache invalidation.",
   "homepage": "https://github.com/NauelG/astro-blocks#readme",
   "repository": {


### PR DESCRIPTION
## What & why

Release of the #138 fix, merged to `main` (`679db0f`, `89bf0eb`, `dda14dc`) but not yet on npm — `latest` still serves `4.0.1`, where the dropdown is still clipped.

**`patch`**: cosmetic, no API/config/contract change. Consumers upgrade with no action.

## Scope

- [x] **Generic improvement** to the integration — not consumer site logic.
- Scope(s) touched: build/packaging · docs

## Checklist

- [x] **Conventional Commits**.
- [x] Branch is short-lived; diff is version bump + changelog entry only.
- [x] Quality gates pass locally:
  - [x] `npm test` — 1291/1291
  - [x] `npm run typecheck`
  - [x] `npm run features:validate`
  - [x] `npm run secrets` — no leaks
- [x] **CHANGELOG.md** updated — `### Fixed`, with a `### Title`.
- [x] **`AGENTS.consumer.md` synced** — n/a, nothing in the public surface changed.
- [x] **README version badge** bumped to `4.0.2`.
- [x] `package-lock.json` bumped alongside `package.json`.
- [x] No closed ADR reopened.
- [x] No credentials, `.env` or `dist/` committed.

## Notes for reviewers

**The changelog entry describes the symptom, not the mechanism.** "Positioned against the viewport instead of its offset parent" is accurate and tells a consumer nothing about whether this release affects them. "Opening a select inside a modal cut the options panel off" is what they would have seen.

**Lower urgency than the last three releases, deliberately stated.** This is cosmetic — nothing is lost, no session survives that should not, no install breaks. It ships now only because leaving `main` ahead of npm is a state worth not letting grow; it would have been reasonable to batch it.