### PR TITLE
chore(release): 4.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [4.0.8] - 2026-07-21
+
+### Title
+
+Legible modal errors, and a shared controller for the list pages
+
+### Fixed
+
+- **A failed validation in a detail modal was barely visible.** The inline error message under the configs, redirects, menus and global-block modals rendered in muted grey instead of red, so a validation failure was easy to miss. The error element carried two conflicting colour classes and the muted grey one happened to win the cascade; the contradictory class is removed, so the error now shows in the intended red. (#117)
+
+### Changed
+
+- **Internal: the configs and redirects list pages share one controller.** Their near-identical list machinery (fetch, render, row binding, delete-confirm, search) is now a single `createListEditor` with a typed, escape-by-construction cell model, and the row renderer is a pure function covered by unit tests rather than only end-to-end. No consumer-visible behaviour change. (#117)
+
 ## [4.0.7] - 2026-07-21
 
 ### Title

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Licensed under the Business Source License 1.1
 </p>
 
 <p align="center">
-  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-4.0.7-blue" alt="version" /></a>
+  <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/version-4.0.8-blue" alt="version" /></a>
   <img src="https://img.shields.io/badge/coverage-93.17%25-brightgreen" alt="coverage" />
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/v/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/@astroblocks/astro-blocks"><img src="https://img.shields.io/npm/dm/%40astroblocks%2Fastro-blocks?logo=npm" alt="npm downloads" /></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astroblocks/astro-blocks",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "Block-based content CMS integration for Astro with admin panel, page builder, menus, SEO and cache invalidation.",
   "homepage": "https://github.com/NauelG/astro-blocks#readme",
   "repository": {


### PR DESCRIPTION
## What & why

Bundles the two changes already merged to `main` since 4.0.7.

### Included

- **#159** — `fix(admin)`: the detail-modal inline validation error rendered muted grey (a cascade conflict where `.cms-muted` overrode `.cms-hint-error`); the contradictory class is removed so the error shows in red. Consumer-visible → `### Fixed`.
- **#117 / #158** — `refactor(admin)`: `createListEditor` for the configs and redirects list pages (typed escape-by-construction cell model, node-tested pure renderer). Internal → `### Changed`.

### Bumps

| File | Change |
| --- | --- |
| `package.json` | `4.0.7` → `4.0.8` |
| `README.md:17` | version badge |
| `CHANGELOG.md` | new `[4.0.8]` entry with `### Title` |

`src/meta/features.json` **unchanged**: neither the CSS fix nor the internal refactor changes a described capability.

`patch` per `AGENTS.md`: a contained fix plus an internal refactor, no new capability, no breaking change.

## Scope

- [x] **Generic improvement** to the integration.
- Scope(s) touched: docs · build/packaging

## Checklist

- [x] **Conventional Commits** — no AI attribution in commits or PR description.
- [x] Quality gates pass locally on the combined tree:
  - [x] `npm test` — 1340 pass, 0 fail
  - [x] `npm run typecheck`
  - [x] `npm run features:validate` — 26 features valid
  - [x] `npm run check` (`biome ci`) — 0 errors
  - [x] `npm run e2e` — 15/15 (incl. Test G and the redirect-modal test)
- [x] **CHANGELOG.md** updated — Keep a Changelog, `### Title` present.
- [x] **README version badge** bumped (line 17).
- [x] **`AGENTS.consumer.md`** — unchanged.
- [x] **Playground sample** — N/A.
- [x] No incidental changes under `playgrounds/` or `data/`.
- [x] No credentials, `.env` files or `dist/` artifacts committed.

## After merge

Annotated tag `v4.0.8` on the merge commit, pushed with `--follow-tags`, triggering the npm publish and the GitHub Release.