### PR TITLE
fix(admin): make modal validation errors legible

### DIFF
--- a/src/routes/admin/configs.astro
+++ b/src/routes/admin/configs.astro
@@ -129,7 +129,7 @@ const t = createT(uiLocale);
         <textarea id="config-detail-description" name="description" rows="2" placeholder={t('configs.descriptionPlaceholder')}></textarea>
       </div>
       <p class="cms-muted cms-hint">{t('configs.hint')}</p>
-      <p id="config-detail-error" class="cms-muted cms-hidden cms-hint cms-hint-error" role="alert"></p>
+      <p id="config-detail-error" class="cms-hidden cms-hint cms-hint-error" role="alert"></p>
     </form>
     <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" data-close-modal="config-detail-modal">{t('common.cancel')}</button>
     <button type="button" class="cms-btn cms-btn-primary" slot="actions-right" id="config-detail-submit">{t('common.save')}</button>

--- a/src/routes/admin/global-blocks.astro
+++ b/src/routes/admin/global-blocks.astro
@@ -97,7 +97,7 @@ const t = createT(uiLocale);
   <DetailModal id="global-block-detail-modal" title={t('globalBlocks.title')} large>
     <form id="global-block-detail-form" class="cms-form cms-global-block-detail-form">
       <div id="global-block-form-container"></div>
-      <p id="global-block-error" class="cms-muted cms-hidden cms-hint cms-hint-error" role="alert"></p>
+      <p id="global-block-error" class="cms-hidden cms-hint cms-hint-error" role="alert"></p>
     </form>
     <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" id="global-block-cancel-btn">{t('common.cancel')}</button>
     <button type="submit" form="global-block-detail-form" class="cms-btn cms-btn-primary" slot="actions-right" id="global-block-submit-btn">{t('common.save')}</button>

--- a/src/routes/admin/menus.astro
+++ b/src/routes/admin/menus.astro
@@ -120,7 +120,7 @@ const t = createT(uiLocale);
           <p id="menu-detail-empty" class="cms-menu-builder-empty">{t('menus.noItems')}</p>
         </div>
       </div>
-      <p id="menu-detail-error" class="cms-muted cms-hidden cms-hint cms-hint-error" role="alert"></p>
+      <p id="menu-detail-error" class="cms-hidden cms-hint cms-hint-error" role="alert"></p>
     </form>
     <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" data-close-modal="menu-detail-modal">{t('common.cancel')}</button>
     <button type="button" id="menu-detail-submit" class="cms-btn cms-btn-primary" slot="actions-right">{t('common.save')}</button>

--- a/src/routes/admin/redirects.astro
+++ b/src/routes/admin/redirects.astro
@@ -131,7 +131,7 @@ const t = createT(uiLocale);
         <label for="redirect-detail-enabled" class="cms-label-tight">{t('redirects.labelEnabled')}</label>
       </div>
       <p class="cms-muted cms-hint">{t('redirects.hint')}</p>
-      <p id="redirect-detail-error" class="cms-muted cms-hidden cms-hint cms-hint-error" role="alert"></p>
+      <p id="redirect-detail-error" class="cms-hidden cms-hint cms-hint-error" role="alert"></p>
     </form>
     <button type="button" class="cms-btn cms-btn-secondary" slot="actions-left" data-close-modal="redirect-detail-modal">{t('common.cancel')}</button>
     <button type="button" class="cms-btn cms-btn-primary" slot="actions-right" id="redirect-detail-submit">{t('common.save')}</button>


### PR DESCRIPTION
## What & why

A failed validation in the detail modals showed its error message in muted grey instead of red, so it was barely visible — reported for the redirects modal.

### Root cause

The error `<p>` carried both `cms-muted` and `cms-hint-error`:

- `.cms-hint-error` (`cms-admin.css:1789`) → `color: var(--pico-del-color)` — a red, the intended error color.
- `.cms-muted` (`cms-admin.css:1824`) → `color: #6b7280` — grey.

Both are single-class selectors (equal specificity), so the one later in the stylesheet wins. `.cms-muted` (1824) comes **after** `.cms-hint-error` (1789), so grey overrode red. `cms-muted` on an error element is a contradiction that had been copy-pasted across four modals.

### Fix

Remove `cms-muted` from the four detail-error elements — **configs, global-blocks, menus, redirects**. `cms-hint` already sets the small font size, so nothing is lost and `cms-hint-error`'s red now applies (`--pico-del-color` resolves to a visible red in both light and dark themes: `rgb(136,56.5,53)` / `rgb(205.5,126,123)`).

### Not this PR

`cms-login-error` and `cms-users-error` carry `cms-muted` **without** `cms-hint-error` — they were never styled as errors at all, so making them red is a design decision, not this bug. Flagged for a separate call rather than silently restyled.

### Relationship to #117 / #158

Pre-existing, **not** caused by the createListEditor refactor (#158): the error show/hide logic is byte-identical before and after (`setInlineError` = the old `setError`), and the `.astro` error markup was untouched by it. This branch is off `main` and is independent of #158 — it can merge in either order.

## Scope

- [x] **Generic improvement** to the integration (admin UI).
- Scope(s) touched: admin-ui

## Checklist

- [x] **Conventional Commits** — no AI attribution in commits or PR description.
- [x] Quality gates pass locally:
  - [x] `npm test` — 1333 pass, 0 fail
  - [x] `npm run check` (`biome ci`) — 0 errors; 30 warnings (baseline)
  - [x] `npm run secrets` (gitleaks — no leaks)
- [x] **CHANGELOG.md** not updated — at release close this is a `patch` with a `### Fixed` line.
- [x] **`AGENTS.consumer.md`** — unchanged; no public API/option/route/env var changed.
- [x] **README version badge** — N/A, not a release PR.
- [x] **Playground sample** — N/A; a CSS-class correction on existing modals.
- [x] No credentials, `.env` files or `dist/` artifacts committed.

## Diff

4 files, 4 lines — one `class=` attribute per modal.
