### PR TITLE
fix(media): key the variant cache by file identity, not mtime alone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,16 +82,22 @@ En **Archive** estos deltas se integran en `docs/specs/` para que la spec viva r
 - **Comportamiento vivo del sistema** → **`docs/specs/`**.
 - **Contexto de código efímero** → **descartar**.
 
-Formato ADR (`docs/adr/NNNN-titulo.md`), con la numeración a **cuatro dígitos** y una serie única:
+**Los ADR se escriben en inglés** (ADR-0041): slug del fichero, título, cabecera, secciones y prosa.
+Es la única excepción al principio de idioma de este documento — el resto de `docs/` sigue el idioma
+del humano.
 
-- Título `# NNNN — <decisión>`.
+Formato ADR (`docs/adr/NNNN-english-slug.md`), con la numeración a **cuatro dígitos** y una serie única:
+
+- Título `# NNNN — <decision>`.
 - Cabecera: `- **Status:**` y `- **Date:** AAAA-MM-DD` (obligatorios, los parsea el índice),
-  `- **Decisores:**` y `- **Source:**` (recomendados). Otras claves (`Relación`, `Procedencia`) son libres.
-- Secciones `## Contexto` / `## Decisión` / `## Consecuencias`.
+  `- **Deciders:**` y `- **Source:**` (recomendados). Otras claves son libres.
+- Secciones `## Context` / `## Decision` / `## Consequences`. No añadas una sección de evidencia del
+  código actual: envejece hasta volverse falsa y es justo el contexto efímero que se descarta (ADR-0041).
 
 Un ADR es **inmutable**: si la decisión cambia, se crea uno nuevo y el viejo pasa a
-`Status: Superseded by [ADR-NNNN](./NNNN-….md)`. Tras crear uno, `npm run adr:index` regenera
-`docs/DECISIONS.md`; CI falla si el índice no está al día.
+`Status: Superseded by [ADR-NNNN](./NNNN-….md)`. La inmutabilidad protege **la decisión, no la prosa**:
+traducir, renombrar o normalizar cabeceras la preserva y no requiere superseder (ADR-0041). Tras crear
+uno, `npm run adr:index` regenera `docs/DECISIONS.md`; CI falla si el índice no está al día.
 
 **No cites decisiones por números que no vivan en `docs/adr/`.** Un `ADR-4` de un `design.md` de
 cambio no es un ADR del proyecto: colisiona con la serie real y deja de resolverse en cuanto ese

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -64,6 +64,7 @@ The table below is **generated**. Run `npm run adr:index` after adding an ADR, o
 | [ADR-0038](./adr/0038-el-escaneo-solo-borra-lo-que-puede-demostrar-que-es-huerfano.md) | El escaneo solo borra lo que puede demostrar que es huérfano, y la prueba es la antigüedad | Accepted | 2026-07-29 |
 | [ADR-0039](./adr/0039-las-cadenas-de-cliente-del-panel-vienen-de-ct.md) | Las cadenas de cliente del panel vienen de `ct`, no de un puente i18n | Accepted | 2026-08-20 |
 | [ADR-0040](./adr/0040-el-orden-del-backlog-es-una-cadena-de-blocked-by-no-las-etiquetas-p0-p3.md) | El orden del backlog es una cadena de `blocked_by`, no las etiquetas `P0`–`P3` | Accepted | 2026-09-07 |
+| [ADR-0041](./adr/0041-the-adr-corpus-is-written-in-english.md) | The ADR corpus is written in English, and translating one does not break its immutability | Accepted | 2026-09-08 |
 <!-- adr-index:end -->
 
 ---

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -65,6 +65,7 @@ The table below is **generated**. Run `npm run adr:index` after adding an ADR, o
 | [ADR-0039](./adr/0039-las-cadenas-de-cliente-del-panel-vienen-de-ct.md) | Las cadenas de cliente del panel vienen de `ct`, no de un puente i18n | Accepted | 2026-08-20 |
 | [ADR-0040](./adr/0040-el-orden-del-backlog-es-una-cadena-de-blocked-by-no-las-etiquetas-p0-p3.md) | El orden del backlog es una cadena de `blocked_by`, no las etiquetas `P0`–`P3` | Accepted | 2026-09-07 |
 | [ADR-0041](./adr/0041-the-adr-corpus-is-written-in-english.md) | The ADR corpus is written in English, and translating one does not break its immutability | Accepted | 2026-09-08 |
+| [ADR-0042](./adr/0042-the-media-variant-cache-key-is-not-mtime-alone.md) | The media variant cache key is not mtime alone | Accepted | 2026-09-08 |
 <!-- adr-index:end -->
 
 ---

--- a/docs/adr/0041-the-adr-corpus-is-written-in-english.md
+++ b/docs/adr/0041-the-adr-corpus-is-written-in-english.md
@@ -1,0 +1,86 @@
+<!--
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+-->
+
+# 0041 — The ADR corpus is written in English, and translating one does not break its immutability
+
+- **Status:** Accepted — 2026-09-08
+- **Date:** 2026-09-08
+- **Deciders:** Nauel Gómez
+- **Source:** #178
+
+## Context
+
+The corpus drifted across three independent axes, and no rule was ever written down.
+
+| Axis | State before this decision | Switch point |
+| --- | --- | --- |
+| Body language | 29 English (0001–0029), 11 Spanish (0030–0040) | `0030` |
+| Filename slug | English through 0031, Spanish from 0032 | `0032` |
+| Section headings | 25 use `Contexto/Decisión/Consecuencias`, 15 use `Context/Decision/Consequences` plus an `Evidence (current repo)` section | scattered |
+
+The two switch points do not coincide: `0030` and `0031` carry an English filename over a Spanish
+body. The heading axis is not aligned with either, and `Evidence (current repo)` appears in fifteen
+files while `AGENTS.md` documents only three sections.
+
+The failure mode is cumulative rather than acute. No ADR is unreadable today. But every new ADR is
+written by copying whichever neighbour the author opened first, so an unstated rule keeps
+manufacturing new inconsistency at no cost to anyone. Filenames are the surface people scan, which
+is where the drift is most visible and least excusable.
+
+Issue #178 argued for Spanish on the grounds that it is where the corpus converged and that
+choosing English would make "19 existing files the exception instead of 13". Measurement does not
+support that: by body language the split is 29/11, so English is the majority by a wide margin and
+Spanish is the recent minority. The premise of the original recommendation was wrong.
+
+English also matches what the repo already does everywhere else that is not an ADR — code,
+comments, tests, commit messages (`AGENTS.md` mandates English commits without exception), and the
+`## Contexto`-vs-`## Context` split is the only place the project speaks two languages about the
+same artifact.
+
+A second question blocks any retrofit. `AGENTS.md` states that an ADR is **immutable**: if a
+decision changes, a new ADR supersedes the old one. Read literally, that forbids touching the
+eleven Spanish bodies at all, and an agent asked to translate them would be violating the repo's
+own constitution with no way to tell that the exception was intended.
+
+## Decision
+
+**English is the canonical language of the ADR corpus** — filename slug, title, section headings,
+header keys, and body prose.
+
+The canonical shape is:
+
+- Filename `docs/adr/NNNN-english-slug.md`, four digits, single series.
+- Title `# NNNN — <decision>`.
+- Header keys `- **Status:**`, `- **Date:**` (both parsed by `scripts/adr-index.mjs`), plus
+  `- **Deciders:**` and `- **Source:**`.
+- Sections `## Context` / `## Decision` / `## Consequences`.
+
+**Immutability protects the decision, not the prose that carries it.** Translating an ADR, renaming
+its file, or normalising its headings preserves the decision unchanged and is therefore permitted
+without superseding it. What immutability forbids is unchanged: altering what was decided, or why.
+That still requires a new ADR and a `Superseded by` status on the old one.
+
+`## Evidence (current repo)` is **retired**. It records the state of the code at authoring time,
+which is exactly the ephemeral context `AGENTS.md` routes to "discard" — it ages into a false
+statement about a repo that has moved on. The fifteen files carrying it drop the section; anything
+in it that is genuinely load-bearing for the decision moves into `## Context`.
+
+## Consequences
+
+- The retrofit is mechanical and bounded: 9 filenames, 11 bodies (1014 lines), 25 heading sets, 15
+  `Evidence` sections, and 2 hand-written cross-references (`0037` cites `0036`;
+  `docs/specs/media-uploads.md` cites `0038`). Tracked as #178.
+- `docs/DECISIONS.md` needs no manual edit. `scripts/adr-index.mjs` matches
+  `/^(\d{4})-[a-z0-9-]+\.md$/` and reads only the title and the `Status`/`Date` lines, so renaming
+  is transparent to it; `npm run adr:index` regenerates the table and `npm run adr:check` gates it
+  in CI.
+- Git history becomes the only record of the original Spanish prose. That is an accepted cost: the
+  decisions themselves are preserved verbatim in meaning, and no ADR is being reversed.
+- `AGENTS.md` § *Enrutado de artefactos* is updated to describe the English format. The rest of
+  `AGENTS.md` stays in Spanish — this decision governs the ADR corpus, not the repo's working
+  documents, which the human reads and writes directly.
+- Future ADRs have a rule to copy instead of a neighbour to imitate, which is the actual fix. The
+  format half of it could later be enforced by a sibling of `scripts/validate-features.mjs`; that
+  is deliberately not part of this decision.

--- a/docs/adr/0042-the-media-variant-cache-key-is-not-mtime-alone.md
+++ b/docs/adr/0042-the-media-variant-cache-key-is-not-mtime-alone.md
@@ -1,0 +1,82 @@
+<!--
+Copyright (c) 2026 Nauel Gómez Gamero
+Licensed under the Business Source License 1.1
+-->
+
+# 0042 — The media variant cache key is not mtime alone
+
+- **Status:** Accepted
+- **Date:** 2026-09-08
+- **Deciders:** Nauel Gómez
+- **Source:** #182
+
+## Context
+
+ADR-0017 describes `utils/getMediaVariants.ts` as "an mtime-cached registry reader": a module-level
+singleton, keyed by `data/media.json`'s modification time in milliseconds, reloaded only when that
+value changes. The premise was that two writes to the registry would not collide inside one
+millisecond often enough to matter.
+
+That premise is false, and #182 measured it two ways:
+
+- Sampling 36 pre-existing `.ts` files under `src/api/` and `src/utils/` on this repo's own
+  filesystem yielded only 4 distinct `mtimeMs` values across them — millisecond collisions are the
+  common case here, not the edge case.
+- Writing `data/media.json` twice in immediate succession via `data.ts#writeJson` (the sole writer
+  of every store file) and comparing `fs.stat(..., { bigint: true }).mtimeNs` — nanosecond
+  resolution — still collided in roughly 45 of 50 back-to-back writes, on both a `tmpfs` temp
+  directory and the repo's own `ext4` checkout. The clock source `stat` reads is coarser than the
+  nanosecond field implies; raising resolution alone does not fix the underlying problem.
+
+The consequence lands on the public site: `handleReplaceUpload` clears an entry's variants and sets
+`status: 'processing'` under the media lock, then a fire-and-forget job regenerates them (ADR-0017).
+If both the pre-replace read and the post-replace write land in one collision window, the render-time
+accessor keeps serving the pre-replace snapshot — `status: 'ready'` with a variant list whose files
+the replace already deleted. `BlockImage.astro` renders a `<picture>` whose `srcset` 404s on every
+entry, silently.
+
+A fix needed a signal that changes on **every** write to the file, not merely most of them, without
+turning the cache into something that reads disk on every render (`ADR-0017`'s whole reason to
+cache) and without making the data layer aware of a render-time cache module (avoidable coupling,
+weighed against ADR-0017's own future-latency note about `reconcileMedia()`).
+
+`data.ts#writeJson` writes to a freshly, randomly named temp file and `fs.rename`s it over the
+target path. That rename always allocates a new inode for the target — the previous inode is freed,
+not reused in place. Measured across 500 back-to-back writes through that exact path, with no delay
+between them, the inode number never repeated once.
+
+## Decision
+
+`getMediaVariants`'s cache key is the triple `(ino, size, mtimeNs)` read via
+`fs.stat(mediaJsonPath, { bigint: true })`, not `mtimeMs` alone.
+
+`ino` is what actually discriminates every write that goes through `writeJson` — which is every
+production write path (`replaceMedia`, `appendMediaEntry`, `removeMediaEntryByUrl`,
+`updateMediaEntryAlt`, `markMediaVariantsReady`, `markMediaVariantsFailed`, `replaceMediaEntryBytes`,
+and the reconcile path all funnel through `saveMedia` → `writeJson`). `size` and `mtimeNs` are
+retained as a cheap fallback for the one write path in the codebase that does not go through
+`writeJson`: test fixtures that `fs.writeFile` the registry in place. The cache otherwise behaves
+exactly as ADR-0017 describes — a module-level singleton, reloaded only on a key change, harmless to
+race because the event loop is single-threaded.
+
+`ino`-based invalidation is a property of `writeJson`'s atomic rename-over pattern, not an
+independent guarantee `getMediaVariants` enforces on its own. If a future writer of `media.json`
+ever bypasses `writeJson` for an in-place write, this cache degrades back to the `size`/`mtimeNs`
+fallback and inherits the same collision risk this ADR fixes — that writer must go through
+`writeJson`, the same rule ADR-0008 already states for every other store file.
+
+Explicit invalidation from the mutation seam (`data.ts` calling into the cache directly) was the
+alternative with the strongest guarantee, considered and set aside: it would couple the data layer
+to a specific render-time cache's internals for a guarantee the identity key already provides
+without that coupling.
+
+## Consequences
+
+- `tests/get-media-variants.test.js`'s invalidation test no longer needs an artificial delay between
+  writes; a rapid-burst test (20 writes, no delay, read after each) now covers the collision case
+  directly rather than relying on wall-clock timing to reproduce it.
+- `tests/media-replace.test.js`'s P5 (#181) stops depending on the host filesystem's clock
+  resolution to pass — the same failure mode it fails under is what this ADR fixes.
+- Any future `media.json` writer that skips `writeJson` for an in-place edit silently reintroduces
+  the collision window this ADR closes; there is no runtime assertion that catches it.
+</content>

--- a/src/utils/getMediaVariants.ts
+++ b/src/utils/getMediaVariants.ts
@@ -7,8 +7,8 @@ Licensed under the Business Source License 1.1
  * utils/getMediaVariants.ts
  *
  * Render-time accessor for responsive image variants.
- * Reads the consumer's data/media.json with an mtime-keyed in-memory cache so
- * repeated calls within a render cycle do not re-read disk.
+ * Reads the consumer's data/media.json with an in-memory cache keyed off the
+ * file's identity, so repeated calls within a render cycle do not re-read disk.
  *
  * Graceful fallback contract:
  *   - Missing/unreadable registry  → { status: 'none', variants: [] }
@@ -16,14 +16,32 @@ Licensed under the Business Source License 1.1
  *   - Legacy entry (no status)     → { status: 'none', variants: [] }
  *   - Never throws into render
  *
- * Cache strategy:
- *   - Module-level singleton keyed by the file mtime.
- *   - On each call: stat the file. If mtime matches → reuse Map. Else reload.
+ * Cache strategy (see ADR-0042 — supersedes the mtime-only description in
+ * ADR-0017):
+ *   - `mtimeMs` alone is NOT a reliable change signal: sampled writes on this
+ *     repo's dev/CI filesystems (tmpfs, ext4) collapse onto the same
+ *     millisecond routinely, and even nanosecond resolution
+ *     (`fs.stat(..., { bigint: true }).mtimeNs`) still collides on back-to-back
+ *     writes ~90% of the time — the underlying clock source `stat` reads is
+ *     coarser than the nanosecond field suggests.
+ *   - `data.ts#writeJson` — the sole writer of every store file, media.json
+ *     included — writes to a fresh randomly-named temp file and `fs.rename`s
+ *     it over the target. That rename always allocates a NEW inode number for
+ *     the target path; the previous inode is freed. Measured across 500
+ *     back-to-back writes with no delay, `ino` never repeated once.
+ *   - The cache key is therefore the triple `(ino, size, mtimeNs)`: `ino`
+ *     does the real work for every write that goes through `writeJson`;
+ *     `size`/`mtimeNs` are cheap belt-and-braces for the one write path in
+ *     this codebase that does NOT go through it (direct `fs.writeFile`
+ *     in-place, used only by test fixtures).
+ *   - On each call: stat the file (`{ bigint: true }`). If the key matches →
+ *     reuse the Map. Else reload.
  *   - Concurrency: the Node.js event loop is single-threaded; a redundant
  *     concurrent load is harmless (idempotent).
  */
 
 import fs from 'node:fs/promises';
+import type { BigIntStats } from 'node:fs';
 import { getDataPath } from './paths.js';
 import { loadMedia } from '../api/data.js';
 import type { MediaEntry, MediaVariant } from '../types/index.js';
@@ -36,12 +54,12 @@ export interface MediaVariantsResult {
   alt?: string;
 }
 
-/** Module-level mtime-keyed cache. */
-let cache: { mtimeMs: number; byUrl: Map<string, MediaEntry> } | null = null;
+/** Module-level cache keyed off the registry file's identity (see comment above). */
+let cache: { key: string; byUrl: Map<string, MediaEntry> } | null = null;
 
 /**
  * Look up a MediaEntry by its original upload URL and return its variant info.
- * Reads data/media.json with mtime-keyed caching.
+ * Reads data/media.json with identity-keyed caching (see module doc above).
  *
  * Returns { status: 'none', variants: [] } on any error or when URL is unknown.
  * Never throws.
@@ -52,25 +70,26 @@ export async function getMediaVariants(url: string): Promise<MediaVariantsResult
   try {
     const mediaJsonPath = getDataPath('media.json');
 
-    // Stat the file to get current mtime
-    let stat: Awaited<ReturnType<typeof fs.stat>>;
+    // Stat the file (bigint form: nanosecond mtime + full-precision ino/size)
+    // to build the current identity key.
+    let stat: BigIntStats;
     try {
-      stat = await fs.stat(mediaJsonPath);
+      stat = await fs.stat(mediaJsonPath, { bigint: true });
     } catch {
       // File does not exist or is unreadable — return graceful fallback
       return EMPTY;
     }
 
-    const currentMtimeMs = stat.mtimeMs;
+    const currentKey = `${stat.ino}:${stat.size}:${stat.mtimeNs}`;
 
     // Rebuild cache if stale or absent
-    if (cache === null || cache.mtimeMs !== currentMtimeMs) {
+    if (cache === null || cache.key !== currentKey) {
       const mediaData = await loadMedia();
       const byUrl = new Map<string, MediaEntry>();
       for (const entry of mediaData.uploads) {
         byUrl.set(entry.url, entry);
       }
-      cache = { mtimeMs: currentMtimeMs, byUrl };
+      cache = { key: currentKey, byUrl };
     }
 
     // Look up the entry

--- a/tests/get-media-variants.test.js
+++ b/tests/get-media-variants.test.js
@@ -61,7 +61,7 @@ test('cache hit — single loadMedia call when mtime unchanged', async () => {
   });
 });
 
-test('cache invalidation — re-reads after mtime changes', async () => {
+test('cache invalidation — re-reads after a registry write, no delay needed', async () => {
   await withTempProject(async () => {
     const url = '/uploads/2026/06/img2.jpg';
     const entry1 = {
@@ -79,9 +79,9 @@ test('cache invalidation — re-reads after mtime changes', async () => {
     const result1 = await getMediaVariants(url);
     assert.equal(result1.status, 'processing');
 
-    // Wait briefly so mtime can change, then update the registry
-    await new Promise((r) => setTimeout(r, 10));
-
+    // Write the registry again IMMEDIATELY — no artificial delay. Two writes
+    // landing in the same mtime resolution window (even nanosecond) must still
+    // both be observed (#182).
     const entry2 = {
       ...entry1,
       status: 'ready',
@@ -91,10 +91,37 @@ test('cache invalidation — re-reads after mtime changes', async () => {
 
     // Next call should see the updated status
     const result2 = await getMediaVariants(url);
-    // Status should reflect the new registry (processing or ready depending on cache)
-    // Since mtime changed (replaceMedia writes a new file), cache should be invalidated
-    assert.equal(result2.status, 'ready', 'should read updated status after mtime change');
-    assert.equal(result2.variants.length, 1, 'should have updated variants');
+    assert.equal(result2.status, 'ready', 'should read the updated status after the second write');
+    assert.equal(result2.variants.length, 1, 'should have the updated variants');
+  });
+});
+
+test('cache invalidation — observes a rapid burst of back-to-back writes', async () => {
+  await withTempProject(async () => {
+    const url = '/uploads/2026/06/img3.jpg';
+    const baseEntry = {
+      id: 'burst-test-1',
+      url,
+      filename: 'img3.jpg',
+      size: 1000,
+      mimeType: 'image/jpeg',
+      createdAt: new Date().toISOString(),
+      status: 'processing',
+      variants: [],
+    };
+
+    // Write the registry 20 times in a tight loop with no delay, reading the
+    // accessor after each write. Every read must reflect the write that just
+    // happened — a stale hit anywhere in the burst reproduces #182.
+    for (let i = 0; i < 20; i++) {
+      const width = i + 1;
+      await replaceMedia({
+        uploads: [{ ...baseEntry, width, status: i % 2 === 0 ? 'ready' : 'processing' }],
+      });
+      const result = await getMediaVariants(url);
+      assert.equal(result.status, i % 2 === 0 ? 'ready' : 'processing', `write #${i} observed`);
+      assert.equal(result.width, width, `write #${i} width observed`);
+    }
   });
 });
 


### PR DESCRIPTION
Closes #182

## Problem

`getMediaVariants` cached the media registry keyed by `mtimeMs`. Two writes landing in the
same millisecond resolution window are indistinguishable, so the second write is invisible
to the cache. After a replace, the render-time accessor kept serving the pre-replace
snapshot — `status: 'ready'` with variants whose files the replace had already cleared —
producing 404s on the public page's `srcset`.

## What was measured

- Nanosecond mtime (`fs.stat(..., { bigint: true }).mtimeNs`) does **not** fix it: 500
  back-to-back writes through `data.ts#writeJson` collided ~90% of the time, on both
  `tmpfs` and this repo's `ext4` checkout.
- `writeJson`'s atomic write pattern (temp file + `fs.rename` over the target) allocates a
  **new inode** on every write. Same 500-write measurement: zero `ino` collisions.

## Fix

Key the cache on `(ino, size, mtimeNs)` instead of `mtimeMs` alone. `ino` does the real work
for every production write path (all funnel through `writeJson` via `saveMedia`);
`size`/`mtimeNs` are a fallback for the one write path that doesn't (test fixtures writing
the registry in place). No change to the exported signature or `MediaVariantsResult`
contract; `BlockImage.astro`'s consumption is untouched.

Adds ADR-0042, which supersedes the "mtime-cached" description in ADR-0017 without
reopening that ADR's actual decision (async variant generation).

## Verification

- `npm run typecheck`, `npm run build`, `npm run check` — clean (same pre-existing warnings
  in unrelated files as before this change).
- `npm test` — 1407/1407, including `media-replace.test.js` P5 (the test called out as
  flaky in #181/#182) run 5x in a row with no failures.
- `tests/get-media-variants.test.js`: removed the artificial delay from the invalidation
  test, added a no-delay double-write test and a 20-write rapid-burst test.