### PR TITLE
fix(scripts): stop the dev server through astro, not by signalling npx

### DIFF
--- a/scripts/capture-media-screenshots.mjs
+++ b/scripts/capture-media-screenshots.mjs
@@ -36,7 +36,6 @@ import path from 'node:path';
 import net from 'node:net';
 import fs from 'node:fs/promises';
 import { spawn } from 'node:child_process';
-import { once } from 'node:events';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { TextEncoder } from 'node:util';
 import { SignJWT } from 'jose';
@@ -155,13 +154,77 @@ function runCommand(command, args, options = {}) {
   });
 }
 
-async function closeDevServer(child) {
-  if (!child || child.killed) return;
-  child.kill('SIGTERM');
-  const timeout = sleep(5000).then(() => {
-    if (!child.killed) child.kill('SIGKILL');
+/**
+ * Run an `astro` subcommand in the playground and resolve its combined output.
+ *
+ * Not `run()`: these are expected to be uneventful (there may be no server to stop), and their
+ * result is information here, not a failure.
+ */
+function astroCommand(args) {
+  return new Promise((resolve) => {
+    const child = spawn('npx', ['astro', ...args], {
+      cwd: PLAYGROUND_DIR,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    child.stdout.on('data', (chunk) => {
+      out += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      out += chunk;
+    });
+    child.on('exit', () => resolve(out));
+    child.on('error', () => resolve(''));
   });
-  await Promise.race([once(child, 'exit'), timeout]);
+}
+
+/**
+ * Whether a dev server currently holds the playground's lock.
+ *
+ * Read from the OUTPUT, not the exit code: `astro dev status` exits 0 either way — it reports
+ * "No dev server is running." just as successfully as it reports a running one. Matching the
+ * positive signal means an unrecognised output format lets the run proceed rather than blocking
+ * every invocation on a false alarm.
+ */
+async function isDevServerRunning() {
+  return /Dev server running at/.test(await astroCommand(['dev', 'status']));
+}
+
+/**
+ * Stop the dev server through Astro's own command, not by signalling the child we spawned.
+ *
+ * `spawn('npx', ['astro', 'dev', …])` produces TWO processes: npx, and the astro server it
+ * launches. npx exits almost immediately, so signalling our child hits a process that is already
+ * gone — `child.killed` stays false and the real server keeps running, orphaned. The scripts used
+ * to print "Stopping dev server..." and believe it.
+ *
+ * That alone was survivable while ports differed. Astro's dev-server lock is per PROJECT, so a
+ * surviving server makes the next `astro dev` for the same project refuse to start — it reports the
+ * address of the running one and the caller then polls the port it asked for until it times out.
+ * `npm version` chains screenshots:readme && screenshots:media, so the second always failed.
+ *
+ * `astro dev stop` stops the process and clears the lock, which is what the next run needs.
+ */
+/**
+ * Refuse to run while another dev server owns the playground.
+ *
+ * We would otherwise stop it in the teardown — and if that server is the developer's own, running
+ * for their own work, killing it silently is a nasty surprise. Failing here also replaces the
+ * failure this used to produce: `astro dev` would report the running server's address, this script
+ * would poll the port it asked for instead, and die on an opaque timeout that mentioned neither
+ * the lock nor the other server.
+ */
+async function assertNoDevServerRunning(label) {
+  if (!(await isDevServerRunning())) return;
+  throw new Error(
+    `${label} a dev server is already running for playgrounds/basic, and this script will not stop ` +
+      "one it did not start. Astro's lock is per project, so no second server can start while it " +
+      'holds it. Stop it first:\n\n  cd playgrounds/basic && npx astro dev stop\n',
+  );
+}
+
+async function closeDevServer() {
+  await astroCommand(['dev', 'stop']);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -409,6 +472,10 @@ async function main() {
     // macOS: passing --host 127.0.0.1 forces Astro to bind on the IPv4 loopback.
     // Without it, Astro resolves 'localhost' to the IPv6 address (::1) on macOS
     // and our fetch calls to 127.0.0.1 hit a different interface → ECONNREFUSED.
+    await assertNoDevServerRunning('[media-screenshots]');
+
+    // Not bound: the teardown goes through `astro dev stop`, not through this handle. Signalling it
+    // would hit npx, which exits immediately, leaving the real server orphaned.
     const devServer = spawn('npx', ['astro', 'dev', '--host', HOST, '--port', String(port)], {
       cwd: PLAYGROUND_DIR,
       env: {
@@ -419,6 +486,9 @@ async function main() {
       },
       stdio: 'inherit',
     });
+    devServer.on('error', (err) =>
+      console.error('[media-screenshots] failed to spawn astro dev:', err),
+    );
 
     try {
       await waitForServer(baseUrl);
@@ -444,7 +514,7 @@ async function main() {
     } finally {
       // ── Step 5: Tear down server — always runs, even on error ──────────────
       console.log('[media-screenshots] Stopping dev server...');
-      await closeDevServer(devServer);
+      await closeDevServer();
     }
   } finally {
     // ── Step 6: Restore the versioned demo — always runs, even on error ───────

--- a/scripts/capture-readme-screenshots.mjs
+++ b/scripts/capture-readme-screenshots.mjs
@@ -8,7 +8,6 @@ import net from 'node:net';
 import process from 'node:process';
 import fs from 'node:fs/promises';
 import { spawn } from 'node:child_process';
-import { once } from 'node:events';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { TextEncoder } from 'node:util';
 import { SignJWT } from 'jose';
@@ -192,13 +191,77 @@ async function captureReadmeScreenshots(baseUrl, token, screenshotUser) {
   }
 }
 
-async function closeDevServer(child) {
-  if (!child || child.killed) return;
-  child.kill('SIGTERM');
-  const timeout = sleep(5000).then(() => {
-    if (!child.killed) child.kill('SIGKILL');
+/**
+ * Run an `astro` subcommand in the playground and resolve its combined output.
+ *
+ * Not `run()`: these are expected to be uneventful (there may be no server to stop), and their
+ * result is information here, not a failure.
+ */
+function astroCommand(args) {
+  return new Promise((resolve) => {
+    const child = spawn('npx', ['astro', ...args], {
+      cwd: PLAYGROUND_DIR,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    child.stdout.on('data', (chunk) => {
+      out += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      out += chunk;
+    });
+    child.on('exit', () => resolve(out));
+    child.on('error', () => resolve(''));
   });
-  await Promise.race([once(child, 'exit'), timeout]);
+}
+
+/**
+ * Whether a dev server currently holds the playground's lock.
+ *
+ * Read from the OUTPUT, not the exit code: `astro dev status` exits 0 either way — it reports
+ * "No dev server is running." just as successfully as it reports a running one. Matching the
+ * positive signal means an unrecognised output format lets the run proceed rather than blocking
+ * every invocation on a false alarm.
+ */
+async function isDevServerRunning() {
+  return /Dev server running at/.test(await astroCommand(['dev', 'status']));
+}
+
+/**
+ * Stop the dev server through Astro's own command, not by signalling the child we spawned.
+ *
+ * `spawn('npx', ['astro', 'dev', …])` produces TWO processes: npx, and the astro server it
+ * launches. npx exits almost immediately, so signalling our child hits a process that is already
+ * gone — `child.killed` stays false and the real server keeps running, orphaned. The scripts used
+ * to print "Stopping dev server..." and believe it.
+ *
+ * That alone was survivable while ports differed. Astro's dev-server lock is per PROJECT, so a
+ * surviving server makes the next `astro dev` for the same project refuse to start — it reports the
+ * address of the running one and the caller then polls the port it asked for until it times out.
+ * `npm version` chains screenshots:readme && screenshots:media, so the second always failed.
+ *
+ * `astro dev stop` stops the process and clears the lock, which is what the next run needs.
+ */
+/**
+ * Refuse to run while another dev server owns the playground.
+ *
+ * We would otherwise stop it in the teardown — and if that server is the developer's own, running
+ * for their own work, killing it silently is a nasty surprise. Failing here also replaces the
+ * failure this used to produce: `astro dev` would report the running server's address, this script
+ * would poll the port it asked for instead, and die on an opaque timeout that mentioned neither
+ * the lock nor the other server.
+ */
+async function assertNoDevServerRunning(label) {
+  if (!(await isDevServerRunning())) return;
+  throw new Error(
+    `${label} a dev server is already running for playgrounds/basic, and this script will not stop ` +
+      "one it did not start. Astro's lock is per project, so no second server can start while it " +
+      'holds it. Stop it first:\n\n  cd playgrounds/basic && npx astro dev stop\n',
+  );
+}
+
+async function closeDevServer() {
+  await astroCommand(['dev', 'stop']);
 }
 
 async function main() {
@@ -213,6 +276,10 @@ async function main() {
   await runCommand('npm', ['run', 'prepare:playground'], { cwd: ROOT, env: process.env });
 
   console.log(`[screenshots] Starting playground at ${baseUrl}...`);
+  await assertNoDevServerRunning('[screenshots]');
+
+  // Not bound: the teardown goes through `astro dev stop`, not through this handle. Signalling it
+  // would hit npx, which exits immediately, leaving the real server orphaned.
   const devServer = spawn('npx', ['astro', 'dev', '--host', HOST, '--port', String(port)], {
     cwd: PLAYGROUND_DIR,
     env: {
@@ -221,6 +288,7 @@ async function main() {
     },
     stdio: 'inherit',
   });
+  devServer.on('error', (err) => console.error('[screenshots] failed to spawn astro dev:', err));
 
   try {
     await waitForServer(baseUrl);
@@ -238,7 +306,7 @@ async function main() {
     }
     throw error;
   } finally {
-    await closeDevServer(devServer);
+    await closeDevServer();
     if (!redirectsFileExistedBefore) {
       await fs.rm(PLAYGROUND_REDIRECTS_PATH, { force: true }).catch(() => {});
     }


### PR DESCRIPTION
Closes #165. Two script files; no source change.

## The diagnosis in #165 was wrong

It blamed an Astro 7 dev daemon outliving the scripts. `--background` is opt-in and neither script passes it, so that is not what happens. Verified before fixing.

The real cause is the process tree, and it predates Astro 7:

```
spawn('npx', ['astro', 'dev', …])   →  npx  →  astro (the actual server)
```

`closeDevServer` signalled **our child** — `npx` — which has already exited by teardown time. The signal lands on nothing, `child.killed` stays `false`, and the real server survives orphaned while the script prints `Stopping dev server...` and believes it. A probe confirms it: after `SIGTERM` then `SIGKILL`, `fetch` to the server still returns **200**.

What Astro 7 added is what makes it fatal: the dev-server lock is **per project**, not per port. An orphan makes the next `astro dev` for the same project refuse to start — it prints the running server's address, and the caller then polls the port it asked for until it times out. That is why the distinct ports (4327 / 4328) stopped helping, and why `npm version`'s `screenshots:readme && screenshots:media` chain always failed on the second one.

## The fix

Teardown goes through **`astro dev stop`**, which ends the process *and* clears the lock — the part the next run actually needs.

A **pre-flight** refuses to run when a server is already registered, rather than stopping one the script did not start. Chosen over "stop whatever is there" so a developer's own dev server is never killed silently, and it replaces the opaque timeout with a message that names the cause and the remedy.

Two findings the fix depends on, both verified:

- **`process.kill(-pid)` does not help.** With `detached: true` the group leader is `npx`, which exits, so the group kill returns `ESRCH`.
- **`astro dev status` always exits 0.** It reports "No dev server is running." just as successfully as a running one, so the state is read from its *output*. The check matches the positive signal, so an unrecognised output format lets the run proceed rather than blocking every invocation on a false alarm.

## Verification

Exercised in all three states against the real playground:

| State | Result |
|---|---|
| The two scripts chained, as `npm version` runs them | Both complete, **exit 0** |
| After the run | `astro dev status` → "No dev server is running" — **no orphan** |
| A developer's server already up | Pre-flight fails with a legible message, **and that server survives** |

`typecheck` · 1376 tests · `biome ci` green. No image churn: the screenshots regenerated during testing were reverted, since nothing visual changed.

## Note

The `once` import became unused and is dropped. The spawn gains an `error` listener, so a failure to launch says so instead of surfacing as an unhandled event — the same class of silent failure this PR is about.
