### PR TITLE
chore(release): 4.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [4.0.4] - 2026-07-20
+
+### Title
+
+Repeated failed logins are slowed down
+
+### Fixed
+
+- **The admin login had no defense against password guessing.** Nothing limited how many attempts an unauthenticated caller could make against the owner account: password hashing made each guess expensive, but nothing bounded the number of guesses. Repeated failures for the same email now wait progressively longer — the first few attempts are answered immediately, then the delay doubles up to a few seconds — which takes a sustained attacker from thousands of guesses per minute to roughly seven. A correct password clears the delay instantly, and it is forgotten entirely after fifteen minutes of no attempts, so an owner who mistypes their password is never locked out or made to wait on their next visit. (#125)
+
+  Two details worth knowing when planning a deployment. The delay is tracked **in memory per server process**, so it does not survive a restart and is not shared between instances — a rate limit at your reverse proxy or edge is still the layer that bounds request volume, and this is defense in depth beneath it. And it is keyed by **email address only, never by client IP**: behind a proxy the address the application sees belongs to the proxy, and the forwarded-for header is set by the caller, so neither is a value this package can trust. See the new *Login throttling* section in the README.
+
+  A throttled attempt is deliberately indistinguishable from any other failed login — same response, same status — and the delay builds the same way for email addresses that have no account, so the protection never reveals which addresses are registered.
+
 ## [4.0.3] - 2026-07-20
 
 ### Title

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Licensed under the Business Source License 1.1
 </p>
 
 <p align="center">
-  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-4.0.3-blue" alt="version" /></a>
+  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-4.0.4-blue" alt="version" /></a>
   <img src="https://img.shields.io/badge/coverage-93.17%25-brightgreen" alt="coverage" />
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/v/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/dm/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm downloads" /></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astroblocks/astro-blocks",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Block-based content CMS integration for Astro with admin panel, page builder, menus, SEO and cache invalidation.",
   "homepage": "https://github.com/NauelG/astro-blocks#readme",
   "repository": {

--- a/src/meta/features.json
+++ b/src/meta/features.json
@@ -144,11 +144,11 @@
     {
       "id": "users-and-auth",
       "title": "Users and authentication",
-      "summary": "Session-based CMS authentication with owner and user roles. Requires ASTRO_BLOCKS_JWT_SECRET in production; auth fails closed without it. Sessions are revocable: every request re-validates against the user store, so deleting or demoting a user takes effect immediately and a password change signs the user out everywhere.",
+      "summary": "Session-based CMS authentication with owner and user roles. Requires ASTRO_BLOCKS_JWT_SECRET in production; auth fails closed without it. Sessions are revocable: every request re-validates against the user store, so deleting or demoting a user takes effect immediately and a password change signs the user out everywhere. Repeated failed logins for the same email accrue a capped exponential backoff (in-process, keyed by email only, never by client IP), so a reverse-proxy rate limit remains the expected production layer.",
       "category": "auth",
       "status": "alpha",
       "sinceVersion": "0.3.0",
-      "updatedIn": "3.7.0",
+      "updatedIn": "4.0.4",
       "docsPath": "#cms-routes"
     },
     {


### PR DESCRIPTION
## What & why

Patch release for the login backoff.

Closes nothing on its own — the work landed in #150 (closes #125).

### Included

- **#125 / #150** — capped exponential backoff on repeated failed logins. User-facing, so it gets the changelog entry.
- **#65 / #145** — the Biome unused-code ratchet, on `main` since 4.0.3. Tooling: it changes what CI refuses to accept, not what the product does, so per `AGENTS.md` it carries no changelog entry. Noted here so the diff between tags is not a surprise.

### Bumps

| File | Change |
| --- | --- |
| `package.json` | `4.0.3` → `4.0.4` |
| `README.md:17` | version badge |
| `CHANGELOG.md` | new `[4.0.4]` entry with `### Title` |
| `src/meta/features.json` | `users-and-auth` summary + `updatedIn: 4.0.4` |

`patch` per `AGENTS.md` *Versionado*: a fix, no new capability and no breaking change. The auth surface is unchanged — same endpoint, same request, same responses.

## Scope

- [x] **Generic improvement** to the integration.
- Scope(s) touched: docs · build/packaging

## Checklist

- [x] **Conventional Commits** — no AI attribution in commits or PR description.
- [x] Quality gates pass locally:
  - [x] `npm test` — 1 304 pass, 0 fail
  - [x] `npm run typecheck`
  - [x] `npm run features:validate` — 26 features valid
  - [x] `npm run check` (`biome ci`) — 0 errors
  - [x] `npm run secrets` (gitleaks — no leaks)
- [x] **CHANGELOG.md** updated — Keep a Changelog, `### Title` present.
- [x] **README version badge** bumped (line 17).
- [x] **`AGENTS.consumer.md`** — already synced in #150.
- [x] **Playground sample** — N/A, no new feature surface.
- [x] No incidental changes under `playgrounds/` or `data/`.
- [x] No credentials, `.env` files or `dist/` artifacts committed.

## After merge

Annotated tag `v4.0.4` on the merge commit, pushed with `--follow-tags`, which triggers the npm publish and the GitHub Release.