### PR TITLE
chore(release): 4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [4.0.3] - 2026-07-20
+
+### Title
+
+The interface-language selector opens again
+
+### Fixed
+
+- **The UI-language selector inside the profile menu did not open.** Clicking it did nothing and reported no error. Introduced in `4.0.2`: the fix that stopped select dropdowns being clipped inside modals repositioned every dropdown against the viewport, and the profile menu animates with a CSS transform — which silently changes what "against the viewport" means for anything inside it. The panel was opening around a thousand pixels off the right edge of the screen. Dropdown panels are now positioned by measuring where they actually land rather than by assuming, so the calculation holds inside any container. Only the admin panel's own selectors were affected; a site's public language switcher never was. (#146)
+
 ## [4.0.2] - 2026-07-20
 
 ### Title

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Licensed under the Business Source License 1.1
 </p>
 
 <p align="center">
-  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-4.0.2-blue" alt="version" /></a>
+  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-4.0.3-blue" alt="version" /></a>
   <img src="https://img.shields.io/badge/coverage-93.17%25-brightgreen" alt="coverage" />
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/v/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/dm/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm downloads" /></a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@astroblocks/astro-blocks",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@astroblocks/astro-blocks",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "BUSL-1.1",
       "workspaces": [
         "playgrounds/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astroblocks/astro-blocks",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Block-based content CMS integration for Astro with admin panel, page builder, menus, SEO and cache invalidation.",
   "homepage": "https://github.com/NauelG/astro-blocks#readme",
   "repository": {


### PR DESCRIPTION
## What & why

Release of the #146 fix, merged to `main` (`3e25b15`) but not on npm — `latest` still serves `4.0.2`, where the UI-language selector is broken.

**`patch`**, and a fast one on purpose: `4.0.2` shipped the regression roughly two hours ago, so every install since then has it.

Deliberately minimal — only the fix. #145 (the #65 lint ratchet) is unrelated tooling and stays out, so if anything goes wrong with this release there is exactly one candidate.

## Scope

- [x] **Generic improvement** to the integration — not consumer site logic.
- Scope(s) touched: build/packaging · docs

## Checklist

- [x] **Conventional Commits**.
- [x] Version bump + changelog entry only.
- [x] Quality gates pass locally:
  - [x] `npm test` — 1291/1291
  - [x] `npm run typecheck`
  - [x] `npx biome ci .` — exit 0
  - [x] `npm run features:validate`
  - [x] `npm run secrets` — no leaks
- [x] **CHANGELOG.md** updated — `### Fixed`, with a `### Title`.
- [x] **`AGENTS.consumer.md` synced** — n/a, public surface unchanged.
- [x] **README version badge** bumped to `4.0.3`.
- [x] `package-lock.json` bumped alongside `package.json`.
- [x] No closed ADR reopened.
- [x] No credentials, `.env` or `dist/` committed.

## Notes for reviewers

**The changelog entry states that we caused it, in the version that caused it.** Someone who upgraded to `4.0.2`, hit this, and went looking needs to learn three things: it was ours, it arrived in `4.0.2`, and upgrading fixes it. Describing it as "containing-block resolution for fixed positioning" would be accurate and useless to them — so the entry leads with "clicking it did nothing and reported no error", which is what they saw.

It also states the blast radius explicitly — **only the admin panel's own selectors; a site's public language switcher was never affected** — because that is the first question anyone reading a regression notice actually has.