### PR TITLE
fix(admin): correct select panel position under a transformed ancestor

### DIFF
--- a/e2e/select-position.spec.ts
+++ b/e2e/select-position.spec.ts
@@ -1,0 +1,85 @@
+/*
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+*/
+
+/**
+ * The enhanced select panel is position: fixed (#138, ADR-0031). A `fixed` element only resolves
+ * against the viewport while no ancestor establishes a containing block, and transform / filter /
+ * will-change all do — .cms-topbar-dropdown animates with a transform, which put the UI-locale
+ * panel ~1000px off-screen after #138 shipped.
+ *
+ * These cover all three contexts a select lives in, because #138 verified only one and generalised.
+ */
+
+import { test, expect } from '@playwright/test';
+
+async function login(page: import('@playwright/test').Page): Promise<void> {
+  await page.goto('/cms');
+  await page.locator('#cms-auth-forms').waitFor({ state: 'visible', timeout: 15_000 });
+  await page.locator('#cms-email-input').fill('owner@example.com');
+  await page.locator('#cms-password-input').fill('password123');
+  await page.locator('#cms-login-btn').click();
+  await page.locator('#admin-content').waitFor({ state: 'visible', timeout: 20_000 });
+}
+
+/** Geometry of the open panel relative to its own trigger — the invariant, in every context. */
+async function openPanelGeometry(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const menu = document.querySelector('.cms-select--open .cms-select-menu') as HTMLElement | null;
+    const trigger = document.querySelector(
+      '.cms-select--open .cms-select-trigger',
+    ) as HTMLElement | null;
+    if (!menu || !trigger) return null;
+    const m = menu.getBoundingClientRect();
+    const t = trigger.getBoundingClientRect();
+    return {
+      alignedLeft: Math.abs(m.left - t.left) <= 1,
+      sameWidth: Math.abs(m.width - t.width) <= 1,
+      adjacent: Math.abs(m.top - t.bottom) <= 8 || Math.abs(m.bottom - t.top) <= 8,
+      onScreen:
+        m.left >= 0 && m.top >= 0 && m.right <= window.innerWidth && m.bottom <= window.innerHeight,
+    };
+  });
+}
+
+test('select panel: topbar (no containing block)', async ({ page }) => {
+  await login(page);
+  await page
+    .locator('#cms-content-locale-select')
+    .locator('xpath=..')
+    .locator('.cms-select-trigger')
+    .click();
+  await page.waitForTimeout(300);
+  const g = await openPanelGeometry(page);
+  expect(g, 'the panel must be open').not.toBeNull();
+  expect(g).toMatchObject({ alignedLeft: true, sameWidth: true, adjacent: true, onScreen: true });
+});
+
+test('select panel: inside the profile dropdown (transformed ancestor)', async ({ page }) => {
+  await login(page);
+  await page.locator('#cms-profile-trigger').click();
+  await page.waitForTimeout(300);
+  await page
+    .locator('#cms-ui-locale-select')
+    .locator('xpath=..')
+    .locator('.cms-select-trigger')
+    .click();
+  await page.waitForTimeout(300);
+  const g = await openPanelGeometry(page);
+  expect(g, 'the panel must be open').not.toBeNull();
+  expect(g).toMatchObject({ alignedLeft: true, sameWidth: true, adjacent: true, onScreen: true });
+});
+
+test('select panel: inside a modal (clipping ancestors)', async ({ page }) => {
+  await login(page);
+  await page.goto('/cms/redirects');
+  await page.locator('#cms-redirect-new-btn').click();
+  await page.locator('#redirect-detail-modal').waitFor({ state: 'visible', timeout: 10_000 });
+  await page.waitForTimeout(300);
+  await page.locator('#redirect-detail-modal .cms-select-trigger').first().click();
+  await page.waitForTimeout(300);
+  const g = await openPanelGeometry(page);
+  expect(g, 'the panel must be open').not.toBeNull();
+  expect(g).toMatchObject({ alignedLeft: true, sameWidth: true, adjacent: true, onScreen: true });
+});

--- a/src/routes/admin/layout.astro
+++ b/src/routes/admin/layout.astro
@@ -726,10 +726,25 @@ const t = createT(uiLocale);
           const rect = entry.trigger.getBoundingClientRect();
           const menu = entry.menu;
 
-          menu.style.left = `${rect.left}px`;
-          menu.style.width = `${rect.width}px`;
           // Clear a cap left by a previous open, or the panel would shrink further every time.
           menu.style.maxHeight = '';
+
+          // A `fixed` element resolves against the viewport ONLY while no ancestor establishes a
+          // containing block — transform, filter, backdrop-filter, will-change and contain all do.
+          // .cms-topbar-dropdown animates with a transform, so the UI-locale select inside it had
+          // its viewport coordinates reinterpreted relative to the dropdown and landed ~1000px
+          // off-screen: open, invisible, no error.
+          //
+          // Rather than enumerate the properties that trap it — enumerating is exactly what went
+          // wrong when this was written (#138) — park the panel at 0,0 and measure where that
+          // lands. `origin` is the containing block's offset in viewport coordinates, whatever
+          // created it, so subtracting it makes the maths correct for cases nobody has thought of.
+          menu.style.left = '0px';
+          menu.style.top = '0px';
+          const origin = menu.getBoundingClientRect();
+
+          menu.style.left = `${rect.left - origin.left}px`;
+          menu.style.width = `${rect.width}px`;
 
           // Measure after the panel is laid out; the stylesheet's max-height caps it, but the
           // content may be shorter.
@@ -750,9 +765,11 @@ const t = createT(uiLocale);
           }
 
           const height = menu.offsetHeight;
-          menu.style.top = flip
-            ? `${Math.max(MENU_GAP, rect.top - MENU_GAP - height)}px`
-            : `${rect.bottom + MENU_GAP}px`;
+          const top = flip
+            ? Math.max(MENU_GAP, rect.top - MENU_GAP - height)
+            : rect.bottom + MENU_GAP;
+          // Same correction as `left`: `top` is a viewport coordinate, the style property is not.
+          menu.style.top = `${top - origin.top}px`;
         }
 
         function openMenu(entry: ManagedSelect): void {


### PR DESCRIPTION
## What & why

The UI-language selector in the profile dropdown does not open — no console error, nothing visible. Reported from the playground.

It **does** open. The panel is drawn about 1000px past the right edge of the window.

Closes #146 · regression from #138, **released in `4.0.2`**.

### Measured

Profile dropdown open, viewport 1280 wide:

```
trigger rect:      left=1029  top=162
positionMenu set:  left=1029px  top=196px     ← correct viewport coordinates
panel rendered at: left=2035  top=258         ← +1006px
onScreen: false
```

### Cause

#138 made `.cms-select-menu` `position: fixed`, with `openMenu` writing `top`/`left`/`width` from the trigger's `getBoundingClientRect()` — viewport coordinates.

A `fixed` element resolves against the viewport **only while no ancestor establishes a containing block**. `transform`, `filter`, `backdrop-filter`, `will-change` and `contain` all do:

```css
.cms-topbar-dropdown {
  position: fixed;
  transform: translateY(-6px) scale(0.98);   /* ← containing block */
}
```

Inside the dropdown, those coordinates are reinterpreted relative to the dropdown's box.

### Fix

`positionMenu` parks the panel at `0,0`, measures where that lands, and subtracts the offset. That value **is** the containing block's position in viewport coordinates, whatever created it.

Chosen over detecting transformed ancestors deliberately: **the enumeration is what failed.** #138 checked the modal path, found `backdrop-filter` only on `::backdrop` — a pseudo-element, which does not trap — and generalised to all nine selects. A fix that does not need the enumeration cannot repeat the bug. Cost: one extra reflow per open.

## Scope

- [x] **Generic improvement** to the integration — not consumer site logic.
- Scope(s) touched: admin-ui

## Checklist

- [x] **Conventional Commits** — body explains WHY.
- [x] Small: one function, plus a new e2e spec.
- [x] Quality gates pass locally:
  - [x] `npm test` — 1291/1291
  - [x] `npm run typecheck`
  - [x] `npx biome ci .` — exit 0
  - [x] `npm run e2e` — **14/14** (11 existing + 3 new)
- [ ] **CHANGELOG.md** — in the release PR that follows, as a `patch`.
- [x] **`AGENTS.consumer.md` synced** — n/a, public surface unchanged.
- [x] No ADR reopened. ADR-0031's decision stands; this corrects its implementation, and the ADR already named `popover` as the successor if anchoring ever needs to survive scroll.
- [x] No credentials, `.env` or `dist/` committed.

## Notes for reviewers

**Two process failures produced this, and the second is the one worth reading.**

1. The containing-block check in #138 was done for **one** context and generalised to nine. The topbar dropdown's `transform` had been there all along.

2. **A failing test was explained away.** #138's own verification tried to click `#cms-ui-locale-select`, hit a timeout, and I attributed it to the select sitting inside a collapsed dropdown — then switched to `#cms-content-locale-select`, which is *not* inside the dropdown, and it passed. The test that would have caught this was written, failed, and was reasoned around instead of investigated.

**The new spec covers all three contexts a select lives in** — topbar (no containing block), profile dropdown (transformed ancestor), modal (clipping ancestors) — and asserts panel geometry *relative to its own trigger*, which is the invariant that holds everywhere.

Verified against the pre-fix build: **1 failed, 2 passed**, failing on exactly the dropdown case. That distribution is the shape of the hole the original verification fell through.