### PR TITLE
docs(consumer): sessions are stateful, and a Users import revokes all of them

### DIFF
--- a/AGENTS.consumer.md
+++ b/AGENTS.consumer.md
@@ -563,7 +563,7 @@ Navigate to `/cms/import-export` in the admin panel. The page allows you to:
 - Preview the `manifest.json` inside an uploaded archive before committing.
 - Confirm the destructive replace-all action explicitly.
 
-When the **Users** unit is imported the current session is invalidated and the browser is redirected to the login screen (current-browser-only; other active sessions remain valid because sessions are stateless JWTs).
+When the **Users** unit is imported, **every session on the instance is revoked** — not just the current browser's. The importing browser is redirected to the login screen; every other logged-in user and device is signed out too, and any token issued before the import stops being accepted. This is deliberate: a restore replaces the whole user store, so it is treated as a security event rather than a data operation. Expect to log in again everywhere after importing this unit.
 
 ### Content units
 
@@ -756,7 +756,7 @@ The `<GlobalBlock>` component resolves the correct locale value at render time u
 
 ## Authentication (admin UI)
 
-The admin UI at `/cms` uses stateless JWT sessions. The admin account is created on **first login** — there are no admin credentials to configure in the environment.
+The admin UI at `/cms` authenticates with a JWT carried in a request header, **verified against the user store on every request**. Sessions are therefore revocable, not stateless: each user record holds a session generation, and a token whose generation no longer matches is rejected. Deleting a user, changing a password, or importing the Users unit takes effect immediately on tokens already issued. The admin account is created on **first login** — there are no admin credentials to configure in the environment.
 
 ### Required environment variable
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ yarn add @astroblocks/astro-blocks @astrojs/node
 
 ## Environment Setup
 
-The admin UI at `/cms` uses stateless JWT sessions. The admin account is created on **first login** — there are no admin username/password variables to configure.
+The admin UI at `/cms` authenticates with a JWT carried in a request header, verified against the user store on every request — so sessions are revocable, not stateless. Deleting a user or changing a password signs them out everywhere immediately, even though their token has not expired. The admin account is created on **first login** — there are no admin username/password variables to configure.
 
 | Variable | Required | Description |
 | --- | --- | --- |
@@ -583,6 +583,8 @@ The Import / Export admin page (`/cms/import-export`, owner only) backs up and r
 | Configuration | `data/configs.json`, `data/site.json`, `data/languages.json`, `data/menus.json`, `data/redirects.json` |
 
 Export streams a single `.zip` (selected data files + a `manifest.json` recording the schema version, timestamp and per-file SHA-256 checksums). Import validates structure and checksums before applying, then replaces selected units **in full** — a pre-replace snapshot is written to `data/_backups/` automatically (retention: 5). When an instance has no users yet, the login screen offers a bootstrap import to seed an initial data set with no admin account required. The underlying REST endpoints (`GET /cms/api/export`, `POST /cms/api/import`, `POST /cms/api/import/bootstrap`) and their auth rules are documented in [AGENTS.consumer.md → Import / Export](./AGENTS.consumer.md#import--export-backup-and-restore).
+
+**Importing the Users unit signs everyone out.** Every session on the instance is revoked — not only the browser performing the import — and every token issued beforehand stops being accepted. A restore replaces the whole user store, so it is treated as a security event rather than a data operation: plan to log in again on every device afterwards. The other four units do not affect sessions.
 
 Three environment variables control import size limits (defaults: `ASTRO_BLOCKS_MAX_IMPORT_FILE_BYTES` = 50 MB, `ASTRO_BLOCKS_MAX_IMPORT_TOTAL_BYTES` = 500 MB, `ASTRO_BLOCKS_MAX_IMPORT_COMPRESSED_BYTES` = 1 GB).
 


### PR DESCRIPTION
## What & why

`AGENTS.consumer.md` told consumers that importing the Users unit leaves other sessions valid *"because sessions are stateless JWTs"*. Both halves are wrong, and the first one **inverts a security property**.

Closes #149

### The inverted claim

`AGENTS.consumer.md:566` said:

> current-browser-only; **other active sessions remain valid** because sessions are stateless JWTs

`docs/specs/session-auth.md` R4 says the opposite:

> every restored record is written at one generation **above the high-water mark** … **revoking every session on the instance** (ADR-0028)

A consumer planning around "my other devices stay logged in" is signed out everywhere with no warning, and anyone reasoning about incident response has the guarantee backwards. This file ships in the npm tarball (ADR-005) and is what a consumer's AI assistant reads, so the wrong claim propagates into generated code and advice.

### The stale premise

Sessions stopped being stateless in **ADR-0027**. `getAuth` verifies the signature *and* re-loads the user from `users.json` on every request, rejecting on a `tokenVersion` mismatch (spec R1/R3). That statefulness is what makes revocation possible at all — the old wording described the very design ADR-0027 replaced.

## Changes

| Location | Was | Now |
| --- | --- | --- |
| `AGENTS.consumer.md:566` | other sessions remain valid | every session on the instance is revoked, and why |
| `AGENTS.consumer.md:759` | "stateless JWT sessions" | header-carried JWT verified against the store per request, with a session generation |
| `README.md:175` | "stateless JWT sessions" | same, in consumer-facing terms |
| `README.md` Import / Export | *silent* | added: importing Users signs everyone out; the other four units do not affect sessions |

The README's Import / Export section was not wrong, it was **silent** — for a destructive operation, an omission this size costs about as much as the wrong sentence.

### Deliberately left alone

`CHANGELOG.md:516` and `ADR-0027` also say "stateless", and there it is **correct**: both describe what was true at the time. Both are immutable history, and editing them to match today would destroy the record of the change ADR-0027 exists to document.

### Verified, not assumed

"The other four units do not affect sessions" was checked against `src/api/backup.ts:716` — `usersReplaced: selectedUnits.includes('users')` — rather than inferred from the unit list.

## Scope

- [x] **Generic improvement** to the integration.
- Scope(s) touched: docs

## Checklist

- [x] **Conventional Commits** — body explains WHY. No AI attribution in commits or PR description.
- [x] Branch is short-lived; diff is small.
- [x] Quality gates pass locally:
  - [x] `npm run features:validate` — 26 features valid
  - [x] `npm run check` (`biome ci`) — 0 errors
  - [x] `npm run secrets` (gitleaks — no leaks)
- [x] **CHANGELOG.md** not updated — documentation correction, no behaviour change. The behaviour being described has been in place since ADR-0027; only the description of it was wrong.
- [x] **`AGENTS.consumer.md` synced** — it is the subject of this PR.
- [x] **README version badge** — N/A, not a release PR.
- [x] **Playground sample** — N/A, no feature.
- [x] No closed ADR reopened. ADR-0027 and ADR-0028 are cited, not modified.
- [x] No credentials, `.env` files or `dist/` artifacts committed.

## Note for the next release

The wrong text shipped in the `4.0.4` tarball published minutes before this was written. Nothing is broken by it, but the corrected `AGENTS.consumer.md` only reaches consumers with the next publish.