### PR TITLE
chore(release): 4.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [4.0.7] - 2026-07-21
+
+### Title
+
+File-field validation errors are now translated
+
+### Fixed
+
+- **A validation error on a file field showed a raw internal key instead of a message.** When a block's file field failed validation — the value was not a file object, or a file had no URL — the admin editor displayed the literal text `blockValidation.fieldMustBeFile` (or `…fieldFileNeedsUrl`) instead of a readable sentence, in both English and Spanish. Two message keys had drifted out of the translation catalogs while remaining in the validator. Both are now present and translated, so file-field errors read like every other validation message. (#40)
+
+### Changed
+
+- **Internal: the admin translation catalogs and the block-validation messages are now checked by the compiler.** Catalog parity between English and Spanish, and the single source for validation-message text, were previously kept aligned by hand and by a comment — which is how the bug above shipped unnoticed. They are now enforced at build time, so this class of drift cannot recur silently. No consumer-visible behaviour change beyond the fix above. (#40)
+
 ## [4.0.6] - 2026-07-21
 
 ### Title

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Licensed under the Business Source License 1.1
 </p>
 
 <p align="center">
-  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-4.0.6-blue" alt="version" /></a>
+  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-4.0.7-blue" alt="version" /></a>
   <img src="https://img.shields.io/badge/coverage-93.17%25-brightgreen" alt="coverage" />
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/v/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/dm/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm downloads" /></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astroblocks/astro-blocks",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "description": "Block-based content CMS integration for Astro with admin panel, page builder, menus, SEO and cache invalidation.",
   "homepage": "https://github.com/NauelG/astro-blocks#readme",
   "repository": {


### PR DESCRIPTION
## What & why

Patch release for the i18n compiler-parity refactor.

Closes nothing on its own — the work landed in #156 (closed #40).

### Included

- **#40 / #156** — catalog parity and the block-validation messages are now compiler-enforced. Carries a consumer-visible fix: a file-field validation error used to render the raw key `blockValidation.fieldMustBeFile` in both languages because two keys had drifted out of the catalogs; both are now present and translated. `### Fixed` + `### Changed` in the changelog.

### Bumps

| File | Change |
| --- | --- |
| `package.json` | `4.0.6` → `4.0.7` |
| `README.md:17` | version badge |
| `CHANGELOG.md` | new `[4.0.7]` entry with `### Title` |

`src/meta/features.json` is **deliberately unchanged**: the fix closes a gap in the already-described `admin-ui-i18n` capability ("renders in English or Spanish") rather than changing or adding one — same reasoning as 4.0.5 / 4.0.6.

`patch` per `AGENTS.md`: a refactor plus a contained fix, no new capability, no breaking change.

## Scope

- [x] **Generic improvement** to the integration.
- Scope(s) touched: docs · build/packaging

## Checklist

- [x] **Conventional Commits** — no AI attribution in commits or PR description.
- [x] Quality gates pass locally:
  - [x] `npm test` — 1333 pass, 0 fail
  - [x] `npm run typecheck`
  - [x] `npm run features:validate` — 26 features valid
  - [x] `npm run check` (`biome ci`) — 0 errors
  - [x] `npm run secrets` (gitleaks — no leaks)
- [x] **CHANGELOG.md** updated — Keep a Changelog, `### Title` present.
- [x] **README version badge** bumped (line 17).
- [x] **`AGENTS.consumer.md`** — unchanged; no public API/option/route/env var changed.
- [x] **Playground sample** — N/A, no new feature surface.
- [x] No incidental changes under `playgrounds/` or `data/`.
- [x] No credentials, `.env` files or `dist/` artifacts committed.

## After merge

Annotated tag `v4.0.7` on the merge commit, pushed with `--follow-tags`, triggering the npm publish and the GitHub Release.