### PR TITLE
chore(release): 4.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [4.0.5] - 2026-07-20
+
+### Title
+
+Corrected documentation: importing users signs everyone out
+
+### Fixed
+
+- **The bundled documentation described session behaviour backwards.** `AGENTS.consumer.md` stated that importing the Users unit invalidated only the importing browser and that "other active sessions remain valid because sessions are stateless JWTs". The opposite is true, and has been since `3.7.0`: importing the Users unit **revokes every session on the instance**, and every token issued beforehand stops being accepted. Anyone who planned around other devices staying signed in was in for a surprise, and anyone reasoning about incident response had the guarantee inverted. (#149)
+
+  The stale premise is corrected in both bundled documents: sessions are **not** stateless. Every request re-validates the token against the user store, which is exactly what makes deleting a user, changing a password or restoring the user store take effect immediately rather than whenever the token happens to expire.
+
+  The README's Import / Export section, which never mentioned sessions at all, now says plainly that importing Users signs everyone out and that the other four units do not affect sessions.
+
+  Documentation only — no behaviour changed. This release exists so the corrected `AGENTS.consumer.md`, which ships inside the package and is what AI coding assistants read, reaches consumers rather than waiting for the next functional change.
+
 ## [4.0.4] - 2026-07-20
 
 ### Title

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Licensed under the Business Source License 1.1
 </p>
 
 <p align="center">
-  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-4.0.4-blue" alt="version" /></a>
+  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-4.0.5-blue" alt="version" /></a>
   <img src="https://img.shields.io/badge/coverage-93.17%25-brightgreen" alt="coverage" />
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/v/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/dm/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm downloads" /></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astroblocks/astro-blocks",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Block-based content CMS integration for Astro with admin panel, page builder, menus, SEO and cache invalidation.",
   "homepage": "https://github.com/NauelG/astro-blocks#readme",
   "repository": {


### PR DESCRIPTION
## What & why

Documentation-only patch release, cut deliberately rather than waiting for the next functional change.

`AGENTS.consumer.md` ships inside the npm tarball (ADR-005) and is what a consumer's AI coding assistant reads. Until this is published, every consumer installing the package gets a document stating that importing the Users unit leaves other sessions valid — the inverse of what happens — and their assistant will repeat it in generated advice. That is the entire reason for the release.

### Included

- **#149 / #152** — `docs(consumer): sessions are stateful, and a Users import revokes all of them`. No behaviour change; the behaviour being described has been in place since `3.7.0` (ADR-0027) and only the description was wrong.

### Bumps

| File | Change |
| --- | --- |
| `package.json` | `4.0.4` → `4.0.5` |
| `README.md:17` | version badge |
| `CHANGELOG.md` | new `[4.0.5]` entry with `### Title` |

`src/meta/features.json` is **deliberately unchanged**: `users-and-auth` already describes sessions as revocable, and no capability changed here — bumping its `updatedIn` would claim otherwise.

`patch` per `AGENTS.md` *Versionado*: no new capability, no breaking change, no behaviour change at all.

## Scope

- [x] **Generic improvement** to the integration.
- Scope(s) touched: docs · build/packaging

## Checklist

- [x] **Conventional Commits** — no AI attribution in commits or PR description.
- [x] Quality gates pass locally:
  - [x] `npm test` — 1 304 pass, 0 fail
  - [x] `npm run typecheck`
  - [x] `npm run features:validate` — 26 features valid
  - [x] `npm run check` (`biome ci`) — 0 errors
  - [x] `npm run secrets` (gitleaks — no leaks)
- [x] **CHANGELOG.md** updated — Keep a Changelog, `### Title` present. A docs-only release still earns an entry here, because the artefact being corrected is one consumers receive.
- [x] **README version badge** bumped (line 17).
- [x] **`AGENTS.consumer.md`** — corrected in #152, which is what this ships.
- [x] **Playground sample** — N/A, no feature.
- [x] No incidental changes under `playgrounds/` or `data/`.
- [x] No credentials, `.env` files or `dist/` artifacts committed.

## After merge

Annotated tag `v4.0.5` on the merge commit, pushed with `--follow-tags`, triggering the npm publish and the GitHub Release.