### PR TITLE
chore(release): 4.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [4.0.6] - 2026-07-21
+
+### Title
+
+The upload picker and the server agree on the allowed file types
+
+### Fixed
+
+- **The admin upload picker could offer file types the server would reject.** The allowed-file-type list was decoded in three places — the upload endpoint and two admin surfaces (the media page and the block-form file picker) — and the three did not agree. The two admin surfaces required a non-empty list and, for anything they considered invalid, quietly fell back to the full default catalog; the server did not. So a project that configured `allowedFileTypes` narrowly (or to an empty list, which rejects everything) could see the picker advertise types the server then refused on upload. All three now share a single decoder, so what the picker offers cannot drift from what the server accepts, and a malformed entry is rejected rather than passed through to the picker uncoerced. The `accept` attribute remains a picker hint only — the server has always been the enforcement point. (#116)
+
+### Changed
+
+- **Internal: the build-time "bake" is now a single module.** The mechanism that carries configuration and runtime registries into the server bundle (double-encoding on write, guarded decoding on read) was previously reimplemented at every reader — the source of several past resolution bugs. It now lives in one place. No consumer-visible behaviour change beyond the allowlist fix above. (#116)
+
 ## [4.0.5] - 2026-07-20
 
 ### Title

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Licensed under the Business Source License 1.1
 </p>
 
 <p align="center">
-  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-4.0.5-blue" alt="version" /></a>
+  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-4.0.6-blue" alt="version" /></a>
   <img src="https://img.shields.io/badge/coverage-93.17%25-brightgreen" alt="coverage" />
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/v/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/dm/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm downloads" /></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astroblocks/astro-blocks",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "Block-based content CMS integration for Astro with admin panel, page builder, menus, SEO and cache invalidation.",
   "homepage": "https://github.com/NauelG/astro-blocks#readme",
   "repository": {


### PR DESCRIPTION
## What & why

Patch release for the deep-bake-module refactor.

Closes nothing on its own — the work landed in #154 (closed #116).

### Included

- **#116 / #154** — the bake is now a single deep module (`defineBakedValue` / `readBaked*`), replacing the per-reader decode that had the codebase's worst bug record. It carries a contained, consumer-visible fix: the admin upload picker and the server now decode the allowed-file-type list through one validator, so the picker can no longer advertise types the server would reject, and malformed entries are rejected instead of passed through. `### Fixed` + `### Changed` in the changelog.

### Bumps

| File | Change |
| --- | --- |
| `package.json` | `4.0.5` → `4.0.6` |
| `README.md:17` | version badge |
| `CHANGELOG.md` | new `[4.0.6]` entry with `### Title` |

`src/meta/features.json` is **deliberately unchanged**: no described capability changed — the refactor is internal and the allowlist fix is an edge-case agreement, so bumping any feature's `updatedIn` would misrepresent it.

`patch` per `AGENTS.md`: a refactor plus a contained fix, no new capability, no breaking change.

## Scope

- [x] **Generic improvement** to the integration.
- Scope(s) touched: docs · build/packaging

## Checklist

- [x] **Conventional Commits** — no AI attribution in commits or PR description.
- [x] Quality gates pass locally:
  - [x] `npm test` — 1311 pass, 0 fail
  - [x] `npm run typecheck`
  - [x] `npm run features:validate` — 26 features valid
  - [x] `npm run check` (`biome ci`) — 0 errors
  - [x] `npm run secrets` (gitleaks — no leaks)
- [x] **CHANGELOG.md** updated — Keep a Changelog, `### Title` present.
- [x] **README version badge** bumped (line 17).
- [x] **`AGENTS.consumer.md`** — unchanged; no public API/option/route/env var changed.
- [x] **Playground sample** — N/A, no new feature surface.
- [x] No incidental changes under `playgrounds/` or `data/`.
- [x] No credentials, `.env` files or `dist/` artifacts committed.

## After merge

Annotated tag `v4.0.6` on the merge commit, pushed with `--follow-tags`, triggering the npm publish and the GitHub Release.